### PR TITLE
feat: vim mode in live mode + sync VSCodeVim custom keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,751 +1,769 @@
 {
-	"name": "meo",
-	"displayName": "Markdown Editor Optimized",
-	"description": "An optimized markdown editor with live editing mode for VS Code.",
-	"version": "0.1.23",
-	"publisher": "vadimmelnicuk",
-	"private": true,
-	"icon": "logo.png",
-	"engines": {
-		"vscode": "^1.97.0"
-	},
-	"categories": [
-		"Programming Languages",
-		"Formatters",
-		"Other"
-	],
-	"keywords": [
-		"markdown",
-		"editor",
-		"live-edit",
-		"wysiwyg",
-		"markdown-editor",
-		"markdown-preview"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/vadimmelnicuk/meo.git"
-	},
-	"main": "./dist/extension.js",
-	"activationEvents": [
-		"onStartupFinished"
-	],
-	"contributes": {
-		"languages": [
-			{
-				"id": "markdown",
-				"extensions": [
-					".mdx",
-					".mdc"
-				]
-			}
-		],
-		"commands": [
-			{
-				"command": "markdownEditorOptimized.open",
-				"title": "Open With Markdown Editor Optimized",
-				"icon": "$(book)"
-			},
-			{
-				"command": "markdownEditorOptimized.setDefaultEditor",
-				"title": "Markdown Editor Optimized: Set as Default",
-				"icon": "$(check)"
-			},
-			{
-				"command": "markdownEditorOptimized.resetThemeToDefault",
-				"title": "Markdown Editor Optimized: Reset Theme to Default",
-				"icon": "$(discard)"
-			},
-			{
-				"command": "markdownEditorOptimized.selectTheme",
-				"title": "Markdown Editor Optimized: Select Theme"
-			},
-			{
-				"command": "markdownEditorOptimized.importTheme",
-				"title": "Markdown Editor Optimized: Import Theme JSON"
-			},
-			{
-				"command": "markdownEditorOptimized.exportTheme",
-				"title": "Markdown Editor Optimized: Export Theme JSON"
-			},
-			{
-				"command": "markdownEditorOptimized.deleteImportedTheme",
-				"title": "Markdown Editor Optimized: Delete Imported Theme"
-			},
-			{
-				"command": "markdownEditorOptimized.toggleMode",
-				"title": "Markdown Editor Optimized: Toggle Live/Source Mode",
-				"icon": "$(sync)"
-			},
-			{
-				"command": "markdownEditorOptimized.exportHtml",
-				"title": "Markdown Editor Optimized: Export as HTML",
-				"icon": "$(export)"
-			},
-			{
-				"command": "markdownEditorOptimized.exportPdf",
-				"title": "Markdown Editor Optimized: Export as PDF",
-				"icon": "$(file-pdf)"
-			}
-		],
-		"keybindings": [
-			{
-				"command": "markdownEditorOptimized.toggleMode",
-				"key": "alt+shift+m",
-				"when": "markdownEditorOptimized.activeEditor"
-			}
-		],
-		"customEditors": [
-			{
-				"viewType": "markdownEditorOptimized.editor",
-				"displayName": "Markdown Editor Optimized",
-				"selector": [
-					{
-						"filenamePattern": "*.md"
-					},
-					{
-						"filenamePattern": "*.markdown"
-					},
-					{
-						"filenamePattern": "*.mdx"
-					},
-					{
-						"filenamePattern": "*.mdc"
-					}
-				],
-				"priority": "default"
-			}
-		],
-		"menus": {
-			"explorer/context": [
-				{
-					"command": "markdownEditorOptimized.open",
-					"when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
-					"group": "navigation"
-				}
-			],
-			"editor/title/context": [
-				{
-					"command": "markdownEditorOptimized.open",
-					"when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
-					"group": "navigation"
-				}
-			]
-		},
-		"configurationDefaults": {
-			"workbench.editorAssociations": {
-				"*.md": "markdownEditorOptimized.editor",
-				"*.markdown": "markdownEditorOptimized.editor",
-				"*.mdx": "markdownEditorOptimized.editor",
-				"*.mdc": "markdownEditorOptimized.editor",
-				"git:/**/*.md": "default",
-				"git:/**/*.markdown": "default",
-				"git:/**/*.mdx": "default",
-				"git:/**/*.mdc": "default",
-				"git:**/*.md": "default",
-				"git:**/*.markdown": "default",
-				"git:**/*.mdx": "default",
-				"git:**/*.mdc": "default",
-				"chat-editing-text-model:/**/*.md": "default",
-				"chat-editing-text-model:/**/*.markdown": "default",
-				"chat-editing-text-model:/**/*.mdx": "default",
-				"chat-editing-text-model:/**/*.mdc": "default",
-				"chat-editing-text-model:**/*.md": "default",
-				"chat-editing-text-model:**/*.markdown": "default",
-				"chat-editing-text-model:**/*.mdx": "default",
-				"chat-editing-text-model:**/*.mdc": "default"
-			}
-		},
-		"configuration": {
-			"title": "Markdown Editor Optimized",
-			"properties": {
-				"markdownEditorOptimized.useAsDefault": {
-					"type": "boolean",
-					"default": true,
-					"order": 1,
-					"description": "Use Markdown Editor Optimized as the default editor for Markdown files"
-				},
-				"markdownEditorOptimized.outline.position": {
-					"type": "string",
-					"enum": [
-						"left",
-						"right"
-					],
-					"enumDescriptions": [
-						"Show the document outline on the left side of the editor.",
-						"Show the document outline on the right side of the editor."
-					],
-					"default": "right",
-					"order": 2,
-					"description": "Position of the contents outline sidebar."
-				},
-				"markdownEditorOptimized.lineNumbers.visible": {
-					"type": "boolean",
-					"default": true,
-					"order": 3,
-					"description": "Show line numbers."
-				},
-				"markdownEditorOptimized.gitChanges.visible": {
-					"type": "boolean",
-					"default": true,
-					"order": 4,
-					"description": "Show Git change indicators in the editor."
-				},
-				"markdownEditorOptimized.gitChanges.lineHighlights": {
-					"type": "boolean",
-					"default": true,
-					"order": 5,
-					"description": "Show subtle line coloring for modified lines in Source mode."
-				},
-				"markdownEditorOptimized.vimMode.enabled": {
-					"type": "boolean",
-					"default": false,
-					"order": 6,
-					"description": "Enable Vim keybindings in Source mode. When not explicitly set, Vim mode is automatically enabled if the VSCodeVim extension (vscodevim.vim) is installed and active."
-				},
-				"markdownEditorOptimized.rememberPosition.lines": {
-					"type": "number",
-					"default": 100,
-					"minimum": 0,
-					"order": 7,
-					"description": "Markdown files with at least this many lines will remember the last viewed line and restore the scroll position when opened."
-				},
-				"markdownEditorOptimized.export.browserPath": {
-					"type": "string",
-					"default": "",
-					"order": 7,
-					"description": "Optional path to a Chrome/Edge executable used for browser-based export rendering (PDF and HTML finalize). Leave empty to auto-detect."
-				},
-				"markdownEditorOptimized.export.pdf.browserPath": {
-					"type": "string",
-					"default": "",
-					"order": 7,
-					"description": "Deprecated: use markdownEditorOptimized.export.browserPath.",
-					"deprecationMessage": "Use markdownEditorOptimized.export.browserPath instead.",
-					"markdownDeprecationMessage": "Use `markdownEditorOptimized.export.browserPath` instead."
-				},
-				"markdownEditorOptimized.export.html.imageMode": {
-					"type": "string",
-					"enum": [
-						"embedded",
-						"linked"
-					],
-					"enumDescriptions": [
-						"Embed local image files in exported HTML.",
-						"Keep local image links as relative paths in exported HTML."
-					],
-					"default": "embedded",
-					"order": 8,
-					"description": "How local images are handled during HTML export."
-				},
-				"markdownEditorOptimized.imageFolder": {
-					"type": "string",
-					"default": "assets",
-					"order": 9,
-					"description": "Folder name to save pasted images (relative to workspace root)."
-				},
-				"markdownEditorOptimized.theme": {
-					"type": "object",
-					"default": {
-						"id": "one-monokai",
-						"name": "One Monokai",
-						"colors": {
-							"base01": "var(--vscode-editor-foreground)",
-							"base02": "#676f7d",
-							"base03": "#3e444d",
-							"base04": "#e06c75",
-							"base05": "#61afef",
-							"base06": "#66d9ef",
-							"base07": "#e5c07b",
-							"base08": "#c678dd",
-							"base09": "#98c379"
-						},
-						"syntaxTokens": {},
-						"fonts": {
-							"liveFont": "",
-							"sourceFont": "",
-							"liveFontWeight": "",
-							"sourceFontWeight": "",
-							"liveFontSize": null,
-							"sourceFontSize": null,
-							"h1FontSize": 1.6,
-							"h2FontSize": 1.5,
-							"h3FontSize": 1.3,
-							"h4FontSize": 1.2,
-							"h5FontSize": 1.1,
-							"h6FontSize": 1,
-							"h1FontWeight": "600",
-							"h2FontWeight": "600",
-							"h3FontWeight": "600",
-							"h4FontWeight": "600",
-							"h5FontWeight": "600",
-							"h6FontWeight": "600",
-							"liveLineHeight": 1.5,
-							"sourceLineHeight": 1.5
-						}
-					},
-					"defaultSnippets": [
-						{
-							"label": "One Monokai theme payload",
-							"description": "Insert the full theme object with sensible defaults.",
-							"body": "{\n\t\"id\": \"one-monokai\",\n\t\"name\": \"One Monokai\",\n\t\"colors\": {\n\t\t\"base01\": \"var(--vscode-editor-foreground)\",\n\t\t\"base02\": \"#676f7d\",\n\t\t\"base03\": \"#3e444d\",\n\t\t\"base04\": \"#e06c75\",\n\t\t\"base05\": \"#61afef\",\n\t\t\"base06\": \"#66d9ef\",\n\t\t\"base07\": \"#e5c07b\",\n\t\t\"base08\": \"#c678dd\",\n\t\t\"base09\": \"#98c379\"\n\t},\n\t\"syntaxTokens\": {},\n\t\"fonts\": {\n\t\t\"liveFont\": \"\",\n\t\t\"sourceFont\": \"\",\n\t\t\"liveFontWeight\": \"\",\n\t\t\"sourceFontWeight\": \"\",\n\t\t\"liveFontSize\": null,\n\t\t\"sourceFontSize\": null,\n\t\t\"h1FontSize\": 1.6,\n\t\t\"h2FontSize\": 1.5,\n\t\t\"h3FontSize\": 1.3,\n\t\t\"h4FontSize\": 1.2,\n\t\t\"h5FontSize\": 1.1,\n\t\t\"h6FontSize\": 1,\n\t\t\"h1FontWeight\": \"600\",\n\t\t\"h2FontWeight\": \"600\",\n\t\t\"h3FontWeight\": \"600\",\n\t\t\"h4FontWeight\": \"600\",\n\t\t\"h5FontWeight\": \"600\",\n\t\t\"h6FontWeight\": \"600\",\n\t\t\"liveLineHeight\": 1.5,\n\t\t\"sourceLineHeight\": 1.5\n\t}\n}"
-						}
-					],
-					"description": "Theme payload containing base palette colors, optional token overrides, and font settings.",
-					"markdownDescription": "[Select Theme](command:markdownEditorOptimized.selectTheme) | [Import Theme](command:markdownEditorOptimized.importTheme) | [Export Theme](command:markdownEditorOptimized.exportTheme) | [Delete Imported Theme](command:markdownEditorOptimized.deleteImportedTheme) | [Reset Theme to Default](command:markdownEditorOptimized.resetThemeToDefault)",
-					"properties": {
-						"id": {
-							"type": "string",
-							"default": "one-monokai",
-							"description": "Unique theme identifier."
-						},
-						"name": {
-							"type": "string",
-							"default": "One Monokai (default)",
-							"description": "Display name for the theme."
-						},
-						"colors": {
-							"type": "object",
-							"default": {},
-							"properties": {
-								"base01": {
-									"type": "string",
-									"description": "Primary foreground color (hex/rgb/hsl/var).",
-									"default": "var(--vscode-editor-foreground)"
-								},
-								"base02": {
-									"type": "string",
-									"format": "color"
-								},
-								"base03": {
-									"type": "string",
-									"format": "color"
-								},
-								"base04": {
-									"type": "string",
-									"format": "color"
-								},
-								"base05": {
-									"type": "string",
-									"format": "color"
-								},
-								"base06": {
-									"type": "string",
-									"format": "color"
-								},
-								"base07": {
-									"type": "string",
-									"format": "color"
-								},
-								"base08": {
-									"type": "string",
-									"format": "color"
-								},
-								"base09": {
-									"type": "string",
-									"format": "color"
-								}
-							},
-							"required": [
-								"base02",
-								"base03",
-								"base04",
-								"base05",
-								"base06",
-								"base07",
-								"base08",
-								"base09"
-							],
-							"additionalProperties": false
-						},
-						"syntaxTokens": {
-							"type": "object",
-							"default": {},
-							"properties": {
-								"keyword": {
-									"type": "string",
-									"format": "color"
-								},
-								"identifier": {
-									"type": "string",
-									"format": "color"
-								},
-								"macroName": {
-									"type": "string",
-									"format": "color"
-								},
-								"variableName": {
-									"type": "string",
-									"format": "color"
-								},
-								"propertyName": {
-									"type": "string",
-									"format": "color"
-								},
-								"typeName": {
-									"type": "string",
-									"format": "color"
-								},
-								"className": {
-									"type": "string",
-									"format": "color"
-								},
-								"namespace": {
-									"type": "string",
-									"format": "color"
-								},
-								"operator": {
-									"type": "string",
-									"format": "color"
-								},
-								"operatorKeyword": {
-									"type": "string",
-									"format": "color"
-								},
-								"punctuation": {
-									"type": "string",
-									"format": "color"
-								},
-								"functionName": {
-									"type": "string",
-									"format": "color"
-								},
-								"labelName": {
-									"type": "string",
-									"format": "color"
-								},
-								"definitionFunction": {
-									"type": "string",
-									"format": "color"
-								},
-								"definedVariable": {
-									"type": "string",
-									"format": "color"
-								},
-								"number": {
-									"type": "string",
-									"format": "color"
-								},
-								"changed": {
-									"type": "string",
-									"format": "color"
-								},
-								"annotation": {
-									"type": "string",
-									"format": "color"
-								},
-								"modifier": {
-									"type": "string",
-									"format": "color"
-								},
-								"self": {
-									"type": "string",
-									"format": "color"
-								},
-								"color": {
-									"type": "string",
-									"format": "color"
-								},
-								"constant": {
-									"type": "string",
-									"format": "color"
-								},
-								"atom": {
-									"type": "string",
-									"format": "color"
-								},
-								"bool": {
-									"type": "string",
-									"format": "color"
-								},
-								"specialVariable": {
-									"type": "string",
-									"format": "color"
-								},
-								"specialString": {
-									"type": "string",
-									"format": "color"
-								},
-								"regexp": {
-									"type": "string",
-									"format": "color"
-								},
-								"string": {
-									"type": "string",
-									"format": "color"
-								},
-								"typeDefinition": {
-									"type": "string",
-									"format": "color"
-								},
-								"meta": {
-									"type": "string",
-									"format": "color"
-								},
-								"comment": {
-									"type": "string",
-									"format": "color"
-								},
-								"tagName": {
-									"type": "string",
-									"format": "color"
-								},
-								"attributeName": {
-									"type": "string",
-									"format": "color"
-								},
-								"invalid": {
-									"type": "string",
-									"format": "color"
-								},
-								"deleted": {
-									"type": "string",
-									"format": "color"
-								},
-								"monospace": {
-									"type": "string",
-									"format": "color"
-								},
-								"heading": {
-									"type": "string",
-									"format": "color"
-								},
-								"emphasis": {
-									"type": "string",
-									"format": "color"
-								},
-								"strong": {
-									"type": "string",
-									"format": "color"
-								},
-								"strikethrough": {
-									"type": "string",
-									"format": "color"
-								},
-								"quote": {
-									"type": "string",
-									"format": "color"
-								},
-								"contentSeparator": {
-									"type": "string",
-									"format": "color"
-								},
-								"link": {
-									"type": "string",
-									"format": "color"
-								},
-								"url": {
-									"type": "string",
-									"format": "color"
-								},
-								"processingInstruction": {
-									"type": "string",
-									"format": "color"
-								}
-							},
-							"additionalProperties": false
-						},
-						"fonts": {
-							"type": "object",
-							"default": {},
-							"properties": {
-								"liveFont": {
-									"type": "string",
-									"default": ""
-								},
-								"sourceFont": {
-									"type": "string",
-									"default": ""
-								},
-								"liveFontWeight": {
-									"type": "string",
-									"default": "",
-									"description": "Live mode font weight override. Leave empty to use VS Code editor font weight."
-								},
-								"sourceFontWeight": {
-									"type": "string",
-									"default": "",
-									"description": "Source mode font weight override. Leave empty to use VS Code editor font weight."
-								},
-								"liveFontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"default": null
-								},
-								"sourceFontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"default": null
-								},
-								"h1FontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"minimum": 1,
-									"maximum": 3,
-									"default": 1.6
-								},
-								"h2FontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"minimum": 1,
-									"maximum": 3,
-									"default": 1.5
-								},
-								"h3FontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"minimum": 1,
-									"maximum": 3,
-									"default": 1.3
-								},
-								"h4FontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"minimum": 1,
-									"maximum": 3,
-									"default": 1.2
-								},
-								"h5FontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"minimum": 1,
-									"maximum": 3,
-									"default": 1.1
-								},
-								"h6FontSize": {
-									"type": [
-										"number",
-										"null"
-									],
-									"minimum": 1,
-									"maximum": 3,
-									"default": 1
-								},
-								"h1FontWeight": {
-									"type": "string",
-									"default": "600",
-									"description": "Heading 1 font weight override."
-								},
-								"h2FontWeight": {
-									"type": "string",
-									"default": "600",
-									"description": "Heading 2 font weight override."
-								},
-								"h3FontWeight": {
-									"type": "string",
-									"default": "600",
-									"description": "Heading 3 font weight override."
-								},
-								"h4FontWeight": {
-									"type": "string",
-									"default": "600",
-									"description": "Heading 4 font weight override."
-								},
-								"h5FontWeight": {
-									"type": "string",
-									"default": "600",
-									"description": "Heading 5 font weight override."
-								},
-								"h6FontWeight": {
-									"type": "string",
-									"default": "600",
-									"description": "Heading 6 font weight override."
-								},
-								"liveLineHeight": {
-									"type": "number",
-									"default": 1.5,
-									"minimum": 1,
-									"maximum": 3
-								},
-								"sourceLineHeight": {
-									"type": "number",
-									"default": 1.5,
-									"minimum": 1,
-									"maximum": 3
-								}
-							},
-							"required": [
-								"liveFont",
-								"sourceFont",
-								"liveFontSize",
-								"sourceFontSize",
-								"liveLineHeight",
-								"sourceLineHeight"
-							],
-							"additionalProperties": false
-						}
-					},
-					"required": [
-						"id",
-						"name",
-						"colors",
-						"syntaxTokens",
-						"fonts"
-					],
-					"additionalProperties": false
-				}
-			}
-		}
-	},
-	"scripts": {
-		"install:all": "bun install && (cd webview && bun install)",
-		"typecheck:webview": "tsc -p webview/tsconfig.json --noEmit",
-		"build": "bun run build:webview && bun run build:extension",
-		"build:webview": "rm -rf webview/dist && mkdir -p webview/dist webview/dist/katex && bun build webview/src/index.ts --target=browser --format=esm --splitting --minify --outdir=webview/dist && cp webview/src/styles.css webview/dist/index.css && cp node_modules/mermaid/dist/mermaid.min.js webview/dist/mermaid.min.js && cp node_modules/katex/dist/katex.min.css webview/dist/katex/katex.min.css && cp -R node_modules/katex/dist/fonts webview/dist/katex/fonts",
-		"build:extension": "bun run build:extension:main && bun run build:extension:export-runtime && bun run build:extension:puppeteer-runtime",
-		"build:extension:main": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode",
-		"build:extension:main:debug": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode --sourcemap=inline",
-		"build:extension:export-runtime": "bun build src/export/runtime.ts --target=node --format=cjs --minify --outfile=dist/export-runtime.js",
-		"build:extension:puppeteer-runtime": "bun build src/export/puppeteerRuntime.ts --target=node --format=cjs --minify --outfile=dist/puppeteer-runtime.js",
-		"release:prep": "bun scripts/release-prep.mjs",
-		"release:finalize": "bun scripts/release-prep.mjs finalize",
-		"vscode:publish": "vsce package"
-	},
-	"dependencies": {
-		"@codemirror/commands": "6.8.1",
-		"@codemirror/lang-cpp": "^6.0.3",
-		"@codemirror/lang-css": "^6.3.1",
-		"@codemirror/lang-go": "^6.0.1",
-		"@codemirror/lang-html": "^6.4.11",
-		"@codemirror/lang-java": "^6.0.2",
-		"@codemirror/lang-javascript": "^6.2.4",
-		"@codemirror/lang-json": "^6.0.2",
-		"@codemirror/lang-markdown": "6.3.4",
-		"@codemirror/lang-python": "^6.2.1",
-		"@codemirror/lang-rust": "^6.0.2",
-		"@codemirror/lang-sql": "^6.10.0",
-		"@codemirror/language": "6.11.3",
-		"@codemirror/state": "6.5.2",
-		"@codemirror/view": "6.36.4",
-		"@lezer/highlight": "^1.2.3",
-		"@replit/codemirror-vim": "^6.3.0",
-		"@types/vscode": "^1.109.0",
-		"highlight.js": "^11.11.1",
-		"katex": "^0.16.28",
-		"lucide": "^0.564.0",
-		"markdown-it": "^14.1.0",
-		"markdown-it-emoji": "^3.0.0",
-		"mermaid": "^11.4.1",
-		"puppeteer-core": "^24.1.1",
-		"sanitize-html": "^2.17.0"
-	},
-	"devDependencies": {
-		"@types/markdown-it": "^14.1.2",
-		"@types/sanitize-html": "^2.16.0",
-		"typescript": "^5.9.3"
-	}
+  "name": "meo",
+  "displayName": "Markdown Editor Optimized",
+  "description": "An optimized markdown editor with live editing mode for VS Code.",
+  "version": "0.1.23",
+  "publisher": "vadimmelnicuk",
+  "private": true,
+  "icon": "logo.png",
+  "engines": {
+    "vscode": "^1.97.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Formatters",
+    "Other"
+  ],
+  "keywords": [
+    "markdown",
+    "editor",
+    "live-edit",
+    "wysiwyg",
+    "markdown-editor",
+    "markdown-preview"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vadimmelnicuk/meo.git"
+  },
+  "main": "./dist/extension.js",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "markdown",
+        "extensions": [
+          ".mdx",
+          ".mdc"
+        ]
+      }
+    ],
+    "commands": [
+      {
+        "command": "markdownEditorOptimized.open",
+        "title": "Open With Markdown Editor Optimized",
+        "icon": "$(book)"
+      },
+      {
+        "command": "markdownEditorOptimized.setDefaultEditor",
+        "title": "Markdown Editor Optimized: Set as Default",
+        "icon": "$(check)"
+      },
+      {
+        "command": "markdownEditorOptimized.resetThemeToDefault",
+        "title": "Markdown Editor Optimized: Reset Theme to Default",
+        "icon": "$(discard)"
+      },
+      {
+        "command": "markdownEditorOptimized.selectTheme",
+        "title": "Markdown Editor Optimized: Select Theme"
+      },
+      {
+        "command": "markdownEditorOptimized.importTheme",
+        "title": "Markdown Editor Optimized: Import Theme JSON"
+      },
+      {
+        "command": "markdownEditorOptimized.exportTheme",
+        "title": "Markdown Editor Optimized: Export Theme JSON"
+      },
+      {
+        "command": "markdownEditorOptimized.deleteImportedTheme",
+        "title": "Markdown Editor Optimized: Delete Imported Theme"
+      },
+      {
+        "command": "markdownEditorOptimized.toggleMode",
+        "title": "Markdown Editor Optimized: Toggle Live/Source Mode",
+        "icon": "$(sync)"
+      },
+      {
+        "command": "markdownEditorOptimized.exportHtml",
+        "title": "Markdown Editor Optimized: Export as HTML",
+        "icon": "$(export)"
+      },
+      {
+        "command": "markdownEditorOptimized.exportPdf",
+        "title": "Markdown Editor Optimized: Export as PDF",
+        "icon": "$(file-pdf)"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "markdownEditorOptimized.toggleMode",
+        "key": "alt+shift+m",
+        "when": "markdownEditorOptimized.activeEditor"
+      }
+    ],
+    "customEditors": [
+      {
+        "viewType": "markdownEditorOptimized.editor",
+        "displayName": "Markdown Editor Optimized",
+        "selector": [
+          {
+            "filenamePattern": "*.md"
+          },
+          {
+            "filenamePattern": "*.markdown"
+          },
+          {
+            "filenamePattern": "*.mdx"
+          },
+          {
+            "filenamePattern": "*.mdc"
+          }
+        ],
+        "priority": "default"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "markdownEditorOptimized.open",
+          "when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
+          "group": "navigation"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "markdownEditorOptimized.open",
+          "when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
+          "group": "navigation"
+        }
+      ]
+    },
+    "configurationDefaults": {
+      "workbench.editorAssociations": {
+        "*.md": "markdownEditorOptimized.editor",
+        "*.markdown": "markdownEditorOptimized.editor",
+        "*.mdx": "markdownEditorOptimized.editor",
+        "*.mdc": "markdownEditorOptimized.editor",
+        "git:/**/*.md": "default",
+        "git:/**/*.markdown": "default",
+        "git:/**/*.mdx": "default",
+        "git:/**/*.mdc": "default",
+        "git:**/*.md": "default",
+        "git:**/*.markdown": "default",
+        "git:**/*.mdx": "default",
+        "git:**/*.mdc": "default",
+        "chat-editing-text-model:/**/*.md": "default",
+        "chat-editing-text-model:/**/*.markdown": "default",
+        "chat-editing-text-model:/**/*.mdx": "default",
+        "chat-editing-text-model:/**/*.mdc": "default",
+        "chat-editing-text-model:**/*.md": "default",
+        "chat-editing-text-model:**/*.markdown": "default",
+        "chat-editing-text-model:**/*.mdx": "default",
+        "chat-editing-text-model:**/*.mdc": "default"
+      }
+    },
+    "configuration": {
+      "title": "Markdown Editor Optimized",
+      "properties": {
+        "markdownEditorOptimized.useAsDefault": {
+          "type": "boolean",
+          "default": true,
+          "order": 1,
+          "description": "Use Markdown Editor Optimized as the default editor for Markdown files"
+        },
+        "markdownEditorOptimized.outline.position": {
+          "type": "string",
+          "enum": [
+            "left",
+            "right"
+          ],
+          "enumDescriptions": [
+            "Show the document outline on the left side of the editor.",
+            "Show the document outline on the right side of the editor."
+          ],
+          "default": "right",
+          "order": 2,
+          "description": "Position of the contents outline sidebar."
+        },
+        "markdownEditorOptimized.lineNumbers.visible": {
+          "type": "boolean",
+          "default": true,
+          "order": 3,
+          "description": "Show line numbers."
+        },
+        "markdownEditorOptimized.gitChanges.visible": {
+          "type": "boolean",
+          "default": true,
+          "order": 4,
+          "description": "Show Git change indicators in the editor."
+        },
+        "markdownEditorOptimized.gitChanges.lineHighlights": {
+          "type": "boolean",
+          "default": true,
+          "order": 5,
+          "description": "Show subtle line coloring for modified lines in Source mode."
+        },
+        "markdownEditorOptimized.vimMode.enabled": {
+          "type": "boolean",
+          "default": false,
+          "order": 6,
+          "description": "Legacy Vim keybinding override.",
+          "deprecationMessage": "Use markdownEditorOptimized.vimMode.behavior instead.",
+          "markdownDeprecationMessage": "Use `markdownEditorOptimized.vimMode.behavior` instead."
+        },
+        "markdownEditorOptimized.vimMode.behavior": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "enabled",
+            "disabled"
+          ],
+          "enumDescriptions": [
+            "Enable Vim emulation automatically when VSCodeVim (vscodevim.vim) is installed and enabled, or when VSCode Neovim (asvetliakov.vscode-neovim) is installed.",
+            "Always enable Vim emulation in Markdown Editor Optimized.",
+            "Always disable Vim keybindings in Markdown Editor Optimized."
+          ],
+          "default": "auto",
+          "order": 6,
+          "description": "Controls Vim emulation in Source and Live mode."
+        },
+        "markdownEditorOptimized.rememberPosition.lines": {
+          "type": "number",
+          "default": 100,
+          "minimum": 0,
+          "order": 7,
+          "description": "Markdown files with at least this many lines will remember the last viewed line and restore the scroll position when opened."
+        },
+        "markdownEditorOptimized.export.browserPath": {
+          "type": "string",
+          "default": "",
+          "order": 7,
+          "description": "Optional path to a Chrome/Edge executable used for browser-based export rendering (PDF and HTML finalize). Leave empty to auto-detect."
+        },
+        "markdownEditorOptimized.export.pdf.browserPath": {
+          "type": "string",
+          "default": "",
+          "order": 7,
+          "description": "Deprecated: use markdownEditorOptimized.export.browserPath.",
+          "deprecationMessage": "Use markdownEditorOptimized.export.browserPath instead.",
+          "markdownDeprecationMessage": "Use `markdownEditorOptimized.export.browserPath` instead."
+        },
+        "markdownEditorOptimized.export.html.imageMode": {
+          "type": "string",
+          "enum": [
+            "embedded",
+            "linked"
+          ],
+          "enumDescriptions": [
+            "Embed local image files in exported HTML.",
+            "Keep local image links as relative paths in exported HTML."
+          ],
+          "default": "embedded",
+          "order": 8,
+          "description": "How local images are handled during HTML export."
+        },
+        "markdownEditorOptimized.imageFolder": {
+          "type": "string",
+          "default": "assets",
+          "order": 9,
+          "description": "Folder name to save pasted images (relative to workspace root)."
+        },
+        "markdownEditorOptimized.theme": {
+          "type": "object",
+          "default": {
+            "id": "one-monokai",
+            "name": "One Monokai",
+            "colors": {
+              "base01": "var(--vscode-editor-foreground)",
+              "base02": "#676f7d",
+              "base03": "#3e444d",
+              "base04": "#e06c75",
+              "base05": "#61afef",
+              "base06": "#66d9ef",
+              "base07": "#e5c07b",
+              "base08": "#c678dd",
+              "base09": "#98c379"
+            },
+            "syntaxTokens": {},
+            "fonts": {
+              "liveFont": "",
+              "sourceFont": "",
+              "liveFontWeight": "",
+              "sourceFontWeight": "",
+              "liveFontSize": null,
+              "sourceFontSize": null,
+              "h1FontSize": 1.6,
+              "h2FontSize": 1.5,
+              "h3FontSize": 1.3,
+              "h4FontSize": 1.2,
+              "h5FontSize": 1.1,
+              "h6FontSize": 1,
+              "h1FontWeight": "600",
+              "h2FontWeight": "600",
+              "h3FontWeight": "600",
+              "h4FontWeight": "600",
+              "h5FontWeight": "600",
+              "h6FontWeight": "600",
+              "liveLineHeight": 1.5,
+              "sourceLineHeight": 1.5
+            }
+          },
+          "defaultSnippets": [
+            {
+              "label": "One Monokai theme payload",
+              "description": "Insert the full theme object with sensible defaults.",
+              "body": "{\n\t\"id\": \"one-monokai\",\n\t\"name\": \"One Monokai\",\n\t\"colors\": {\n\t\t\"base01\": \"var(--vscode-editor-foreground)\",\n\t\t\"base02\": \"#676f7d\",\n\t\t\"base03\": \"#3e444d\",\n\t\t\"base04\": \"#e06c75\",\n\t\t\"base05\": \"#61afef\",\n\t\t\"base06\": \"#66d9ef\",\n\t\t\"base07\": \"#e5c07b\",\n\t\t\"base08\": \"#c678dd\",\n\t\t\"base09\": \"#98c379\"\n\t},\n\t\"syntaxTokens\": {},\n\t\"fonts\": {\n\t\t\"liveFont\": \"\",\n\t\t\"sourceFont\": \"\",\n\t\t\"liveFontWeight\": \"\",\n\t\t\"sourceFontWeight\": \"\",\n\t\t\"liveFontSize\": null,\n\t\t\"sourceFontSize\": null,\n\t\t\"h1FontSize\": 1.6,\n\t\t\"h2FontSize\": 1.5,\n\t\t\"h3FontSize\": 1.3,\n\t\t\"h4FontSize\": 1.2,\n\t\t\"h5FontSize\": 1.1,\n\t\t\"h6FontSize\": 1,\n\t\t\"h1FontWeight\": \"600\",\n\t\t\"h2FontWeight\": \"600\",\n\t\t\"h3FontWeight\": \"600\",\n\t\t\"h4FontWeight\": \"600\",\n\t\t\"h5FontWeight\": \"600\",\n\t\t\"h6FontWeight\": \"600\",\n\t\t\"liveLineHeight\": 1.5,\n\t\t\"sourceLineHeight\": 1.5\n\t}\n}"
+            }
+          ],
+          "description": "Theme payload containing base palette colors, optional token overrides, and font settings.",
+          "markdownDescription": "[Select Theme](command:markdownEditorOptimized.selectTheme) | [Import Theme](command:markdownEditorOptimized.importTheme) | [Export Theme](command:markdownEditorOptimized.exportTheme) | [Delete Imported Theme](command:markdownEditorOptimized.deleteImportedTheme) | [Reset Theme to Default](command:markdownEditorOptimized.resetThemeToDefault)",
+          "properties": {
+            "id": {
+              "type": "string",
+              "default": "one-monokai",
+              "description": "Unique theme identifier."
+            },
+            "name": {
+              "type": "string",
+              "default": "One Monokai (default)",
+              "description": "Display name for the theme."
+            },
+            "colors": {
+              "type": "object",
+              "default": {},
+              "properties": {
+                "base01": {
+                  "type": "string",
+                  "description": "Primary foreground color (hex/rgb/hsl/var).",
+                  "default": "var(--vscode-editor-foreground)"
+                },
+                "base02": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base03": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base04": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base05": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base06": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base07": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base08": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "base09": {
+                  "type": "string",
+                  "format": "color"
+                }
+              },
+              "required": [
+                "base02",
+                "base03",
+                "base04",
+                "base05",
+                "base06",
+                "base07",
+                "base08",
+                "base09"
+              ],
+              "additionalProperties": false
+            },
+            "syntaxTokens": {
+              "type": "object",
+              "default": {},
+              "properties": {
+                "keyword": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "identifier": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "macroName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "variableName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "propertyName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "typeName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "className": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "namespace": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "operator": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "operatorKeyword": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "punctuation": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "functionName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "labelName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "definitionFunction": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "definedVariable": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "number": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "changed": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "annotation": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "modifier": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "self": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "color": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "constant": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "atom": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "bool": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "specialVariable": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "specialString": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "regexp": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "string": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "typeDefinition": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "meta": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "comment": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "tagName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "attributeName": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "invalid": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "deleted": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "monospace": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "heading": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "emphasis": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "strong": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "strikethrough": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "quote": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "contentSeparator": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "link": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "color"
+                },
+                "processingInstruction": {
+                  "type": "string",
+                  "format": "color"
+                }
+              },
+              "additionalProperties": false
+            },
+            "fonts": {
+              "type": "object",
+              "default": {},
+              "properties": {
+                "liveFont": {
+                  "type": "string",
+                  "default": ""
+                },
+                "sourceFont": {
+                  "type": "string",
+                  "default": ""
+                },
+                "liveFontWeight": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Live mode font weight override. Leave empty to use VS Code editor font weight."
+                },
+                "sourceFontWeight": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Source mode font weight override. Leave empty to use VS Code editor font weight."
+                },
+                "liveFontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "sourceFontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "default": null
+                },
+                "h1FontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 1,
+                  "maximum": 3,
+                  "default": 1.6
+                },
+                "h2FontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 1,
+                  "maximum": 3,
+                  "default": 1.5
+                },
+                "h3FontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 1,
+                  "maximum": 3,
+                  "default": 1.3
+                },
+                "h4FontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 1,
+                  "maximum": 3,
+                  "default": 1.2
+                },
+                "h5FontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 1,
+                  "maximum": 3,
+                  "default": 1.1
+                },
+                "h6FontSize": {
+                  "type": [
+                    "number",
+                    "null"
+                  ],
+                  "minimum": 1,
+                  "maximum": 3,
+                  "default": 1
+                },
+                "h1FontWeight": {
+                  "type": "string",
+                  "default": "600",
+                  "description": "Heading 1 font weight override."
+                },
+                "h2FontWeight": {
+                  "type": "string",
+                  "default": "600",
+                  "description": "Heading 2 font weight override."
+                },
+                "h3FontWeight": {
+                  "type": "string",
+                  "default": "600",
+                  "description": "Heading 3 font weight override."
+                },
+                "h4FontWeight": {
+                  "type": "string",
+                  "default": "600",
+                  "description": "Heading 4 font weight override."
+                },
+                "h5FontWeight": {
+                  "type": "string",
+                  "default": "600",
+                  "description": "Heading 5 font weight override."
+                },
+                "h6FontWeight": {
+                  "type": "string",
+                  "default": "600",
+                  "description": "Heading 6 font weight override."
+                },
+                "liveLineHeight": {
+                  "type": "number",
+                  "default": 1.5,
+                  "minimum": 1,
+                  "maximum": 3
+                },
+                "sourceLineHeight": {
+                  "type": "number",
+                  "default": 1.5,
+                  "minimum": 1,
+                  "maximum": 3
+                }
+              },
+              "required": [
+                "liveFont",
+                "sourceFont",
+                "liveFontSize",
+                "sourceFontSize",
+                "liveLineHeight",
+                "sourceLineHeight"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "colors",
+            "syntaxTokens",
+            "fonts"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "scripts": {
+    "install:all": "bun install && (cd webview && bun install)",
+    "typecheck:webview": "tsc -p webview/tsconfig.json --noEmit",
+    "build": "bun run build:webview && bun run build:extension",
+    "build:webview": "rm -rf webview/dist && mkdir -p webview/dist webview/dist/katex && bun build webview/src/index.ts --target=browser --format=esm --splitting --minify --outdir=webview/dist && cp webview/src/styles.css webview/dist/index.css && cp node_modules/mermaid/dist/mermaid.min.js webview/dist/mermaid.min.js && cp node_modules/katex/dist/katex.min.css webview/dist/katex/katex.min.css && cp -R node_modules/katex/dist/fonts webview/dist/katex/fonts",
+    "build:extension": "bun run build:extension:main && bun run build:extension:export-runtime && bun run build:extension:puppeteer-runtime",
+    "build:extension:main": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode",
+    "build:extension:main:debug": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode --sourcemap=inline",
+    "build:extension:export-runtime": "bun build src/export/runtime.ts --target=node --format=cjs --minify --outfile=dist/export-runtime.js",
+    "build:extension:puppeteer-runtime": "bun build src/export/puppeteerRuntime.ts --target=node --format=cjs --minify --outfile=dist/puppeteer-runtime.js",
+    "release:prep": "bun scripts/release-prep.mjs",
+    "release:finalize": "bun scripts/release-prep.mjs finalize",
+    "vscode:publish": "vsce package"
+  },
+  "dependencies": {
+    "@codemirror/commands": "6.8.1",
+    "@codemirror/lang-cpp": "^6.0.3",
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-go": "^6.0.1",
+    "@codemirror/lang-html": "^6.4.11",
+    "@codemirror/lang-java": "^6.0.2",
+    "@codemirror/lang-javascript": "^6.2.4",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "6.3.4",
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-rust": "^6.0.2",
+    "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/language": "6.11.3",
+    "@codemirror/state": "6.5.2",
+    "@codemirror/view": "6.36.4",
+    "@lezer/highlight": "^1.2.3",
+    "@replit/codemirror-vim": "^6.3.0",
+    "@types/vscode": "^1.109.0",
+    "highlight.js": "^11.11.1",
+    "katex": "^0.16.28",
+    "lucide": "^0.564.0",
+    "markdown-it": "^14.1.0",
+    "markdown-it-emoji": "^3.0.0",
+    "mermaid": "^11.4.1",
+    "puppeteer-core": "^24.1.1",
+    "sanitize-html": "^2.17.0"
+  },
+  "devDependencies": {
+    "@types/markdown-it": "^14.1.2",
+    "@types/sanitize-html": "^2.16.0",
+    "typescript": "^5.9.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,751 +1,751 @@
 {
-  "name": "meo",
-  "displayName": "Markdown Editor Optimized",
-  "description": "An optimized markdown editor with live editing mode for VS Code.",
-  "version": "0.1.23",
-  "publisher": "vadimmelnicuk",
-  "private": true,
-  "icon": "logo.png",
-  "engines": {
-    "vscode": "^1.97.0"
-  },
-  "categories": [
-    "Programming Languages",
-    "Formatters",
-    "Other"
-  ],
-  "keywords": [
-    "markdown",
-    "editor",
-    "live-edit",
-    "wysiwyg",
-    "markdown-editor",
-    "markdown-preview"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vadimmelnicuk/meo.git"
-  },
-  "main": "./dist/extension.js",
-  "activationEvents": [
-    "onStartupFinished"
-  ],
-  "contributes": {
-    "languages": [
-      {
-        "id": "markdown",
-        "extensions": [
-          ".mdx",
-          ".mdc"
-        ]
-      }
-    ],
-    "commands": [
-      {
-        "command": "markdownEditorOptimized.open",
-        "title": "Open With Markdown Editor Optimized",
-        "icon": "$(book)"
-      },
-      {
-        "command": "markdownEditorOptimized.setDefaultEditor",
-        "title": "Markdown Editor Optimized: Set as Default",
-        "icon": "$(check)"
-      },
-      {
-        "command": "markdownEditorOptimized.resetThemeToDefault",
-        "title": "Markdown Editor Optimized: Reset Theme to Default",
-        "icon": "$(discard)"
-      },
-      {
-        "command": "markdownEditorOptimized.selectTheme",
-        "title": "Markdown Editor Optimized: Select Theme"
-      },
-      {
-        "command": "markdownEditorOptimized.importTheme",
-        "title": "Markdown Editor Optimized: Import Theme JSON"
-      },
-      {
-        "command": "markdownEditorOptimized.exportTheme",
-        "title": "Markdown Editor Optimized: Export Theme JSON"
-      },
-      {
-        "command": "markdownEditorOptimized.deleteImportedTheme",
-        "title": "Markdown Editor Optimized: Delete Imported Theme"
-      },
-      {
-        "command": "markdownEditorOptimized.toggleMode",
-        "title": "Markdown Editor Optimized: Toggle Live/Source Mode",
-        "icon": "$(sync)"
-      },
-      {
-        "command": "markdownEditorOptimized.exportHtml",
-        "title": "Markdown Editor Optimized: Export as HTML",
-        "icon": "$(export)"
-      },
-      {
-        "command": "markdownEditorOptimized.exportPdf",
-        "title": "Markdown Editor Optimized: Export as PDF",
-        "icon": "$(file-pdf)"
-      }
-    ],
-    "keybindings": [
-      {
-        "command": "markdownEditorOptimized.toggleMode",
-        "key": "alt+shift+m",
-        "when": "markdownEditorOptimized.activeEditor"
-      }
-    ],
-    "customEditors": [
-      {
-        "viewType": "markdownEditorOptimized.editor",
-        "displayName": "Markdown Editor Optimized",
-        "selector": [
-          {
-            "filenamePattern": "*.md"
-          },
-          {
-            "filenamePattern": "*.markdown"
-          },
-          {
-            "filenamePattern": "*.mdx"
-          },
-          {
-            "filenamePattern": "*.mdc"
-          }
-        ],
-        "priority": "default"
-      }
-    ],
-    "menus": {
-      "explorer/context": [
-        {
-          "command": "markdownEditorOptimized.open",
-          "when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
-          "group": "navigation"
-        }
-      ],
-      "editor/title/context": [
-        {
-          "command": "markdownEditorOptimized.open",
-          "when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
-          "group": "navigation"
-        }
-      ]
-    },
-    "configurationDefaults": {
-      "workbench.editorAssociations": {
-        "*.md": "markdownEditorOptimized.editor",
-        "*.markdown": "markdownEditorOptimized.editor",
-        "*.mdx": "markdownEditorOptimized.editor",
-        "*.mdc": "markdownEditorOptimized.editor",
-        "git:/**/*.md": "default",
-        "git:/**/*.markdown": "default",
-        "git:/**/*.mdx": "default",
-        "git:/**/*.mdc": "default",
-        "git:**/*.md": "default",
-        "git:**/*.markdown": "default",
-        "git:**/*.mdx": "default",
-        "git:**/*.mdc": "default",
-        "chat-editing-text-model:/**/*.md": "default",
-        "chat-editing-text-model:/**/*.markdown": "default",
-        "chat-editing-text-model:/**/*.mdx": "default",
-        "chat-editing-text-model:/**/*.mdc": "default",
-        "chat-editing-text-model:**/*.md": "default",
-        "chat-editing-text-model:**/*.markdown": "default",
-        "chat-editing-text-model:**/*.mdx": "default",
-        "chat-editing-text-model:**/*.mdc": "default"
-      }
-    },
-    "configuration": {
-      "title": "Markdown Editor Optimized",
-      "properties": {
-        "markdownEditorOptimized.useAsDefault": {
-          "type": "boolean",
-          "default": true,
-          "order": 1,
-          "description": "Use Markdown Editor Optimized as the default editor for Markdown files"
-        },
-        "markdownEditorOptimized.outline.position": {
-          "type": "string",
-          "enum": [
-            "left",
-            "right"
-          ],
-          "enumDescriptions": [
-            "Show the document outline on the left side of the editor.",
-            "Show the document outline on the right side of the editor."
-          ],
-          "default": "right",
-          "order": 2,
-          "description": "Position of the contents outline sidebar."
-        },
-        "markdownEditorOptimized.lineNumbers.visible": {
-          "type": "boolean",
-          "default": true,
-          "order": 3,
-          "description": "Show line numbers."
-        },
-        "markdownEditorOptimized.gitChanges.visible": {
-          "type": "boolean",
-          "default": true,
-          "order": 4,
-          "description": "Show Git change indicators in the editor."
-        },
-        "markdownEditorOptimized.gitChanges.lineHighlights": {
-          "type": "boolean",
-          "default": true,
-          "order": 5,
-          "description": "Show subtle line coloring for modified lines in Source mode."
-        },
-        "markdownEditorOptimized.vimMode.enabled": {
-          "type": "boolean",
-          "default": false,
-          "order": 6,
-          "description": "Enable Vim keybindings in Source mode."
-        },
-        "markdownEditorOptimized.rememberPosition.lines": {
-          "type": "number",
-          "default": 100,
-          "minimum": 0,
-          "order": 7,
-          "description": "Markdown files with at least this many lines will remember the last viewed line and restore the scroll position when opened."
-        },
-        "markdownEditorOptimized.export.browserPath": {
-          "type": "string",
-          "default": "",
-          "order": 7,
-          "description": "Optional path to a Chrome/Edge executable used for browser-based export rendering (PDF and HTML finalize). Leave empty to auto-detect."
-        },
-        "markdownEditorOptimized.export.pdf.browserPath": {
-          "type": "string",
-          "default": "",
-          "order": 7,
-          "description": "Deprecated: use markdownEditorOptimized.export.browserPath.",
-          "deprecationMessage": "Use markdownEditorOptimized.export.browserPath instead.",
-          "markdownDeprecationMessage": "Use `markdownEditorOptimized.export.browserPath` instead."
-        },
-        "markdownEditorOptimized.export.html.imageMode": {
-          "type": "string",
-          "enum": [
-            "embedded",
-            "linked"
-          ],
-          "enumDescriptions": [
-            "Embed local image files in exported HTML.",
-            "Keep local image links as relative paths in exported HTML."
-          ],
-          "default": "embedded",
-          "order": 8,
-          "description": "How local images are handled during HTML export."
-        },
-        "markdownEditorOptimized.imageFolder": {
-          "type": "string",
-          "default": "assets",
-          "order": 9,
-          "description": "Folder name to save pasted images (relative to workspace root)."
-        },
-        "markdownEditorOptimized.theme": {
-          "type": "object",
-          "default": {
-            "id": "one-monokai",
-            "name": "One Monokai",
-            "colors": {
-              "base01": "var(--vscode-editor-foreground)",
-              "base02": "#676f7d",
-              "base03": "#3e444d",
-              "base04": "#e06c75",
-              "base05": "#61afef",
-              "base06": "#66d9ef",
-              "base07": "#e5c07b",
-              "base08": "#c678dd",
-              "base09": "#98c379"
-            },
-            "syntaxTokens": {},
-            "fonts": {
-              "liveFont": "",
-              "sourceFont": "",
-              "liveFontWeight": "",
-              "sourceFontWeight": "",
-              "liveFontSize": null,
-              "sourceFontSize": null,
-              "h1FontSize": 1.6,
-              "h2FontSize": 1.5,
-              "h3FontSize": 1.3,
-              "h4FontSize": 1.2,
-              "h5FontSize": 1.1,
-              "h6FontSize": 1,
-              "h1FontWeight": "600",
-              "h2FontWeight": "600",
-              "h3FontWeight": "600",
-              "h4FontWeight": "600",
-              "h5FontWeight": "600",
-              "h6FontWeight": "600",
-              "liveLineHeight": 1.5,
-              "sourceLineHeight": 1.5
-            }
-          },
-          "defaultSnippets": [
-            {
-              "label": "One Monokai theme payload",
-              "description": "Insert the full theme object with sensible defaults.",
-              "body": "{\n\t\"id\": \"one-monokai\",\n\t\"name\": \"One Monokai\",\n\t\"colors\": {\n\t\t\"base01\": \"var(--vscode-editor-foreground)\",\n\t\t\"base02\": \"#676f7d\",\n\t\t\"base03\": \"#3e444d\",\n\t\t\"base04\": \"#e06c75\",\n\t\t\"base05\": \"#61afef\",\n\t\t\"base06\": \"#66d9ef\",\n\t\t\"base07\": \"#e5c07b\",\n\t\t\"base08\": \"#c678dd\",\n\t\t\"base09\": \"#98c379\"\n\t},\n\t\"syntaxTokens\": {},\n\t\"fonts\": {\n\t\t\"liveFont\": \"\",\n\t\t\"sourceFont\": \"\",\n\t\t\"liveFontWeight\": \"\",\n\t\t\"sourceFontWeight\": \"\",\n\t\t\"liveFontSize\": null,\n\t\t\"sourceFontSize\": null,\n\t\t\"h1FontSize\": 1.6,\n\t\t\"h2FontSize\": 1.5,\n\t\t\"h3FontSize\": 1.3,\n\t\t\"h4FontSize\": 1.2,\n\t\t\"h5FontSize\": 1.1,\n\t\t\"h6FontSize\": 1,\n\t\t\"h1FontWeight\": \"600\",\n\t\t\"h2FontWeight\": \"600\",\n\t\t\"h3FontWeight\": \"600\",\n\t\t\"h4FontWeight\": \"600\",\n\t\t\"h5FontWeight\": \"600\",\n\t\t\"h6FontWeight\": \"600\",\n\t\t\"liveLineHeight\": 1.5,\n\t\t\"sourceLineHeight\": 1.5\n\t}\n}"
-            }
-          ],
-          "description": "Theme payload containing base palette colors, optional token overrides, and font settings.",
-          "markdownDescription": "[Select Theme](command:markdownEditorOptimized.selectTheme) | [Import Theme](command:markdownEditorOptimized.importTheme) | [Export Theme](command:markdownEditorOptimized.exportTheme) | [Delete Imported Theme](command:markdownEditorOptimized.deleteImportedTheme) | [Reset Theme to Default](command:markdownEditorOptimized.resetThemeToDefault)",
-          "properties": {
-            "id": {
-              "type": "string",
-              "default": "one-monokai",
-              "description": "Unique theme identifier."
-            },
-            "name": {
-              "type": "string",
-              "default": "One Monokai (default)",
-              "description": "Display name for the theme."
-            },
-            "colors": {
-              "type": "object",
-              "default": {},
-              "properties": {
-                "base01": {
-                  "type": "string",
-                  "description": "Primary foreground color (hex/rgb/hsl/var).",
-                  "default": "var(--vscode-editor-foreground)"
-                },
-                "base02": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base03": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base04": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base05": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base06": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base07": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base08": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "base09": {
-                  "type": "string",
-                  "format": "color"
-                }
-              },
-              "required": [
-                "base02",
-                "base03",
-                "base04",
-                "base05",
-                "base06",
-                "base07",
-                "base08",
-                "base09"
-              ],
-              "additionalProperties": false
-            },
-            "syntaxTokens": {
-              "type": "object",
-              "default": {},
-              "properties": {
-                "keyword": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "identifier": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "macroName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "variableName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "propertyName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "typeName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "className": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "namespace": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "operator": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "operatorKeyword": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "punctuation": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "functionName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "labelName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "definitionFunction": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "definedVariable": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "number": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "changed": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "annotation": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "modifier": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "self": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "color": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "constant": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "atom": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "bool": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "specialVariable": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "specialString": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "regexp": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "string": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "typeDefinition": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "meta": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "comment": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "tagName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "attributeName": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "invalid": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "deleted": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "monospace": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "heading": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "emphasis": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "strong": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "strikethrough": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "quote": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "contentSeparator": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "link": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "url": {
-                  "type": "string",
-                  "format": "color"
-                },
-                "processingInstruction": {
-                  "type": "string",
-                  "format": "color"
-                }
-              },
-              "additionalProperties": false
-            },
-            "fonts": {
-              "type": "object",
-              "default": {},
-              "properties": {
-                "liveFont": {
-                  "type": "string",
-                  "default": ""
-                },
-                "sourceFont": {
-                  "type": "string",
-                  "default": ""
-                },
-                "liveFontWeight": {
-                  "type": "string",
-                  "default": "",
-                  "description": "Live mode font weight override. Leave empty to use VS Code editor font weight."
-                },
-                "sourceFontWeight": {
-                  "type": "string",
-                  "default": "",
-                  "description": "Source mode font weight override. Leave empty to use VS Code editor font weight."
-                },
-                "liveFontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "sourceFontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "default": null
-                },
-                "h1FontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "minimum": 1,
-                  "maximum": 3,
-                  "default": 1.6
-                },
-                "h2FontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "minimum": 1,
-                  "maximum": 3,
-                  "default": 1.5
-                },
-                "h3FontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "minimum": 1,
-                  "maximum": 3,
-                  "default": 1.3
-                },
-                "h4FontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "minimum": 1,
-                  "maximum": 3,
-                  "default": 1.2
-                },
-                "h5FontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "minimum": 1,
-                  "maximum": 3,
-                  "default": 1.1
-                },
-                "h6FontSize": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
-                  "minimum": 1,
-                  "maximum": 3,
-                  "default": 1
-                },
-                "h1FontWeight": {
-                  "type": "string",
-                  "default": "600",
-                  "description": "Heading 1 font weight override."
-                },
-                "h2FontWeight": {
-                  "type": "string",
-                  "default": "600",
-                  "description": "Heading 2 font weight override."
-                },
-                "h3FontWeight": {
-                  "type": "string",
-                  "default": "600",
-                  "description": "Heading 3 font weight override."
-                },
-                "h4FontWeight": {
-                  "type": "string",
-                  "default": "600",
-                  "description": "Heading 4 font weight override."
-                },
-                "h5FontWeight": {
-                  "type": "string",
-                  "default": "600",
-                  "description": "Heading 5 font weight override."
-                },
-                "h6FontWeight": {
-                  "type": "string",
-                  "default": "600",
-                  "description": "Heading 6 font weight override."
-                },
-                "liveLineHeight": {
-                  "type": "number",
-                  "default": 1.5,
-                  "minimum": 1,
-                  "maximum": 3
-                },
-                "sourceLineHeight": {
-                  "type": "number",
-                  "default": 1.5,
-                  "minimum": 1,
-                  "maximum": 3
-                }
-              },
-              "required": [
-                "liveFont",
-                "sourceFont",
-                "liveFontSize",
-                "sourceFontSize",
-                "liveLineHeight",
-                "sourceLineHeight"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "id",
-            "name",
-            "colors",
-            "syntaxTokens",
-            "fonts"
-          ],
-          "additionalProperties": false
-        }
-      }
-    }
-  },
-  "scripts": {
-    "install:all": "bun install && (cd webview && bun install)",
-    "typecheck:webview": "tsc -p webview/tsconfig.json --noEmit",
-    "build": "bun run build:webview && bun run build:extension",
-    "build:webview": "rm -rf webview/dist && mkdir -p webview/dist webview/dist/katex && bun build webview/src/index.ts --target=browser --format=esm --splitting --minify --outdir=webview/dist && cp webview/src/styles.css webview/dist/index.css && cp node_modules/mermaid/dist/mermaid.min.js webview/dist/mermaid.min.js && cp node_modules/katex/dist/katex.min.css webview/dist/katex/katex.min.css && cp -R node_modules/katex/dist/fonts webview/dist/katex/fonts",
-    "build:extension": "bun run build:extension:main && bun run build:extension:export-runtime && bun run build:extension:puppeteer-runtime",
-    "build:extension:main": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode",
-    "build:extension:main:debug": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode --sourcemap=inline",
-    "build:extension:export-runtime": "bun build src/export/runtime.ts --target=node --format=cjs --minify --outfile=dist/export-runtime.js",
-    "build:extension:puppeteer-runtime": "bun build src/export/puppeteerRuntime.ts --target=node --format=cjs --minify --outfile=dist/puppeteer-runtime.js",
-    "release:prep": "bun scripts/release-prep.mjs",
-    "release:finalize": "bun scripts/release-prep.mjs finalize",
-    "vscode:publish": "vsce package"
-  },
-  "dependencies": {
-    "@codemirror/commands": "6.8.1",
-    "@codemirror/lang-cpp": "^6.0.3",
-    "@codemirror/lang-css": "^6.3.1",
-    "@codemirror/lang-go": "^6.0.1",
-    "@codemirror/lang-html": "^6.4.11",
-    "@codemirror/lang-java": "^6.0.2",
-    "@codemirror/lang-javascript": "^6.2.4",
-    "@codemirror/lang-json": "^6.0.2",
-    "@codemirror/lang-markdown": "6.3.4",
-    "@codemirror/lang-python": "^6.2.1",
-    "@codemirror/lang-rust": "^6.0.2",
-    "@codemirror/lang-sql": "^6.10.0",
-    "@codemirror/language": "6.11.3",
-    "@codemirror/state": "6.5.2",
-    "@codemirror/view": "6.36.4",
-    "@lezer/highlight": "^1.2.3",
-    "@replit/codemirror-vim": "^6.3.0",
-    "@types/vscode": "^1.109.0",
-    "highlight.js": "^11.11.1",
-    "katex": "^0.16.28",
-    "lucide": "^0.564.0",
-    "markdown-it": "^14.1.0",
-    "markdown-it-emoji": "^3.0.0",
-    "mermaid": "^11.4.1",
-    "puppeteer-core": "^24.1.1",
-    "sanitize-html": "^2.17.0"
-  },
-  "devDependencies": {
-    "@types/markdown-it": "^14.1.2",
-    "@types/sanitize-html": "^2.16.0",
-    "typescript": "^5.9.3"
-  }
+	"name": "meo",
+	"displayName": "Markdown Editor Optimized",
+	"description": "An optimized markdown editor with live editing mode for VS Code.",
+	"version": "0.1.23",
+	"publisher": "vadimmelnicuk",
+	"private": true,
+	"icon": "logo.png",
+	"engines": {
+		"vscode": "^1.97.0"
+	},
+	"categories": [
+		"Programming Languages",
+		"Formatters",
+		"Other"
+	],
+	"keywords": [
+		"markdown",
+		"editor",
+		"live-edit",
+		"wysiwyg",
+		"markdown-editor",
+		"markdown-preview"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/vadimmelnicuk/meo.git"
+	},
+	"main": "./dist/extension.js",
+	"activationEvents": [
+		"onStartupFinished"
+	],
+	"contributes": {
+		"languages": [
+			{
+				"id": "markdown",
+				"extensions": [
+					".mdx",
+					".mdc"
+				]
+			}
+		],
+		"commands": [
+			{
+				"command": "markdownEditorOptimized.open",
+				"title": "Open With Markdown Editor Optimized",
+				"icon": "$(book)"
+			},
+			{
+				"command": "markdownEditorOptimized.setDefaultEditor",
+				"title": "Markdown Editor Optimized: Set as Default",
+				"icon": "$(check)"
+			},
+			{
+				"command": "markdownEditorOptimized.resetThemeToDefault",
+				"title": "Markdown Editor Optimized: Reset Theme to Default",
+				"icon": "$(discard)"
+			},
+			{
+				"command": "markdownEditorOptimized.selectTheme",
+				"title": "Markdown Editor Optimized: Select Theme"
+			},
+			{
+				"command": "markdownEditorOptimized.importTheme",
+				"title": "Markdown Editor Optimized: Import Theme JSON"
+			},
+			{
+				"command": "markdownEditorOptimized.exportTheme",
+				"title": "Markdown Editor Optimized: Export Theme JSON"
+			},
+			{
+				"command": "markdownEditorOptimized.deleteImportedTheme",
+				"title": "Markdown Editor Optimized: Delete Imported Theme"
+			},
+			{
+				"command": "markdownEditorOptimized.toggleMode",
+				"title": "Markdown Editor Optimized: Toggle Live/Source Mode",
+				"icon": "$(sync)"
+			},
+			{
+				"command": "markdownEditorOptimized.exportHtml",
+				"title": "Markdown Editor Optimized: Export as HTML",
+				"icon": "$(export)"
+			},
+			{
+				"command": "markdownEditorOptimized.exportPdf",
+				"title": "Markdown Editor Optimized: Export as PDF",
+				"icon": "$(file-pdf)"
+			}
+		],
+		"keybindings": [
+			{
+				"command": "markdownEditorOptimized.toggleMode",
+				"key": "alt+shift+m",
+				"when": "markdownEditorOptimized.activeEditor"
+			}
+		],
+		"customEditors": [
+			{
+				"viewType": "markdownEditorOptimized.editor",
+				"displayName": "Markdown Editor Optimized",
+				"selector": [
+					{
+						"filenamePattern": "*.md"
+					},
+					{
+						"filenamePattern": "*.markdown"
+					},
+					{
+						"filenamePattern": "*.mdx"
+					},
+					{
+						"filenamePattern": "*.mdc"
+					}
+				],
+				"priority": "default"
+			}
+		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "markdownEditorOptimized.open",
+					"when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
+					"group": "navigation"
+				}
+			],
+			"editor/title/context": [
+				{
+					"command": "markdownEditorOptimized.open",
+					"when": "resourceFilename =~ /\\.(md|markdown|mdx|mdc)$/",
+					"group": "navigation"
+				}
+			]
+		},
+		"configurationDefaults": {
+			"workbench.editorAssociations": {
+				"*.md": "markdownEditorOptimized.editor",
+				"*.markdown": "markdownEditorOptimized.editor",
+				"*.mdx": "markdownEditorOptimized.editor",
+				"*.mdc": "markdownEditorOptimized.editor",
+				"git:/**/*.md": "default",
+				"git:/**/*.markdown": "default",
+				"git:/**/*.mdx": "default",
+				"git:/**/*.mdc": "default",
+				"git:**/*.md": "default",
+				"git:**/*.markdown": "default",
+				"git:**/*.mdx": "default",
+				"git:**/*.mdc": "default",
+				"chat-editing-text-model:/**/*.md": "default",
+				"chat-editing-text-model:/**/*.markdown": "default",
+				"chat-editing-text-model:/**/*.mdx": "default",
+				"chat-editing-text-model:/**/*.mdc": "default",
+				"chat-editing-text-model:**/*.md": "default",
+				"chat-editing-text-model:**/*.markdown": "default",
+				"chat-editing-text-model:**/*.mdx": "default",
+				"chat-editing-text-model:**/*.mdc": "default"
+			}
+		},
+		"configuration": {
+			"title": "Markdown Editor Optimized",
+			"properties": {
+				"markdownEditorOptimized.useAsDefault": {
+					"type": "boolean",
+					"default": true,
+					"order": 1,
+					"description": "Use Markdown Editor Optimized as the default editor for Markdown files"
+				},
+				"markdownEditorOptimized.outline.position": {
+					"type": "string",
+					"enum": [
+						"left",
+						"right"
+					],
+					"enumDescriptions": [
+						"Show the document outline on the left side of the editor.",
+						"Show the document outline on the right side of the editor."
+					],
+					"default": "right",
+					"order": 2,
+					"description": "Position of the contents outline sidebar."
+				},
+				"markdownEditorOptimized.lineNumbers.visible": {
+					"type": "boolean",
+					"default": true,
+					"order": 3,
+					"description": "Show line numbers."
+				},
+				"markdownEditorOptimized.gitChanges.visible": {
+					"type": "boolean",
+					"default": true,
+					"order": 4,
+					"description": "Show Git change indicators in the editor."
+				},
+				"markdownEditorOptimized.gitChanges.lineHighlights": {
+					"type": "boolean",
+					"default": true,
+					"order": 5,
+					"description": "Show subtle line coloring for modified lines in Source mode."
+				},
+				"markdownEditorOptimized.vimMode.enabled": {
+					"type": "boolean",
+					"default": false,
+					"order": 6,
+					"description": "Enable Vim keybindings in Source mode. When not explicitly set, Vim mode is automatically enabled if the VSCodeVim extension (vscodevim.vim) is installed and active."
+				},
+				"markdownEditorOptimized.rememberPosition.lines": {
+					"type": "number",
+					"default": 100,
+					"minimum": 0,
+					"order": 7,
+					"description": "Markdown files with at least this many lines will remember the last viewed line and restore the scroll position when opened."
+				},
+				"markdownEditorOptimized.export.browserPath": {
+					"type": "string",
+					"default": "",
+					"order": 7,
+					"description": "Optional path to a Chrome/Edge executable used for browser-based export rendering (PDF and HTML finalize). Leave empty to auto-detect."
+				},
+				"markdownEditorOptimized.export.pdf.browserPath": {
+					"type": "string",
+					"default": "",
+					"order": 7,
+					"description": "Deprecated: use markdownEditorOptimized.export.browserPath.",
+					"deprecationMessage": "Use markdownEditorOptimized.export.browserPath instead.",
+					"markdownDeprecationMessage": "Use `markdownEditorOptimized.export.browserPath` instead."
+				},
+				"markdownEditorOptimized.export.html.imageMode": {
+					"type": "string",
+					"enum": [
+						"embedded",
+						"linked"
+					],
+					"enumDescriptions": [
+						"Embed local image files in exported HTML.",
+						"Keep local image links as relative paths in exported HTML."
+					],
+					"default": "embedded",
+					"order": 8,
+					"description": "How local images are handled during HTML export."
+				},
+				"markdownEditorOptimized.imageFolder": {
+					"type": "string",
+					"default": "assets",
+					"order": 9,
+					"description": "Folder name to save pasted images (relative to workspace root)."
+				},
+				"markdownEditorOptimized.theme": {
+					"type": "object",
+					"default": {
+						"id": "one-monokai",
+						"name": "One Monokai",
+						"colors": {
+							"base01": "var(--vscode-editor-foreground)",
+							"base02": "#676f7d",
+							"base03": "#3e444d",
+							"base04": "#e06c75",
+							"base05": "#61afef",
+							"base06": "#66d9ef",
+							"base07": "#e5c07b",
+							"base08": "#c678dd",
+							"base09": "#98c379"
+						},
+						"syntaxTokens": {},
+						"fonts": {
+							"liveFont": "",
+							"sourceFont": "",
+							"liveFontWeight": "",
+							"sourceFontWeight": "",
+							"liveFontSize": null,
+							"sourceFontSize": null,
+							"h1FontSize": 1.6,
+							"h2FontSize": 1.5,
+							"h3FontSize": 1.3,
+							"h4FontSize": 1.2,
+							"h5FontSize": 1.1,
+							"h6FontSize": 1,
+							"h1FontWeight": "600",
+							"h2FontWeight": "600",
+							"h3FontWeight": "600",
+							"h4FontWeight": "600",
+							"h5FontWeight": "600",
+							"h6FontWeight": "600",
+							"liveLineHeight": 1.5,
+							"sourceLineHeight": 1.5
+						}
+					},
+					"defaultSnippets": [
+						{
+							"label": "One Monokai theme payload",
+							"description": "Insert the full theme object with sensible defaults.",
+							"body": "{\n\t\"id\": \"one-monokai\",\n\t\"name\": \"One Monokai\",\n\t\"colors\": {\n\t\t\"base01\": \"var(--vscode-editor-foreground)\",\n\t\t\"base02\": \"#676f7d\",\n\t\t\"base03\": \"#3e444d\",\n\t\t\"base04\": \"#e06c75\",\n\t\t\"base05\": \"#61afef\",\n\t\t\"base06\": \"#66d9ef\",\n\t\t\"base07\": \"#e5c07b\",\n\t\t\"base08\": \"#c678dd\",\n\t\t\"base09\": \"#98c379\"\n\t},\n\t\"syntaxTokens\": {},\n\t\"fonts\": {\n\t\t\"liveFont\": \"\",\n\t\t\"sourceFont\": \"\",\n\t\t\"liveFontWeight\": \"\",\n\t\t\"sourceFontWeight\": \"\",\n\t\t\"liveFontSize\": null,\n\t\t\"sourceFontSize\": null,\n\t\t\"h1FontSize\": 1.6,\n\t\t\"h2FontSize\": 1.5,\n\t\t\"h3FontSize\": 1.3,\n\t\t\"h4FontSize\": 1.2,\n\t\t\"h5FontSize\": 1.1,\n\t\t\"h6FontSize\": 1,\n\t\t\"h1FontWeight\": \"600\",\n\t\t\"h2FontWeight\": \"600\",\n\t\t\"h3FontWeight\": \"600\",\n\t\t\"h4FontWeight\": \"600\",\n\t\t\"h5FontWeight\": \"600\",\n\t\t\"h6FontWeight\": \"600\",\n\t\t\"liveLineHeight\": 1.5,\n\t\t\"sourceLineHeight\": 1.5\n\t}\n}"
+						}
+					],
+					"description": "Theme payload containing base palette colors, optional token overrides, and font settings.",
+					"markdownDescription": "[Select Theme](command:markdownEditorOptimized.selectTheme) | [Import Theme](command:markdownEditorOptimized.importTheme) | [Export Theme](command:markdownEditorOptimized.exportTheme) | [Delete Imported Theme](command:markdownEditorOptimized.deleteImportedTheme) | [Reset Theme to Default](command:markdownEditorOptimized.resetThemeToDefault)",
+					"properties": {
+						"id": {
+							"type": "string",
+							"default": "one-monokai",
+							"description": "Unique theme identifier."
+						},
+						"name": {
+							"type": "string",
+							"default": "One Monokai (default)",
+							"description": "Display name for the theme."
+						},
+						"colors": {
+							"type": "object",
+							"default": {},
+							"properties": {
+								"base01": {
+									"type": "string",
+									"description": "Primary foreground color (hex/rgb/hsl/var).",
+									"default": "var(--vscode-editor-foreground)"
+								},
+								"base02": {
+									"type": "string",
+									"format": "color"
+								},
+								"base03": {
+									"type": "string",
+									"format": "color"
+								},
+								"base04": {
+									"type": "string",
+									"format": "color"
+								},
+								"base05": {
+									"type": "string",
+									"format": "color"
+								},
+								"base06": {
+									"type": "string",
+									"format": "color"
+								},
+								"base07": {
+									"type": "string",
+									"format": "color"
+								},
+								"base08": {
+									"type": "string",
+									"format": "color"
+								},
+								"base09": {
+									"type": "string",
+									"format": "color"
+								}
+							},
+							"required": [
+								"base02",
+								"base03",
+								"base04",
+								"base05",
+								"base06",
+								"base07",
+								"base08",
+								"base09"
+							],
+							"additionalProperties": false
+						},
+						"syntaxTokens": {
+							"type": "object",
+							"default": {},
+							"properties": {
+								"keyword": {
+									"type": "string",
+									"format": "color"
+								},
+								"identifier": {
+									"type": "string",
+									"format": "color"
+								},
+								"macroName": {
+									"type": "string",
+									"format": "color"
+								},
+								"variableName": {
+									"type": "string",
+									"format": "color"
+								},
+								"propertyName": {
+									"type": "string",
+									"format": "color"
+								},
+								"typeName": {
+									"type": "string",
+									"format": "color"
+								},
+								"className": {
+									"type": "string",
+									"format": "color"
+								},
+								"namespace": {
+									"type": "string",
+									"format": "color"
+								},
+								"operator": {
+									"type": "string",
+									"format": "color"
+								},
+								"operatorKeyword": {
+									"type": "string",
+									"format": "color"
+								},
+								"punctuation": {
+									"type": "string",
+									"format": "color"
+								},
+								"functionName": {
+									"type": "string",
+									"format": "color"
+								},
+								"labelName": {
+									"type": "string",
+									"format": "color"
+								},
+								"definitionFunction": {
+									"type": "string",
+									"format": "color"
+								},
+								"definedVariable": {
+									"type": "string",
+									"format": "color"
+								},
+								"number": {
+									"type": "string",
+									"format": "color"
+								},
+								"changed": {
+									"type": "string",
+									"format": "color"
+								},
+								"annotation": {
+									"type": "string",
+									"format": "color"
+								},
+								"modifier": {
+									"type": "string",
+									"format": "color"
+								},
+								"self": {
+									"type": "string",
+									"format": "color"
+								},
+								"color": {
+									"type": "string",
+									"format": "color"
+								},
+								"constant": {
+									"type": "string",
+									"format": "color"
+								},
+								"atom": {
+									"type": "string",
+									"format": "color"
+								},
+								"bool": {
+									"type": "string",
+									"format": "color"
+								},
+								"specialVariable": {
+									"type": "string",
+									"format": "color"
+								},
+								"specialString": {
+									"type": "string",
+									"format": "color"
+								},
+								"regexp": {
+									"type": "string",
+									"format": "color"
+								},
+								"string": {
+									"type": "string",
+									"format": "color"
+								},
+								"typeDefinition": {
+									"type": "string",
+									"format": "color"
+								},
+								"meta": {
+									"type": "string",
+									"format": "color"
+								},
+								"comment": {
+									"type": "string",
+									"format": "color"
+								},
+								"tagName": {
+									"type": "string",
+									"format": "color"
+								},
+								"attributeName": {
+									"type": "string",
+									"format": "color"
+								},
+								"invalid": {
+									"type": "string",
+									"format": "color"
+								},
+								"deleted": {
+									"type": "string",
+									"format": "color"
+								},
+								"monospace": {
+									"type": "string",
+									"format": "color"
+								},
+								"heading": {
+									"type": "string",
+									"format": "color"
+								},
+								"emphasis": {
+									"type": "string",
+									"format": "color"
+								},
+								"strong": {
+									"type": "string",
+									"format": "color"
+								},
+								"strikethrough": {
+									"type": "string",
+									"format": "color"
+								},
+								"quote": {
+									"type": "string",
+									"format": "color"
+								},
+								"contentSeparator": {
+									"type": "string",
+									"format": "color"
+								},
+								"link": {
+									"type": "string",
+									"format": "color"
+								},
+								"url": {
+									"type": "string",
+									"format": "color"
+								},
+								"processingInstruction": {
+									"type": "string",
+									"format": "color"
+								}
+							},
+							"additionalProperties": false
+						},
+						"fonts": {
+							"type": "object",
+							"default": {},
+							"properties": {
+								"liveFont": {
+									"type": "string",
+									"default": ""
+								},
+								"sourceFont": {
+									"type": "string",
+									"default": ""
+								},
+								"liveFontWeight": {
+									"type": "string",
+									"default": "",
+									"description": "Live mode font weight override. Leave empty to use VS Code editor font weight."
+								},
+								"sourceFontWeight": {
+									"type": "string",
+									"default": "",
+									"description": "Source mode font weight override. Leave empty to use VS Code editor font weight."
+								},
+								"liveFontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"default": null
+								},
+								"sourceFontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"default": null
+								},
+								"h1FontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"minimum": 1,
+									"maximum": 3,
+									"default": 1.6
+								},
+								"h2FontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"minimum": 1,
+									"maximum": 3,
+									"default": 1.5
+								},
+								"h3FontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"minimum": 1,
+									"maximum": 3,
+									"default": 1.3
+								},
+								"h4FontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"minimum": 1,
+									"maximum": 3,
+									"default": 1.2
+								},
+								"h5FontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"minimum": 1,
+									"maximum": 3,
+									"default": 1.1
+								},
+								"h6FontSize": {
+									"type": [
+										"number",
+										"null"
+									],
+									"minimum": 1,
+									"maximum": 3,
+									"default": 1
+								},
+								"h1FontWeight": {
+									"type": "string",
+									"default": "600",
+									"description": "Heading 1 font weight override."
+								},
+								"h2FontWeight": {
+									"type": "string",
+									"default": "600",
+									"description": "Heading 2 font weight override."
+								},
+								"h3FontWeight": {
+									"type": "string",
+									"default": "600",
+									"description": "Heading 3 font weight override."
+								},
+								"h4FontWeight": {
+									"type": "string",
+									"default": "600",
+									"description": "Heading 4 font weight override."
+								},
+								"h5FontWeight": {
+									"type": "string",
+									"default": "600",
+									"description": "Heading 5 font weight override."
+								},
+								"h6FontWeight": {
+									"type": "string",
+									"default": "600",
+									"description": "Heading 6 font weight override."
+								},
+								"liveLineHeight": {
+									"type": "number",
+									"default": 1.5,
+									"minimum": 1,
+									"maximum": 3
+								},
+								"sourceLineHeight": {
+									"type": "number",
+									"default": 1.5,
+									"minimum": 1,
+									"maximum": 3
+								}
+							},
+							"required": [
+								"liveFont",
+								"sourceFont",
+								"liveFontSize",
+								"sourceFontSize",
+								"liveLineHeight",
+								"sourceLineHeight"
+							],
+							"additionalProperties": false
+						}
+					},
+					"required": [
+						"id",
+						"name",
+						"colors",
+						"syntaxTokens",
+						"fonts"
+					],
+					"additionalProperties": false
+				}
+			}
+		}
+	},
+	"scripts": {
+		"install:all": "bun install && (cd webview && bun install)",
+		"typecheck:webview": "tsc -p webview/tsconfig.json --noEmit",
+		"build": "bun run build:webview && bun run build:extension",
+		"build:webview": "rm -rf webview/dist && mkdir -p webview/dist webview/dist/katex && bun build webview/src/index.ts --target=browser --format=esm --splitting --minify --outdir=webview/dist && cp webview/src/styles.css webview/dist/index.css && cp node_modules/mermaid/dist/mermaid.min.js webview/dist/mermaid.min.js && cp node_modules/katex/dist/katex.min.css webview/dist/katex/katex.min.css && cp -R node_modules/katex/dist/fonts webview/dist/katex/fonts",
+		"build:extension": "bun run build:extension:main && bun run build:extension:export-runtime && bun run build:extension:puppeteer-runtime",
+		"build:extension:main": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode",
+		"build:extension:main:debug": "bun build src/extension.ts --target=node --format=cjs --minify --outfile=dist/extension.js -e vscode --sourcemap=inline",
+		"build:extension:export-runtime": "bun build src/export/runtime.ts --target=node --format=cjs --minify --outfile=dist/export-runtime.js",
+		"build:extension:puppeteer-runtime": "bun build src/export/puppeteerRuntime.ts --target=node --format=cjs --minify --outfile=dist/puppeteer-runtime.js",
+		"release:prep": "bun scripts/release-prep.mjs",
+		"release:finalize": "bun scripts/release-prep.mjs finalize",
+		"vscode:publish": "vsce package"
+	},
+	"dependencies": {
+		"@codemirror/commands": "6.8.1",
+		"@codemirror/lang-cpp": "^6.0.3",
+		"@codemirror/lang-css": "^6.3.1",
+		"@codemirror/lang-go": "^6.0.1",
+		"@codemirror/lang-html": "^6.4.11",
+		"@codemirror/lang-java": "^6.0.2",
+		"@codemirror/lang-javascript": "^6.2.4",
+		"@codemirror/lang-json": "^6.0.2",
+		"@codemirror/lang-markdown": "6.3.4",
+		"@codemirror/lang-python": "^6.2.1",
+		"@codemirror/lang-rust": "^6.0.2",
+		"@codemirror/lang-sql": "^6.10.0",
+		"@codemirror/language": "6.11.3",
+		"@codemirror/state": "6.5.2",
+		"@codemirror/view": "6.36.4",
+		"@lezer/highlight": "^1.2.3",
+		"@replit/codemirror-vim": "^6.3.0",
+		"@types/vscode": "^1.109.0",
+		"highlight.js": "^11.11.1",
+		"katex": "^0.16.28",
+		"lucide": "^0.564.0",
+		"markdown-it": "^14.1.0",
+		"markdown-it-emoji": "^3.0.0",
+		"mermaid": "^11.4.1",
+		"puppeteer-core": "^24.1.1",
+		"sanitize-html": "^2.17.0"
+	},
+	"devDependencies": {
+		"@types/markdown-it": "^14.1.2",
+		"@types/sanitize-html": "^2.16.0",
+		"typescript": "^5.9.3"
+	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,900 +1,740 @@
-import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
-import * as vscode from 'vscode';
-import { createGitApiWatcher } from './git/gitApiWatch';
-import {
-  AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS,
-  AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS,
-  AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS,
-  AgentReviewHandoffController
-} from './agents/reviewHandoff';
-import {
-  areAgentReviewTextsEquivalent,
-  findLikelyAgentReviewState,
-  getComparableFileUri,
-  isLikelyAgentReviewUri,
-  resolveAgentReviewRedirectState
-} from './agents/reviewState';
-import {
-  getComparableResourceKey,
-  getOpenTextDocumentForComparableKey,
-  getOpenTextDocumentForUri,
-  getPreferredCommandUri,
-  parseGitUriQuery,
-  resolveWorktreeUriFromGitUri
-} from './agents/resourceMatching';
-import { AgentReviewOverrideController } from './agents/reviewOverrides';
-import {
-  EXTENSION_CONFIG_SECTION,
-  GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY,
-  GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY,
-  GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY,
-  GIT_CHANGES_GUTTER_SETTING_KEY,
-  GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY,
-  LINE_NUMBERS_LEGACY_SETTING_KEY,
-  LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY,
-  LINE_NUMBERS_SETTING_KEY,
-  OUTLINE_VISIBLE_KEY,
-  VIM_MODE_SETTING_KEY,
-  syncEditorAssociations,
-  type ExportHtmlImageMode,
-  getExportHtmlImageMode,
-  getExportEditorFontEnvironment,
-  getExportPdfBrowserPath,
-  getGitChangesGutterEnabled,
-  getGitDiffLineHighlightsEnabled,
-  getLineNumbersEnabled,
-  getOutlinePosition,
-  getOutlineVisible,
-  getThemeSettings,
-  getVimModeEnabled,
-  isMarkdownDocumentPath,
-  migrateLegacyToggleSettings,
-  resetThemeSettingsToDefault
-} from './shared/extensionConfig';
-import { createPanelSessionController, type ExportFormat, type PanelSession } from './extension/panelSession';
-import { serializeThemeSettings, themePresets, type ThemeSettings, validateThemePayload } from './shared/themeDefaults';
-import {
-  runWithTimedUiTimeout,
-  showTimedErrorMessage,
-  showTimedInformationMessage,
-  showTimedQuickPick,
-  showTimedWarningMessage,
-  showTimedWarningMessageWithItems
-} from './shared/timedUi';
-import type { ExportStyleEnvironment } from './export/runtime';
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import * as vscode from "vscode";
+import { createGitApiWatcher } from "./git/gitApiWatch";
+import { AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS, AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS, AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS, AgentReviewHandoffController } from "./agents/reviewHandoff";
+import { areAgentReviewTextsEquivalent, findLikelyAgentReviewState, getComparableFileUri, isLikelyAgentReviewUri, resolveAgentReviewRedirectState } from "./agents/reviewState";
+import { getComparableResourceKey, getOpenTextDocumentForComparableKey, getOpenTextDocumentForUri, getPreferredCommandUri, parseGitUriQuery, resolveWorktreeUriFromGitUri } from "./agents/resourceMatching";
+import { AgentReviewOverrideController } from "./agents/reviewOverrides";
+import { EXTENSION_CONFIG_SECTION, GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY, LINE_NUMBERS_LEGACY_SETTING_KEY, LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY, LINE_NUMBERS_SETTING_KEY, OUTLINE_VISIBLE_KEY, VIM_MODE_SETTING_KEY, syncEditorAssociations, type ExportHtmlImageMode, getExportHtmlImageMode, getExportEditorFontEnvironment, getExportPdfBrowserPath, getGitChangesGutterEnabled, getGitDiffLineHighlightsEnabled, getLineNumbersEnabled, getOutlinePosition, getOutlineVisible, getThemeSettings, getVimModeEnabled, getVimKeybindings, getVimLeaderKey, isMarkdownDocumentPath, migrateLegacyToggleSettings, resetThemeSettingsToDefault } from "./shared/extensionConfig";
+import { createPanelSessionController, type ExportFormat, type PanelSession } from "./extension/panelSession";
+import { serializeThemeSettings, themePresets, type ThemeSettings, validateThemePayload } from "./shared/themeDefaults";
+import { runWithTimedUiTimeout, showTimedErrorMessage, showTimedInformationMessage, showTimedQuickPick, showTimedWarningMessage, showTimedWarningMessageWithItems } from "./shared/timedUi";
+import type { ExportStyleEnvironment } from "./export/runtime";
 
-const VIEW_TYPE = 'markdownEditorOptimized.editor';
-const ACTIVE_EDITOR_CONTEXT_KEY = 'markdownEditorOptimized.activeEditor';
-const FIND_OPTIONS_STATE_KEY = 'findOptions';
-const CUSTOM_THEMES_STATE_KEY = 'customThemes';
+const VIEW_TYPE = "markdownEditorOptimized.editor";
+const ACTIVE_EDITOR_CONTEXT_KEY = "markdownEditorOptimized.activeEditor";
+const FIND_OPTIONS_STATE_KEY = "findOptions";
+const CUSTOM_THEMES_STATE_KEY = "customThemes";
 
 type FindOptionsState = {
-  wholeWord: boolean;
-  caseSensitive: boolean;
+    wholeWord: boolean;
+    caseSensitive: boolean;
 };
 
-type ThemeSource = 'built-in' | 'imported';
+type ThemeSource = "built-in" | "imported";
 
 type ThemeQuickPickItem = vscode.QuickPickItem & {
-  theme: ThemeSettings;
-  source: ThemeSource;
+    theme: ThemeSettings;
+    source: ThemeSource;
 };
 
 type ImportedThemeQuickPickItem = vscode.QuickPickItem & {
-  theme: ThemeSettings;
+    theme: ThemeSettings;
 };
 
 type ExportRuntimeModule = {
-  renderExportHtmlDocument: (options: {
-    markdownText: string;
-    sourceDocumentPath: string;
-    outputFilePath: string;
-    target: ExportFormat;
-    htmlImageMode: ExportHtmlImageMode;
-    theme: ThemeSettings;
-    styleEnvironment?: ExportStyleEnvironment;
-    editorFontEnvironment?: {
-      editorFontFamily?: string;
-      editorFontWeight?: string;
-      editorFontSizePx?: number;
-    };
-    mermaidRuntimeSrc: string;
-    katexStylesHref: string;
-    baseHref: string;
-    title: string;
-  }) => { htmlDocument: string; hasMermaid: boolean; hasMath: boolean };
-  writeFinalizedHtmlExport: (options: {
-    htmlDocument: string;
-    outputHtmlPath: string;
-    browserExecutablePath?: string;
-    puppeteerRuntimeModulePath?: string;
-    timeoutMs?: number;
-    skipHeadlessFinalize?: boolean;
-  }) => Promise<void>;
-  renderPdfFromHtmlExport: (options: {
-    htmlDocument: string;
-    outputPdfPath: string;
-    browserExecutablePath?: string;
-    puppeteerRuntimeModulePath?: string;
-    timeoutMs?: number;
-  }) => Promise<void>;
+    renderExportHtmlDocument: (options: {
+        markdownText: string;
+        sourceDocumentPath: string;
+        outputFilePath: string;
+        target: ExportFormat;
+        htmlImageMode: ExportHtmlImageMode;
+        theme: ThemeSettings;
+        styleEnvironment?: ExportStyleEnvironment;
+        editorFontEnvironment?: {
+            editorFontFamily?: string;
+            editorFontWeight?: string;
+            editorFontSizePx?: number;
+        };
+        mermaidRuntimeSrc: string;
+        katexStylesHref: string;
+        baseHref: string;
+        title: string;
+    }) => { htmlDocument: string; hasMermaid: boolean; hasMath: boolean };
+    writeFinalizedHtmlExport: (options: { htmlDocument: string; outputHtmlPath: string; browserExecutablePath?: string; puppeteerRuntimeModulePath?: string; timeoutMs?: number; skipHeadlessFinalize?: boolean }) => Promise<void>;
+    renderPdfFromHtmlExport: (options: { htmlDocument: string; outputPdfPath: string; browserExecutablePath?: string; puppeteerRuntimeModulePath?: string; timeoutMs?: number }) => Promise<void>;
 };
 
 let exportRuntimeModulePromise: Promise<ExportRuntimeModule> | null = null;
 
 export function activate(context: vscode.ExtensionContext): void {
-  void vscode.commands.executeCommand('setContext', ACTIVE_EDITOR_CONTEXT_KEY, false);
-  const useAsDefault = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>('useAsDefault', true);
-  void syncEditorAssociations(useAsDefault);
+    void vscode.commands.executeCommand("setContext", ACTIVE_EDITOR_CONTEXT_KEY, false);
+    const useAsDefault = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>("useAsDefault", true);
+    void syncEditorAssociations(useAsDefault);
 
-  const agentReviewHandoff = new AgentReviewHandoffController({
-    viewType: VIEW_TYPE,
-    getComparableResourceKey,
-    getOpenTextDocumentForUri,
-    hasLikelyReviewState: (targetUri, targetText) =>
-      Boolean(findLikelyAgentReviewState(targetUri, getComparableResourceKey, getOpenTextDocumentForUri, targetText))
-  });
-  const agentReviewOverrides = new AgentReviewOverrideController(context, {
-    getComparableResourceKey,
-    getOpenTextDocumentForComparableKey,
-    isLikelyAgentReviewUri
-  });
-  void agentReviewOverrides.syncNow();
-
-  const provider = new MarkdownWebviewProvider(context, agentReviewHandoff);
-  void provider.initializeGitWatcher();
-
-  context.subscriptions.push(
-    vscode.window.registerCustomEditorProvider(VIEW_TYPE, provider, {
-      supportsMultipleEditorsPerDocument: false,
-      webviewOptions: { retainContextWhenHidden: true }
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.useAsDefault`)) {
-        const shouldUseAsDefault = vscode.workspace
-          .getConfiguration(EXTENSION_CONFIG_SECTION)
-          .get<boolean>('useAsDefault', true);
-        void syncEditorAssociations(shouldUseAsDefault);
-      }
-
-      void provider.handleConfigurationChanged(event);
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidOpenTextDocument((document) => {
-      if (!isLikelyAgentReviewUri(document.uri)) {
-        return;
-      }
-      void agentReviewOverrides.syncNow();
-      void provider.redirectOpenEditorsForCopilotReview(document.uri);
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidCloseTextDocument((document) => {
-      if (!isLikelyAgentReviewUri(document.uri)) {
-        return;
-      }
-      agentReviewOverrides.scheduleSync(AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS);
-      const targetUri = getComparableFileUri(document.uri, getComparableResourceKey);
-      if (targetUri) {
-        const targetPath = (targetUri.path || targetUri.fsPath || '').toLowerCase();
-        if (isMarkdownDocumentPath(targetPath)) {
-          const openTargetDocument = getOpenTextDocumentForUri(targetUri);
-          const reviewApplied = areAgentReviewTextsEquivalent(document.getText(), openTargetDocument?.getText());
-          if (reviewApplied && agentReviewHandoff.hasOpenNativeTextTabForUri(targetUri)) {
-            agentReviewHandoff.scheduleDeferredReopen(targetUri);
-          }
-        }
-
-        agentReviewHandoff.notePendingMEOtabDedup(targetUri);
-        agentReviewHandoff.scheduleMEOtabDedup(targetUri, AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS);
-      }
-      agentReviewHandoff.scheduleFlushDeferredReopens(AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS);
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.workspace.onDidChangeTextDocument((event) => {
-      const isAgentReviewDocument = isLikelyAgentReviewUri(event.document.uri);
-      if (isAgentReviewDocument) {
-        agentReviewOverrides.scheduleSync();
-      }
-      if (!agentReviewHandoff.hasRecentMEOOwnedFileChangeForUri(event.document.uri)) {
-        void provider.redirectOpenEditorsForCopilotReview(event.document.uri);
-      }
-
-      const shouldReevaluate = agentReviewHandoff.shouldReevaluateDeferredReopen(
-        event.document.uri,
-        isAgentReviewDocument
-      );
-      if (!shouldReevaluate) {
-        return;
-      }
-
-      if (!isAgentReviewDocument) {
-        agentReviewOverrides.scheduleSync();
-      }
-      agentReviewHandoff.scheduleFlushDeferredReopens();
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.window.tabGroups.onDidChangeTabs((event) => {
-      agentReviewHandoff.noteRecentTextDiffActivity(event.opened);
-      agentReviewHandoff.noteRecentTextDiffActivity(event.changed);
-      void agentReviewHandoff.flushPendingMEOtabDedups();
-      if (!agentReviewHandoff.hasPendingDeferredReopens()) {
-        return;
-      }
-      agentReviewHandoff.scheduleFlushDeferredReopens();
-    })
-  );
-
-  void migrateLegacyToggleSettings(context);
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.open', async (uriLike?: unknown) => {
-      const targetUri = getPreferredCommandUri(uriLike);
-      if (!targetUri) {
-        return;
-      }
-      const targetPath = (targetUri.path || targetUri.fsPath || '').toLowerCase();
-      if (!isMarkdownDocumentPath(targetPath)) {
-        return;
-      }
-      const pendingReview = findLikelyAgentReviewState(
-        targetUri,
+    const agentReviewHandoff = new AgentReviewHandoffController({
+        viewType: VIEW_TYPE,
         getComparableResourceKey,
         getOpenTextDocumentForUri,
-        getOpenTextDocumentForUri(targetUri)?.getText()
-      );
-      if (pendingReview) {
-        agentReviewHandoff.scheduleDeferredReopen(targetUri);
-        return;
-      }
-      await vscode.commands.executeCommand('vscode.openWith', targetUri, VIEW_TYPE);
-    })
-  );
+        hasLikelyReviewState: (targetUri, targetText) => Boolean(findLikelyAgentReviewState(targetUri, getComparableResourceKey, getOpenTextDocumentForUri, targetText)),
+    });
+    const agentReviewOverrides = new AgentReviewOverrideController(context, {
+        getComparableResourceKey,
+        getOpenTextDocumentForComparableKey,
+        isLikelyAgentReviewUri,
+    });
+    void agentReviewOverrides.syncNow();
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.setDefaultEditor', async () => {
-      await syncEditorAssociations(true);
-      void showTimedInformationMessage('Markdown Editor Optimized is now set as the default editor for Markdown files.');
-    })
-  );
+    const provider = new MarkdownWebviewProvider(context, agentReviewHandoff);
+    void provider.initializeGitWatcher();
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.resetThemeToDefault', async () => {
-      await resetThemeSettingsToDefault();
-      provider.notifyThemeChanged();
-      void showTimedInformationMessage('Markdown Editor Optimized theme was reset to default.');
-    })
-  );
+    context.subscriptions.push(
+        vscode.window.registerCustomEditorProvider(VIEW_TYPE, provider, {
+            supportsMultipleEditorsPerDocument: false,
+            webviewOptions: { retainContextWhenHidden: true },
+        }),
+    );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.selectTheme', async () => {
-      const themeItems = buildThemeQuickPickItems(context);
-      const selectedTheme = await showTimedQuickPick(
-        themeItems,
-        { title: 'Select Theme', placeHolder: 'Select & apply a theme preset.' },
-        0
-      );
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.useAsDefault`)) {
+                const shouldUseAsDefault = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>("useAsDefault", true);
+                void syncEditorAssociations(shouldUseAsDefault);
+            }
 
-      if (!selectedTheme) {
-        return;
-      }
+            void provider.handleConfigurationChanged(event);
+        }),
+    );
 
-      const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-      try {
-        await config.update('theme', serializeThemeSettings(selectedTheme.theme), vscode.ConfigurationTarget.Global);
-      } catch {
-        void showTimedErrorMessage('Failed to apply theme preset.');
-        return;
-      }
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument((document) => {
+            if (!isLikelyAgentReviewUri(document.uri)) {
+                return;
+            }
+            void agentReviewOverrides.syncNow();
+            void provider.redirectOpenEditorsForCopilotReview(document.uri);
+        }),
+    );
 
-      provider.notifyThemeChanged();
-      const sourceSuffix = selectedTheme.source === 'imported' ? ' (imported)' : '';
-      void showTimedInformationMessage(`Selected theme: ${selectedTheme.theme.name}${sourceSuffix}`);
-    })
-  );
+    context.subscriptions.push(
+        vscode.workspace.onDidCloseTextDocument((document) => {
+            if (!isLikelyAgentReviewUri(document.uri)) {
+                return;
+            }
+            agentReviewOverrides.scheduleSync(AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS);
+            const targetUri = getComparableFileUri(document.uri, getComparableResourceKey);
+            if (targetUri) {
+                const targetPath = (targetUri.path || targetUri.fsPath || "").toLowerCase();
+                if (isMarkdownDocumentPath(targetPath)) {
+                    const openTargetDocument = getOpenTextDocumentForUri(targetUri);
+                    const reviewApplied = areAgentReviewTextsEquivalent(document.getText(), openTargetDocument?.getText());
+                    if (reviewApplied && agentReviewHandoff.hasOpenNativeTextTabForUri(targetUri)) {
+                        agentReviewHandoff.scheduleDeferredReopen(targetUri);
+                    }
+                }
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.importTheme', async () => {
-      const openFiles = await vscode.window.showOpenDialog({
-        title: 'Import Theme JSON',
-        filters: { 'Theme JSON': ['json'] },
-        canSelectMany: false
-      });
+                agentReviewHandoff.notePendingMEOtabDedup(targetUri);
+                agentReviewHandoff.scheduleMEOtabDedup(targetUri, AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS);
+            }
+            agentReviewHandoff.scheduleFlushDeferredReopens(AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS);
+        }),
+    );
 
-      if (!openFiles?.length) {
-        return;
-      }
+    context.subscriptions.push(
+        vscode.workspace.onDidChangeTextDocument((event) => {
+            const isAgentReviewDocument = isLikelyAgentReviewUri(event.document.uri);
+            if (isAgentReviewDocument) {
+                agentReviewOverrides.scheduleSync();
+            }
+            if (!agentReviewHandoff.hasRecentMEOOwnedFileChangeForUri(event.document.uri)) {
+                void provider.redirectOpenEditorsForCopilotReview(event.document.uri);
+            }
 
-      const fileUri = openFiles[0];
-      try {
-        const fileContent = await vscode.workspace.fs.readFile(fileUri);
-        const payload = JSON.parse(new TextDecoder().decode(fileContent));
-        const validated = validateThemePayload(payload);
-        if (!validated.success) {
-          void showTimedErrorMessage(
-            `Invalid theme file: ${validated.errors[0] || 'payload does not match schema.'}`
-          );
-          return;
-        }
+            const shouldReevaluate = agentReviewHandoff.shouldReevaluateDeferredReopen(event.document.uri, isAgentReviewDocument);
+            if (!shouldReevaluate) {
+                return;
+            }
 
-        const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-        await config.update('theme', serializeThemeSettings(validated.theme), vscode.ConfigurationTarget.Global);
-        await upsertImportedTheme(context, validated.theme);
-        provider.notifyThemeChanged();
-        void showTimedInformationMessage(`Imported theme: ${validated.theme.name}`);
-      } catch (error) {
-        void showTimedErrorMessage(`Failed to import theme: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    })
-  );
+            if (!isAgentReviewDocument) {
+                agentReviewOverrides.scheduleSync();
+            }
+            agentReviewHandoff.scheduleFlushDeferredReopens();
+        }),
+    );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.exportTheme', async () => {
-      const uri = await vscode.window.showSaveDialog({
-        title: 'Export Theme JSON',
-        filters: { 'Theme JSON': ['json'] },
-        defaultUri: vscode.Uri.file('meo-theme.json'),
-        saveLabel: 'Export Theme'
-      });
+    context.subscriptions.push(
+        vscode.window.tabGroups.onDidChangeTabs((event) => {
+            agentReviewHandoff.noteRecentTextDiffActivity(event.opened);
+            agentReviewHandoff.noteRecentTextDiffActivity(event.changed);
+            void agentReviewHandoff.flushPendingMEOtabDedups();
+            if (!agentReviewHandoff.hasPendingDeferredReopens()) {
+                return;
+            }
+            agentReviewHandoff.scheduleFlushDeferredReopens();
+        }),
+    );
 
-      if (!uri) {
-        return;
-      }
+    void migrateLegacyToggleSettings(context);
 
-      const theme = serializeThemeSettings(getThemeSettings());
-      try {
-        await vscode.workspace.fs.writeFile(
-          uri,
-          new TextEncoder().encode(`${JSON.stringify(theme, null, 2)}\n`)
-        );
-        void showTimedInformationMessage(`Theme exported to ${uri.fsPath}`);
-      } catch (error) {
-        void showTimedErrorMessage(`Failed to export theme: ${error instanceof Error ? error.message : String(error)}`);
-      }
-    })
-  );
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.open", async (uriLike?: unknown) => {
+            const targetUri = getPreferredCommandUri(uriLike);
+            if (!targetUri) {
+                return;
+            }
+            const targetPath = (targetUri.path || targetUri.fsPath || "").toLowerCase();
+            if (!isMarkdownDocumentPath(targetPath)) {
+                return;
+            }
+            const pendingReview = findLikelyAgentReviewState(targetUri, getComparableResourceKey, getOpenTextDocumentForUri, getOpenTextDocumentForUri(targetUri)?.getText());
+            if (pendingReview) {
+                agentReviewHandoff.scheduleDeferredReopen(targetUri);
+                return;
+            }
+            await vscode.commands.executeCommand("vscode.openWith", targetUri, VIEW_TYPE);
+        }),
+    );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.deleteImportedTheme', async () => {
-      const importedThemes = getImportedThemes(context);
-      if (!importedThemes.length) {
-        void showTimedInformationMessage('No imported themes to delete.');
-        return;
-      }
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.setDefaultEditor", async () => {
+            await syncEditorAssociations(true);
+            void showTimedInformationMessage("Markdown Editor Optimized is now set as the default editor for Markdown files.");
+        }),
+    );
 
-      const selected = await showTimedQuickPick(
-        importedThemes.map((theme) => ({
-          label: theme.name,
-          description: theme.id,
-          theme
-        } satisfies ImportedThemeQuickPickItem)),
-        {
-          title: 'Delete Imported Theme',
-          placeHolder: 'Select an imported theme to delete'
-        }
-      );
-      if (!selected) {
-        return;
-      }
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.resetThemeToDefault", async () => {
+            await resetThemeSettingsToDefault();
+            provider.notifyThemeChanged();
+            void showTimedInformationMessage("Markdown Editor Optimized theme was reset to default.");
+        }),
+    );
 
-      const confirm = await showTimedWarningMessageWithItems(
-        `Delete imported theme "${selected.theme.name}"?`,
-        { modal: true },
-        ['Delete'] as const
-      );
-      if (confirm !== 'Delete') {
-        return;
-      }
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.selectTheme", async () => {
+            const themeItems = buildThemeQuickPickItems(context);
+            const selectedTheme = await showTimedQuickPick(themeItems, { title: "Select Theme", placeHolder: "Select & apply a theme preset." }, 0);
 
-      const deleted = await deleteImportedThemeById(context, selected.theme.id);
-      if (!deleted) {
-        void showTimedWarningMessage(`Could not find imported theme "${selected.theme.name}" to delete.`);
-        return;
-      }
+            if (!selectedTheme) {
+                return;
+            }
 
-      const currentTheme = getThemeSettings();
-      const deletingActiveTheme = normalizeThemeId(currentTheme.id) === normalizeThemeId(selected.theme.id);
-      const collidesWithBuiltIn = isBuiltInThemeId(selected.theme.id);
-      if (deletingActiveTheme && !collidesWithBuiltIn) {
-        const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-        await config.update('theme', serializeThemeSettings(themePresets[0] as ThemeSettings), vscode.ConfigurationTarget.Global);
-        provider.notifyThemeChanged();
-        void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}. Active theme reset to ${themePresets[0].name}.`);
-        return;
-      }
+            const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+            try {
+                await config.update("theme", serializeThemeSettings(selectedTheme.theme), vscode.ConfigurationTarget.Global);
+            } catch {
+                void showTimedErrorMessage("Failed to apply theme preset.");
+                return;
+            }
 
-      void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}`);
-    })
-  );
+            provider.notifyThemeChanged();
+            const sourceSuffix = selectedTheme.source === "imported" ? " (imported)" : "";
+            void showTimedInformationMessage(`Selected theme: ${selectedTheme.theme.name}${sourceSuffix}`);
+        }),
+    );
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.toggleMode', async () => {
-      await provider.toggleActiveEditorMode();
-    })
-  );
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.importTheme", async () => {
+            const openFiles = await vscode.window.showOpenDialog({
+                title: "Import Theme JSON",
+                filters: { "Theme JSON": ["json"] },
+                canSelectMany: false,
+            });
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.exportHtml', async () => {
-      await provider.exportActiveDocument('html');
-    })
-  );
+            if (!openFiles?.length) {
+                return;
+            }
 
-  context.subscriptions.push(
-    vscode.commands.registerCommand('markdownEditorOptimized.exportPdf', async () => {
-      await provider.exportActiveDocument('pdf');
-    })
-  );
+            const fileUri = openFiles[0];
+            try {
+                const fileContent = await vscode.workspace.fs.readFile(fileUri);
+                const payload = JSON.parse(new TextDecoder().decode(fileContent));
+                const validated = validateThemePayload(payload);
+                if (!validated.success) {
+                    void showTimedErrorMessage(`Invalid theme file: ${validated.errors[0] || "payload does not match schema."}`);
+                    return;
+                }
+
+                const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+                await config.update("theme", serializeThemeSettings(validated.theme), vscode.ConfigurationTarget.Global);
+                await upsertImportedTheme(context, validated.theme);
+                provider.notifyThemeChanged();
+                void showTimedInformationMessage(`Imported theme: ${validated.theme.name}`);
+            } catch (error) {
+                void showTimedErrorMessage(`Failed to import theme: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.exportTheme", async () => {
+            const uri = await vscode.window.showSaveDialog({
+                title: "Export Theme JSON",
+                filters: { "Theme JSON": ["json"] },
+                defaultUri: vscode.Uri.file("meo-theme.json"),
+                saveLabel: "Export Theme",
+            });
+
+            if (!uri) {
+                return;
+            }
+
+            const theme = serializeThemeSettings(getThemeSettings());
+            try {
+                await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(`${JSON.stringify(theme, null, 2)}\n`));
+                void showTimedInformationMessage(`Theme exported to ${uri.fsPath}`);
+            } catch (error) {
+                void showTimedErrorMessage(`Failed to export theme: ${error instanceof Error ? error.message : String(error)}`);
+            }
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.deleteImportedTheme", async () => {
+            const importedThemes = getImportedThemes(context);
+            if (!importedThemes.length) {
+                void showTimedInformationMessage("No imported themes to delete.");
+                return;
+            }
+
+            const selected = await showTimedQuickPick(
+                importedThemes.map(
+                    (theme) =>
+                        ({
+                            label: theme.name,
+                            description: theme.id,
+                            theme,
+                        }) satisfies ImportedThemeQuickPickItem,
+                ),
+                {
+                    title: "Delete Imported Theme",
+                    placeHolder: "Select an imported theme to delete",
+                },
+            );
+            if (!selected) {
+                return;
+            }
+
+            const confirm = await showTimedWarningMessageWithItems(`Delete imported theme "${selected.theme.name}"?`, { modal: true }, ["Delete"] as const);
+            if (confirm !== "Delete") {
+                return;
+            }
+
+            const deleted = await deleteImportedThemeById(context, selected.theme.id);
+            if (!deleted) {
+                void showTimedWarningMessage(`Could not find imported theme "${selected.theme.name}" to delete.`);
+                return;
+            }
+
+            const currentTheme = getThemeSettings();
+            const deletingActiveTheme = normalizeThemeId(currentTheme.id) === normalizeThemeId(selected.theme.id);
+            const collidesWithBuiltIn = isBuiltInThemeId(selected.theme.id);
+            if (deletingActiveTheme && !collidesWithBuiltIn) {
+                const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+                await config.update("theme", serializeThemeSettings(themePresets[0] as ThemeSettings), vscode.ConfigurationTarget.Global);
+                provider.notifyThemeChanged();
+                void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}. Active theme reset to ${themePresets[0].name}.`);
+                return;
+            }
+
+            void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}`);
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.toggleMode", async () => {
+            await provider.toggleActiveEditorMode();
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.exportHtml", async () => {
+            await provider.exportActiveDocument("html");
+        }),
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("markdownEditorOptimized.exportPdf", async () => {
+            await provider.exportActiveDocument("pdf");
+        }),
+    );
 }
 
 class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
-  private readonly activePanels = new Set<vscode.WebviewPanel>();
-  private readonly panelSessions = new Map<vscode.WebviewPanel, PanelSession>();
-  private lastActivePanel: vscode.WebviewPanel | null = null;
+    private readonly activePanels = new Set<vscode.WebviewPanel>();
+    private readonly panelSessions = new Map<vscode.WebviewPanel, PanelSession>();
+    private lastActivePanel: vscode.WebviewPanel | null = null;
 
-  constructor(
-    private readonly context: vscode.ExtensionContext,
-    private readonly agentReviewHandoff: AgentReviewHandoffController
-  ) {}
+    constructor(
+        private readonly context: vscode.ExtensionContext,
+        private readonly agentReviewHandoff: AgentReviewHandoffController,
+    ) {}
 
-  async initializeGitWatcher(): Promise<void> {
-    const watcher = await createGitApiWatcher((repoRootFsPath) => {
-      for (const session of this.panelSessions.values()) {
-        if (session.getGitRepoRoot() !== repoRootFsPath) {
-          continue;
+    async initializeGitWatcher(): Promise<void> {
+        const watcher = await createGitApiWatcher((repoRootFsPath) => {
+            for (const session of this.panelSessions.values()) {
+                if (session.getGitRepoRoot() !== repoRootFsPath) {
+                    continue;
+                }
+                session.refreshGitBaseline({ forceReload: true });
+            }
+        });
+        if (watcher) {
+            this.context.subscriptions.push(watcher);
         }
-        session.refreshGitBaseline({ forceReload: true });
-      }
-    });
-    if (watcher) {
-      this.context.subscriptions.push(watcher);
-    }
-  }
-
-  async exportActiveDocument(format: ExportFormat): Promise<void> {
-    const session = this.getActiveSession();
-    if (!session) {
-      void showTimedWarningMessage('Open a Markdown file in Markdown Editor Optimized before exporting.');
-      return;
     }
 
-    await this.exportSessionDocument(session, format);
-  }
-
-  async redirectOpenEditorsForCopilotReview(triggerUri: vscode.Uri): Promise<void> {
-    const reviewState = resolveAgentReviewRedirectState(
-      triggerUri,
-      getComparableResourceKey,
-      getOpenTextDocumentForUri
-    );
-    if (!reviewState) {
-      return;
-    }
-
-    const reviewKey = getComparableResourceKey(reviewState.uri);
-    if (!reviewKey) {
-      return;
-    }
-
-    for (const session of Array.from(this.panelSessions.values())) {
-      if (getComparableResourceKey(session.documentUri) !== reviewKey) {
-        continue;
-      }
-
-      if (this.agentReviewHandoff.hasRecentTextDiffActivityForUri(session.documentUri)) {
-        continue;
-      }
-
-      if (this.agentReviewHandoff.hasOpenTextDiffTabForUri(session.documentUri)) {
-        continue;
-      }
-
-      if (areAgentReviewTextsEquivalent(reviewState.text, session.document.getText())) {
-        continue;
-      }
-
-      this.agentReviewHandoff.scheduleDeferredReopen(session.documentUri);
-      await this.redirectCopilotReviewToNativeEditor(session.document, session.panel);
-    }
-  }
-
-  async handleConfigurationChanged(event: vscode.ConfigurationChangeEvent): Promise<void> {
-    if (
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_SETTING_KEY}`) ||
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_SETTING_KEY}`) ||
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY}`)
-    ) {
-      this.broadcast({ type: 'lineNumbersChanged', enabled: getLineNumbersEnabled(this.context) });
-    }
-
-    if (
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_SETTING_KEY}`) ||
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY}`) ||
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY}`) ||
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY}`)
-    ) {
-      this.broadcast({ type: 'gitChangesGutterChanged', enabled: getGitChangesGutterEnabled(this.context) });
-    }
-
-    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY}`)) {
-      this.broadcast({ type: 'gitDiffLineHighlightsChanged', enabled: getGitDiffLineHighlightsEnabled() });
-    }
-
-    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_SETTING_KEY}`)) {
-      this.broadcast({ type: 'vimModeChanged', enabled: getVimModeEnabled(this.context) });
-    }
-
-    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.outline.position`)) {
-      this.broadcast({ type: 'outlinePositionChanged', position: getOutlinePosition() });
-    }
-
-    if (
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`)
-    ) {
-      this.broadcast({ type: 'themeChanged', theme: getThemeSettings() });
-    }
-  }
-
-  notifyThemeChanged(): void {
-    this.broadcast({ type: 'themeChanged', theme: getThemeSettings() });
-  }
-
-  async toggleActiveEditorMode(): Promise<void> {
-    const session = this.getActiveSession();
-    if (!session) {
-      return;
-    }
-
-    this.lastActivePanel = session.panel;
-    await session.ensureInitDelivered();
-    await session.panel.webview.postMessage({ type: 'toggleMode' });
-  }
-
-  async resolveCustomTextEditor(
-    document: vscode.TextDocument,
-    panel: vscode.WebviewPanel,
-    _token: vscode.CancellationToken
-  ): Promise<void> {
-    const pendingReview = findLikelyAgentReviewState(
-      document.uri,
-      getComparableResourceKey,
-      getOpenTextDocumentForUri,
-      document.getText()
-    );
-    if (pendingReview) {
-      this.agentReviewHandoff.scheduleDeferredReopen(document.uri);
-      await this.redirectCopilotReviewToNativeEditor(document, panel, true);
-      return;
-    }
-
-    if (await this.redirectGitResourceToNativeEditor(document, panel)) {
-      return;
-    }
-
-    this.activePanels.add(panel);
-
-    const documentUri = resolveWorktreeUri(document);
-    const distRoot = vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist');
-    panel.webview.options = {
-      enableScripts: true,
-      localResourceRoots: collectLocalResourceRoots(distRoot, documentUri)
-    };
-
-    const controller = createPanelSessionController({
-      panel,
-      document,
-      documentUri,
-      context: this.context,
-      agentReviewHandoff: this.agentReviewHandoff,
-      onExportDocument: (session, format) => this.exportSessionDocument(session, format),
-      getFindOptions: () => this.getFindOptions(),
-      setFindOptions: (options) => this.setFindOptions(options),
-      setOutlineVisible: (visible) => this.setOutlineVisible(visible),
-      onPanelActivated: (activePanel) => {
-        this.lastActivePanel = activePanel;
-      },
-      onPanelViewStateChanged: () => {
-        this.updateActiveEditorContext();
-      },
-      onPanelDisposed: (disposedPanel) => {
-        this.activePanels.delete(disposedPanel);
-        this.panelSessions.delete(disposedPanel);
-        if (this.lastActivePanel === disposedPanel) {
-          this.lastActivePanel = null;
+    async exportActiveDocument(format: ExportFormat): Promise<void> {
+        const session = this.getActiveSession();
+        if (!session) {
+            void showTimedWarningMessage("Open a Markdown file in Markdown Editor Optimized before exporting.");
+            return;
         }
-        this.updateActiveEditorContext();
-      }
-    });
 
-    panel.webview.html = this.getWebviewHtml(panel.webview);
-    this.panelSessions.set(panel, controller.session);
-    if (panel.active) {
-      this.lastActivePanel = panel;
-    }
-    this.updateActiveEditorContext();
-  }
-
-  private broadcast(message: Record<string, unknown>): void {
-    for (const panel of this.activePanels) {
-      void panel.webview.postMessage(message);
-    }
-  }
-
-  private getFindOptions(): FindOptionsState {
-    const stored = this.context.globalState.get<Partial<FindOptionsState> | undefined>(FIND_OPTIONS_STATE_KEY);
-    return {
-      wholeWord: stored?.wholeWord === true,
-      caseSensitive: stored?.caseSensitive === true
-    };
-  }
-
-  private async setFindOptions(options: FindOptionsState): Promise<void> {
-    const nextOptions: FindOptionsState = {
-      wholeWord: options.wholeWord === true,
-      caseSensitive: options.caseSensitive === true
-    };
-    const currentOptions = this.getFindOptions();
-    if (
-      currentOptions.wholeWord === nextOptions.wholeWord &&
-      currentOptions.caseSensitive === nextOptions.caseSensitive
-    ) {
-      return;
+        await this.exportSessionDocument(session, format);
     }
 
-    await this.context.globalState.update(FIND_OPTIONS_STATE_KEY, nextOptions);
-    this.broadcast({ type: 'findOptionsChanged', findOptions: nextOptions });
-  }
+    async redirectOpenEditorsForCopilotReview(triggerUri: vscode.Uri): Promise<void> {
+        const reviewState = resolveAgentReviewRedirectState(triggerUri, getComparableResourceKey, getOpenTextDocumentForUri);
+        if (!reviewState) {
+            return;
+        }
 
-  private async setOutlineVisible(visible: boolean): Promise<void> {
-    const nextVisible = visible === true;
-    if (getOutlineVisible(this.context) === nextVisible) {
-      return;
-    }
+        const reviewKey = getComparableResourceKey(reviewState.uri);
+        if (!reviewKey) {
+            return;
+        }
 
-    await this.context.globalState.update(OUTLINE_VISIBLE_KEY, nextVisible);
-    this.broadcast({ type: 'outlineVisibilityChanged', visible: nextVisible });
-  }
-
-  private updateActiveEditorContext(): void {
-    const hasActiveMEOEditor = Array.from(this.panelSessions.keys()).some((panel) => panel.active);
-    void vscode.commands.executeCommand('setContext', ACTIVE_EDITOR_CONTEXT_KEY, hasActiveMEOEditor);
-  }
-
-  private getActiveSession(): PanelSession | null {
-    if (this.lastActivePanel && this.panelSessions.has(this.lastActivePanel)) {
-      return this.panelSessions.get(this.lastActivePanel) ?? null;
-    }
-
-    for (const panel of this.activePanels) {
-      if (panel.active && this.panelSessions.has(panel)) {
-        this.lastActivePanel = panel;
-        return this.panelSessions.get(panel) ?? null;
-      }
-    }
-
-    const first = this.panelSessions.values().next();
-    return first.done ? null : first.value;
-  }
-
-  private async exportSessionDocument(session: PanelSession, format: ExportFormat): Promise<void> {
-    this.lastActivePanel = session.panel;
-
-    if (session.documentUri.scheme !== 'file') {
-      void showTimedWarningMessage('Export is only supported for local Markdown files in the current version.');
-      return;
-    }
-
-    const saveUri = await this.promptExportTargetUri(session.documentUri, format);
-    if (!saveUri) {
-      return;
-    }
-
-    try {
-      await runWithTimedUiTimeout(() =>
-        vscode.window.withProgress(
-          {
-            location: vscode.ProgressLocation.Notification,
-            cancellable: false,
-            title: format === 'html' ? 'Exporting Markdown to HTML' : 'Exporting Markdown to PDF'
-          },
-          async (progress) => {
-            progress.report({ message: 'Collecting editor content…' });
-            const snapshot = await session.requestExportSnapshot();
-
-            progress.report({ message: 'Rendering export document…' });
-            const exportRuntime = await loadExportRuntimeModule(this.context.extensionUri);
-            const exportRender = await this.buildExportHtmlDocument(exportRuntime, {
-              markdownText: snapshot.text,
-              sourceDocumentUri: session.documentUri,
-              outputFileUri: saveUri,
-              target: format,
-              htmlImageMode: getExportHtmlImageMode(),
-              styleEnvironment: snapshot.environment
-            });
-
-            const browserExecutablePath = getExportPdfBrowserPath();
-            const puppeteerRuntimeModulePath = vscode.Uri.joinPath(
-              this.context.extensionUri,
-              'dist',
-              'puppeteer-runtime.js'
-            ).fsPath;
-            progress.report({ message: format === 'html' ? 'Finalizing HTML…' : 'Rendering PDF in headless browser…' });
-
-            if (format === 'html') {
-              await exportRuntime.writeFinalizedHtmlExport({
-                htmlDocument: exportRender.htmlDocument,
-                outputHtmlPath: saveUri.fsPath,
-                browserExecutablePath,
-                puppeteerRuntimeModulePath,
-                skipHeadlessFinalize: !exportRender.hasMermaid
-              });
-              return;
+        for (const session of Array.from(this.panelSessions.values())) {
+            if (getComparableResourceKey(session.documentUri) !== reviewKey) {
+                continue;
             }
 
-            await exportRuntime.renderPdfFromHtmlExport({
-              htmlDocument: exportRender.htmlDocument,
-              outputPdfPath: saveUri.fsPath,
-              browserExecutablePath,
-              puppeteerRuntimeModulePath
-            });
-          }
-        )
-      );
+            if (this.agentReviewHandoff.hasRecentTextDiffActivityForUri(session.documentUri)) {
+                continue;
+            }
 
-      void vscode.window.setStatusBarMessage(
-        `${format.toUpperCase()} export completed: ${saveUri.fsPath}`,
-        5000
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Export failed';
-      void showTimedErrorMessage(`${format.toUpperCase()} export failed: ${message}`);
-    }
-  }
+            if (this.agentReviewHandoff.hasOpenTextDiffTabForUri(session.documentUri)) {
+                continue;
+            }
 
-  private async promptExportTargetUri(documentUri: vscode.Uri, format: ExportFormat): Promise<vscode.Uri | undefined> {
-    const defaultUri = vscode.Uri.file(replaceFileExtension(documentUri.fsPath, format === 'html' ? '.html' : '.pdf'));
-    return vscode.window.showSaveDialog({
-      defaultUri,
-      filters: format === 'html'
-        ? { HTML: ['html', 'htm'] }
-        : { PDF: ['pdf'] },
-      saveLabel: format === 'html' ? 'Export HTML' : 'Export PDF'
-    });
-  }
+            if (areAgentReviewTextsEquivalent(reviewState.text, session.document.getText())) {
+                continue;
+            }
 
-  private async buildExportHtmlDocument(
-    exportRuntime: ExportRuntimeModule,
-    params: {
-      markdownText: string;
-      sourceDocumentUri: vscode.Uri;
-      outputFileUri: vscode.Uri;
-      target: ExportFormat;
-      htmlImageMode: ExportHtmlImageMode;
-      styleEnvironment?: ExportStyleEnvironment;
-    }
-  ): Promise<{ htmlDocument: string; hasMermaid: boolean; hasMath: boolean }> {
-    const mermaidRuntimeSrc = pathToFileURL(
-      vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'mermaid.min.js').fsPath
-    ).toString();
-    const katexStylesHref = pathToFileURL(
-      vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'katex', 'katex.min.css').fsPath
-    ).toString();
-    const baseHref = pathToFileURL(`${path.dirname(params.outputFileUri.fsPath)}${path.sep}`).toString();
-    return exportRuntime.renderExportHtmlDocument({
-      markdownText: params.markdownText,
-      sourceDocumentPath: params.sourceDocumentUri.fsPath,
-      outputFilePath: params.outputFileUri.fsPath,
-      target: params.target,
-      htmlImageMode: params.htmlImageMode,
-      theme: getThemeSettings(),
-      styleEnvironment: params.styleEnvironment,
-      editorFontEnvironment: getExportEditorFontEnvironment(),
-      mermaidRuntimeSrc,
-      katexStylesHref,
-      baseHref,
-      title: path.basename(params.outputFileUri.fsPath)
-    });
-  }
-
-  private async redirectGitResourceToNativeEditor(
-    document: vscode.TextDocument,
-    panel: vscode.WebviewPanel
-  ): Promise<boolean> {
-    if (document.uri.scheme !== 'git') {
-      return false;
+            this.agentReviewHandoff.scheduleDeferredReopen(session.documentUri);
+            await this.redirectCopilotReviewToNativeEditor(session.document, session.panel);
+        }
     }
 
-    const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
-    const editorOptions = {
-      preserveFocus: false,
-      preview: true,
-      override: 'default'
-    };
-    const existingDiff = findDiffContextForGitUri(document.uri);
+    async handleConfigurationChanged(event: vscode.ConfigurationChangeEvent): Promise<void> {
+        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY}`)) {
+            this.broadcast({ type: "lineNumbersChanged", enabled: getLineNumbersEnabled(this.context) });
+        }
 
-    if (existingDiff) {
-      await vscode.commands.executeCommand(
-        '_workbench.diff',
-        existingDiff.original,
-        existingDiff.modified,
-        existingDiff.title,
-        [viewColumn, editorOptions]
-      );
-      panel.dispose();
-      return true;
+        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY}`)) {
+            this.broadcast({ type: "gitChangesGutterChanged", enabled: getGitChangesGutterEnabled(this.context) });
+        }
+
+        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY}`)) {
+            this.broadcast({ type: "gitDiffLineHighlightsChanged", enabled: getGitDiffLineHighlightsEnabled() });
+        }
+
+        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_SETTING_KEY}`) || event.affectsConfiguration("vim.enable")) {
+            this.broadcast({ type: "vimModeChanged", enabled: getVimModeEnabled(this.context) });
+        }
+
+        if (event.affectsConfiguration("vim.normalModeKeyBindings") || event.affectsConfiguration("vim.normalModeKeyBindingsNonRecursive") || event.affectsConfiguration("vim.insertModeKeyBindings") || event.affectsConfiguration("vim.insertModeKeyBindingsNonRecursive") || event.affectsConfiguration("vim.visualModeKeyBindings") || event.affectsConfiguration("vim.visualModeKeyBindingsNonRecursive") || event.affectsConfiguration("vim.leader")) {
+            this.broadcast({ type: "vimKeybindingsChanged", keybindings: getVimKeybindings(), leaderKey: getVimLeaderKey() });
+        }
+
+        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.outline.position`)) {
+            this.broadcast({ type: "outlinePositionChanged", position: getOutlinePosition() });
+        }
+
+        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`)) {
+            this.broadcast({ type: "themeChanged", theme: getThemeSettings() });
+        }
     }
 
-    const ref = getGitUriRef(document.uri);
-    if (isWorkingTreeOrIndexRef(ref)) {
-      const targetUri = resolveWorktreeUri(document);
-      const title = getNativeWorkingTreeTitle(document.uri, targetUri);
-
-      await vscode.commands.executeCommand(
-        '_workbench.diff',
-        document.uri,
-        targetUri,
-        title,
-        [viewColumn, editorOptions]
-      );
-      panel.dispose();
-      return true;
+    notifyThemeChanged(): void {
+        this.broadcast({ type: "themeChanged", theme: getThemeSettings() });
     }
 
-    return false;
-  }
+    async toggleActiveEditorMode(): Promise<void> {
+        const session = this.getActiveSession();
+        if (!session) {
+            return;
+        }
 
-  private async redirectCopilotReviewToNativeEditor(
-    document: vscode.TextDocument,
-    panel: vscode.WebviewPanel,
-    preserveFocus = false
-  ): Promise<void> {
-    const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
-    await vscode.commands.executeCommand(
-      'vscode.openWith',
-      document.uri,
-      'default',
-      {
-        viewColumn,
-        preserveFocus,
-        preview: true
-      }
-    );
-    panel.dispose();
-  }
+        this.lastActivePanel = session.panel;
+        await session.ensureInitDelivered();
+        await session.panel.webview.postMessage({ type: "toggleMode" });
+    }
 
-  private getWebviewHtml(webview: vscode.Webview): string {
-    const scriptUri = webview
-      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'index.js'))
-      .toString();
-    const styleUri = webview
-      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'index.css'))
-      .toString();
-    const katexStyleUri = webview
-      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'katex', 'katex.min.css'))
-      .toString();
-    const mermaidRuntimeUri = webview
-      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'mermaid.min.js'))
-      .toString();
-    const nonce = getNonce();
-    const csp = [
-      "default-src 'none'",
-      `img-src ${webview.cspSource} https:`,
-      `font-src ${webview.cspSource}`,
-      `style-src ${webview.cspSource} 'unsafe-inline'`,
-      `script-src ${webview.cspSource} 'nonce-${nonce}'`
-    ].join('; ');
+    async resolveCustomTextEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel, _token: vscode.CancellationToken): Promise<void> {
+        const pendingReview = findLikelyAgentReviewState(document.uri, getComparableResourceKey, getOpenTextDocumentForUri, document.getText());
+        if (pendingReview) {
+            this.agentReviewHandoff.scheduleDeferredReopen(document.uri);
+            await this.redirectCopilotReviewToNativeEditor(document, panel, true);
+            return;
+        }
 
-    return `<!DOCTYPE html>
+        if (await this.redirectGitResourceToNativeEditor(document, panel)) {
+            return;
+        }
+
+        this.activePanels.add(panel);
+
+        const documentUri = resolveWorktreeUri(document);
+        const distRoot = vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist");
+        panel.webview.options = {
+            enableScripts: true,
+            localResourceRoots: collectLocalResourceRoots(distRoot, documentUri),
+        };
+
+        const controller = createPanelSessionController({
+            panel,
+            document,
+            documentUri,
+            context: this.context,
+            agentReviewHandoff: this.agentReviewHandoff,
+            onExportDocument: (session, format) => this.exportSessionDocument(session, format),
+            getFindOptions: () => this.getFindOptions(),
+            setFindOptions: (options) => this.setFindOptions(options),
+            setOutlineVisible: (visible) => this.setOutlineVisible(visible),
+            onPanelActivated: (activePanel) => {
+                this.lastActivePanel = activePanel;
+            },
+            onPanelViewStateChanged: () => {
+                this.updateActiveEditorContext();
+            },
+            onPanelDisposed: (disposedPanel) => {
+                this.activePanels.delete(disposedPanel);
+                this.panelSessions.delete(disposedPanel);
+                if (this.lastActivePanel === disposedPanel) {
+                    this.lastActivePanel = null;
+                }
+                this.updateActiveEditorContext();
+            },
+        });
+
+        panel.webview.html = this.getWebviewHtml(panel.webview);
+        this.panelSessions.set(panel, controller.session);
+        if (panel.active) {
+            this.lastActivePanel = panel;
+        }
+        this.updateActiveEditorContext();
+    }
+
+    private broadcast(message: Record<string, unknown>): void {
+        for (const panel of this.activePanels) {
+            void panel.webview.postMessage(message);
+        }
+    }
+
+    private getFindOptions(): FindOptionsState {
+        const stored = this.context.globalState.get<Partial<FindOptionsState> | undefined>(FIND_OPTIONS_STATE_KEY);
+        return {
+            wholeWord: stored?.wholeWord === true,
+            caseSensitive: stored?.caseSensitive === true,
+        };
+    }
+
+    private async setFindOptions(options: FindOptionsState): Promise<void> {
+        const nextOptions: FindOptionsState = {
+            wholeWord: options.wholeWord === true,
+            caseSensitive: options.caseSensitive === true,
+        };
+        const currentOptions = this.getFindOptions();
+        if (currentOptions.wholeWord === nextOptions.wholeWord && currentOptions.caseSensitive === nextOptions.caseSensitive) {
+            return;
+        }
+
+        await this.context.globalState.update(FIND_OPTIONS_STATE_KEY, nextOptions);
+        this.broadcast({ type: "findOptionsChanged", findOptions: nextOptions });
+    }
+
+    private async setOutlineVisible(visible: boolean): Promise<void> {
+        const nextVisible = visible === true;
+        if (getOutlineVisible(this.context) === nextVisible) {
+            return;
+        }
+
+        await this.context.globalState.update(OUTLINE_VISIBLE_KEY, nextVisible);
+        this.broadcast({ type: "outlineVisibilityChanged", visible: nextVisible });
+    }
+
+    private updateActiveEditorContext(): void {
+        const hasActiveMEOEditor = Array.from(this.panelSessions.keys()).some((panel) => panel.active);
+        void vscode.commands.executeCommand("setContext", ACTIVE_EDITOR_CONTEXT_KEY, hasActiveMEOEditor);
+    }
+
+    private getActiveSession(): PanelSession | null {
+        if (this.lastActivePanel && this.panelSessions.has(this.lastActivePanel)) {
+            return this.panelSessions.get(this.lastActivePanel) ?? null;
+        }
+
+        for (const panel of this.activePanels) {
+            if (panel.active && this.panelSessions.has(panel)) {
+                this.lastActivePanel = panel;
+                return this.panelSessions.get(panel) ?? null;
+            }
+        }
+
+        const first = this.panelSessions.values().next();
+        return first.done ? null : first.value;
+    }
+
+    private async exportSessionDocument(session: PanelSession, format: ExportFormat): Promise<void> {
+        this.lastActivePanel = session.panel;
+
+        if (session.documentUri.scheme !== "file") {
+            void showTimedWarningMessage("Export is only supported for local Markdown files in the current version.");
+            return;
+        }
+
+        const saveUri = await this.promptExportTargetUri(session.documentUri, format);
+        if (!saveUri) {
+            return;
+        }
+
+        try {
+            await runWithTimedUiTimeout(() =>
+                vscode.window.withProgress(
+                    {
+                        location: vscode.ProgressLocation.Notification,
+                        cancellable: false,
+                        title: format === "html" ? "Exporting Markdown to HTML" : "Exporting Markdown to PDF",
+                    },
+                    async (progress) => {
+                        progress.report({ message: "Collecting editor content…" });
+                        const snapshot = await session.requestExportSnapshot();
+
+                        progress.report({ message: "Rendering export document…" });
+                        const exportRuntime = await loadExportRuntimeModule(this.context.extensionUri);
+                        const exportRender = await this.buildExportHtmlDocument(exportRuntime, {
+                            markdownText: snapshot.text,
+                            sourceDocumentUri: session.documentUri,
+                            outputFileUri: saveUri,
+                            target: format,
+                            htmlImageMode: getExportHtmlImageMode(),
+                            styleEnvironment: snapshot.environment,
+                        });
+
+                        const browserExecutablePath = getExportPdfBrowserPath();
+                        const puppeteerRuntimeModulePath = vscode.Uri.joinPath(this.context.extensionUri, "dist", "puppeteer-runtime.js").fsPath;
+                        progress.report({ message: format === "html" ? "Finalizing HTML…" : "Rendering PDF in headless browser…" });
+
+                        if (format === "html") {
+                            await exportRuntime.writeFinalizedHtmlExport({
+                                htmlDocument: exportRender.htmlDocument,
+                                outputHtmlPath: saveUri.fsPath,
+                                browserExecutablePath,
+                                puppeteerRuntimeModulePath,
+                                skipHeadlessFinalize: !exportRender.hasMermaid,
+                            });
+                            return;
+                        }
+
+                        await exportRuntime.renderPdfFromHtmlExport({
+                            htmlDocument: exportRender.htmlDocument,
+                            outputPdfPath: saveUri.fsPath,
+                            browserExecutablePath,
+                            puppeteerRuntimeModulePath,
+                        });
+                    },
+                ),
+            );
+
+            void vscode.window.setStatusBarMessage(`${format.toUpperCase()} export completed: ${saveUri.fsPath}`, 5000);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Export failed";
+            void showTimedErrorMessage(`${format.toUpperCase()} export failed: ${message}`);
+        }
+    }
+
+    private async promptExportTargetUri(documentUri: vscode.Uri, format: ExportFormat): Promise<vscode.Uri | undefined> {
+        const defaultUri = vscode.Uri.file(replaceFileExtension(documentUri.fsPath, format === "html" ? ".html" : ".pdf"));
+        return vscode.window.showSaveDialog({
+            defaultUri,
+            filters: format === "html" ? { HTML: ["html", "htm"] } : { PDF: ["pdf"] },
+            saveLabel: format === "html" ? "Export HTML" : "Export PDF",
+        });
+    }
+
+    private async buildExportHtmlDocument(
+        exportRuntime: ExportRuntimeModule,
+        params: {
+            markdownText: string;
+            sourceDocumentUri: vscode.Uri;
+            outputFileUri: vscode.Uri;
+            target: ExportFormat;
+            htmlImageMode: ExportHtmlImageMode;
+            styleEnvironment?: ExportStyleEnvironment;
+        },
+    ): Promise<{ htmlDocument: string; hasMermaid: boolean; hasMath: boolean }> {
+        const mermaidRuntimeSrc = pathToFileURL(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "mermaid.min.js").fsPath).toString();
+        const katexStylesHref = pathToFileURL(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "katex", "katex.min.css").fsPath).toString();
+        const baseHref = pathToFileURL(`${path.dirname(params.outputFileUri.fsPath)}${path.sep}`).toString();
+        return exportRuntime.renderExportHtmlDocument({
+            markdownText: params.markdownText,
+            sourceDocumentPath: params.sourceDocumentUri.fsPath,
+            outputFilePath: params.outputFileUri.fsPath,
+            target: params.target,
+            htmlImageMode: params.htmlImageMode,
+            theme: getThemeSettings(),
+            styleEnvironment: params.styleEnvironment,
+            editorFontEnvironment: getExportEditorFontEnvironment(),
+            mermaidRuntimeSrc,
+            katexStylesHref,
+            baseHref,
+            title: path.basename(params.outputFileUri.fsPath),
+        });
+    }
+
+    private async redirectGitResourceToNativeEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel): Promise<boolean> {
+        if (document.uri.scheme !== "git") {
+            return false;
+        }
+
+        const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
+        const editorOptions = {
+            preserveFocus: false,
+            preview: true,
+            override: "default",
+        };
+        const existingDiff = findDiffContextForGitUri(document.uri);
+
+        if (existingDiff) {
+            await vscode.commands.executeCommand("_workbench.diff", existingDiff.original, existingDiff.modified, existingDiff.title, [viewColumn, editorOptions]);
+            panel.dispose();
+            return true;
+        }
+
+        const ref = getGitUriRef(document.uri);
+        if (isWorkingTreeOrIndexRef(ref)) {
+            const targetUri = resolveWorktreeUri(document);
+            const title = getNativeWorkingTreeTitle(document.uri, targetUri);
+
+            await vscode.commands.executeCommand("_workbench.diff", document.uri, targetUri, title, [viewColumn, editorOptions]);
+            panel.dispose();
+            return true;
+        }
+
+        return false;
+    }
+
+    private async redirectCopilotReviewToNativeEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel, preserveFocus = false): Promise<void> {
+        const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
+        await vscode.commands.executeCommand("vscode.openWith", document.uri, "default", {
+            viewColumn,
+            preserveFocus,
+            preview: true,
+        });
+        panel.dispose();
+    }
+
+    private getWebviewHtml(webview: vscode.Webview): string {
+        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "index.js")).toString();
+        const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "index.css")).toString();
+        const katexStyleUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "katex", "katex.min.css")).toString();
+        const mermaidRuntimeUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "mermaid.min.js")).toString();
+        const nonce = getNonce();
+        const csp = ["default-src 'none'", `img-src ${webview.cspSource} https:`, `font-src ${webview.cspSource}`, `style-src ${webview.cspSource} 'unsafe-inline'`, `script-src ${webview.cspSource} 'nonce-${nonce}'`].join("; ");
+
+        return `<!DOCTYPE html>
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -912,20 +752,20 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
         <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
       </body>
     </html>`;
-  }
+    }
 }
 
 function getNonce(): string {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let nonce = '';
-  for (let i = 0; i < 32; i += 1) {
-    nonce += chars[Math.floor(Math.random() * chars.length)];
-  }
-  return nonce;
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    let nonce = "";
+    for (let i = 0; i < 32; i += 1) {
+        nonce += chars[Math.floor(Math.random() * chars.length)];
+    }
+    return nonce;
 }
 
 function getWebviewPreloadShellCss(): string {
-  return `
+    return `
       html, body {
         margin: 0;
         padding: 0;
@@ -959,7 +799,7 @@ function getWebviewPreloadShellCss(): string {
 }
 
 function getWebviewPreloadShellMarkup(): string {
-  return `
+    return `
           <div class="mode-toolbar meo-preload-toolbar" role="presentation" aria-hidden="true"></div>
           <div class="editor-wrapper meo-preload-editor-shell" role="presentation" aria-hidden="true">
             <div class="editor-host"></div>
@@ -968,198 +808,192 @@ function getWebviewPreloadShellMarkup(): string {
 }
 
 async function loadExportRuntimeModule(extensionUri: vscode.Uri): Promise<ExportRuntimeModule> {
-  if (!exportRuntimeModulePromise) {
-    const runtimePath = vscode.Uri.joinPath(extensionUri, 'dist', 'export-runtime.js').fsPath;
-    const runtimeUrl = pathToFileURL(runtimePath).toString();
-    exportRuntimeModulePromise = import(runtimeUrl)
-      .then((mod: unknown) => unwrapExportRuntimeModule(mod))
-      .catch((error) => {
-        exportRuntimeModulePromise = null;
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to load export runtime (${runtimePath}). Run the extension build to regenerate it. ${message}`);
-      });
-  }
+    if (!exportRuntimeModulePromise) {
+        const runtimePath = vscode.Uri.joinPath(extensionUri, "dist", "export-runtime.js").fsPath;
+        const runtimeUrl = pathToFileURL(runtimePath).toString();
+        exportRuntimeModulePromise = import(runtimeUrl)
+            .then((mod: unknown) => unwrapExportRuntimeModule(mod))
+            .catch((error) => {
+                exportRuntimeModulePromise = null;
+                const message = error instanceof Error ? error.message : String(error);
+                throw new Error(`Failed to load export runtime (${runtimePath}). Run the extension build to regenerate it. ${message}`);
+            });
+    }
 
-  return exportRuntimeModulePromise;
+    return exportRuntimeModulePromise;
 }
 
 function unwrapExportRuntimeModule(mod: unknown): ExportRuntimeModule {
-  let current: unknown = mod;
-  for (let i = 0; i < 5; i += 1) {
-    const candidate = current as Partial<ExportRuntimeModule> | undefined;
-    if (
-      candidate &&
-      typeof candidate.renderExportHtmlDocument === 'function' &&
-      typeof candidate.writeFinalizedHtmlExport === 'function' &&
-      typeof candidate.renderPdfFromHtmlExport === 'function'
-    ) {
-      return candidate as ExportRuntimeModule;
+    let current: unknown = mod;
+    for (let i = 0; i < 5; i += 1) {
+        const candidate = current as Partial<ExportRuntimeModule> | undefined;
+        if (candidate && typeof candidate.renderExportHtmlDocument === "function" && typeof candidate.writeFinalizedHtmlExport === "function" && typeof candidate.renderPdfFromHtmlExport === "function") {
+            return candidate as ExportRuntimeModule;
+        }
+
+        if (!current || typeof current !== "object" || !("default" in current)) {
+            break;
+        }
+        current = (current as { default?: unknown }).default;
     }
 
-    if (!current || typeof current !== 'object' || !('default' in current)) {
-      break;
-    }
-    current = (current as { default?: unknown }).default;
-  }
-
-  throw new Error('Loaded export runtime does not expose the expected export functions.');
+    throw new Error("Loaded export runtime does not expose the expected export functions.");
 }
 
 function collectLocalResourceRoots(distRoot: vscode.Uri, documentUri: vscode.Uri): vscode.Uri[] {
-  const roots = new Map<string, vscode.Uri>();
-  roots.set(distRoot.toString(), distRoot);
+    const roots = new Map<string, vscode.Uri>();
+    roots.set(distRoot.toString(), distRoot);
 
-  const documentDir = vscode.Uri.file(path.dirname(documentUri.fsPath));
-  roots.set(documentDir.toString(), documentDir);
+    const documentDir = vscode.Uri.file(path.dirname(documentUri.fsPath));
+    roots.set(documentDir.toString(), documentDir);
 
-  for (const folder of vscode.workspace.workspaceFolders ?? []) {
-    roots.set(folder.uri.toString(), folder.uri);
-  }
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+        roots.set(folder.uri.toString(), folder.uri);
+    }
 
-  return Array.from(roots.values());
+    return Array.from(roots.values());
 }
 
-function replaceFileExtension(filePath: string, ext: '.html' | '.pdf'): string {
-  const parsed = path.parse(filePath);
-  return path.join(parsed.dir, `${parsed.name}${ext}`);
+function replaceFileExtension(filePath: string, ext: ".html" | ".pdf"): string {
+    const parsed = path.parse(filePath);
+    return path.join(parsed.dir, `${parsed.name}${ext}`);
 }
 
 function resolveWorktreeUri(document: vscode.TextDocument): vscode.Uri {
-  if (document.uri.scheme === 'file') {
-    return document.uri;
-  }
+    if (document.uri.scheme === "file") {
+        return document.uri;
+    }
 
-  return resolveWorktreeUriFromGitUri(document.uri) ?? document.uri;
+    return resolveWorktreeUriFromGitUri(document.uri) ?? document.uri;
 }
 
 function findDiffContextForGitUri(uri: vscode.Uri): { original: vscode.Uri; modified: vscode.Uri; title: string } | undefined {
-  const target = uri.toString();
+    const target = uri.toString();
 
-  for (const group of vscode.window.tabGroups.all) {
-    for (const tab of group.tabs) {
-      const input = tab.input;
-      if (!(input instanceof vscode.TabInputTextDiff)) {
-        continue;
-      }
+    for (const group of vscode.window.tabGroups.all) {
+        for (const tab of group.tabs) {
+            const input = tab.input;
+            if (!(input instanceof vscode.TabInputTextDiff)) {
+                continue;
+            }
 
-      const original = input.original;
-      const modified = input.modified;
-      if (original.toString() !== target && modified.toString() !== target) {
-        continue;
-      }
+            const original = input.original;
+            const modified = input.modified;
+            if (original.toString() !== target && modified.toString() !== target) {
+                continue;
+            }
 
-      return {
-        original,
-        modified,
-        title: tab.label
-      };
+            return {
+                original,
+                modified,
+                title: tab.label,
+            };
+        }
     }
-  }
 
-  return undefined;
+    return undefined;
 }
 
 function getGitUriRef(uri: vscode.Uri): string | undefined {
-  const query = parseGitUriQuery(uri.query);
-  return typeof query?.ref === 'string' ? query.ref : undefined;
+    const query = parseGitUriQuery(uri.query);
+    return typeof query?.ref === "string" ? query.ref : undefined;
 }
 
 function isWorkingTreeOrIndexRef(ref: string | undefined): boolean {
-  return ref === '~' || ref === 'HEAD' || ref === '';
+    return ref === "~" || ref === "HEAD" || ref === "";
 }
 
 function getNativeWorkingTreeTitle(gitUri: vscode.Uri, fileUri: vscode.Uri): string {
-  const fileName = vscode.workspace.asRelativePath(fileUri, false) || fileUri.path;
-  const ref = getGitUriRef(gitUri);
+    const fileName = vscode.workspace.asRelativePath(fileUri, false) || fileUri.path;
+    const ref = getGitUriRef(gitUri);
 
-  if (ref === '~') {
-    return `${fileName} (Working Tree)`;
-  }
+    if (ref === "~") {
+        return `${fileName} (Working Tree)`;
+    }
 
-  if (ref === 'HEAD' || ref === '') {
-    return `${fileName} (Index)`;
-  }
+    if (ref === "HEAD" || ref === "") {
+        return `${fileName} (Index)`;
+    }
 
-  return fileName;
+    return fileName;
 }
 
 function buildThemeQuickPickItems(context: vscode.ExtensionContext): ThemeQuickPickItem[] {
-  const builtInItems: ThemeQuickPickItem[] = themePresets.map((theme) => ({
-    label: theme.name,
-    description: theme.id,
-    detail: 'Built-in',
-    theme,
-    source: 'built-in'
-  }));
-  const importedItems: ThemeQuickPickItem[] = getImportedThemes(context).map((theme) => ({
-    label: theme.name,
-    description: theme.id,
-    detail: 'Imported',
-    theme,
-    source: 'imported'
-  }));
+    const builtInItems: ThemeQuickPickItem[] = themePresets.map((theme) => ({
+        label: theme.name,
+        description: theme.id,
+        detail: "Built-in",
+        theme,
+        source: "built-in",
+    }));
+    const importedItems: ThemeQuickPickItem[] = getImportedThemes(context).map((theme) => ({
+        label: theme.name,
+        description: theme.id,
+        detail: "Imported",
+        theme,
+        source: "imported",
+    }));
 
-  return [...builtInItems, ...importedItems];
+    return [...builtInItems, ...importedItems];
 }
 
 function getImportedThemes(context: vscode.ExtensionContext): ThemeSettings[] {
-  const raw = context.globalState.get<unknown>(CUSTOM_THEMES_STATE_KEY);
-  if (!Array.isArray(raw)) {
-    return [];
-  }
-
-  const themesById = new Map<string, ThemeSettings>();
-  for (const item of raw) {
-    const validated = validateThemePayload(item);
-    if (!validated.success) {
-      continue;
+    const raw = context.globalState.get<unknown>(CUSTOM_THEMES_STATE_KEY);
+    if (!Array.isArray(raw)) {
+        return [];
     }
-    themesById.set(normalizeThemeId(validated.theme.id), validated.theme);
-  }
 
-  return Array.from(themesById.values())
-    .sort((a, b) => a.name.localeCompare(b.name));
+    const themesById = new Map<string, ThemeSettings>();
+    for (const item of raw) {
+        const validated = validateThemePayload(item);
+        if (!validated.success) {
+            continue;
+        }
+        themesById.set(normalizeThemeId(validated.theme.id), validated.theme);
+    }
+
+    return Array.from(themesById.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 async function upsertImportedTheme(context: vscode.ExtensionContext, theme: ThemeSettings): Promise<void> {
-  const importedThemes = getImportedThemes(context);
-  const existingIndex = importedThemes.findIndex((item) => normalizeThemeId(item.id) === normalizeThemeId(theme.id));
-  if (existingIndex >= 0) {
-    importedThemes[existingIndex] = theme;
-  } else {
-    importedThemes.push(theme);
-  }
+    const importedThemes = getImportedThemes(context);
+    const existingIndex = importedThemes.findIndex((item) => normalizeThemeId(item.id) === normalizeThemeId(theme.id));
+    if (existingIndex >= 0) {
+        importedThemes[existingIndex] = theme;
+    } else {
+        importedThemes.push(theme);
+    }
 
-  importedThemes.sort((a, b) => a.name.localeCompare(b.name));
-  await context.globalState.update(
-    CUSTOM_THEMES_STATE_KEY,
-    importedThemes.map((item) => serializeThemeSettings(item))
-  );
+    importedThemes.sort((a, b) => a.name.localeCompare(b.name));
+    await context.globalState.update(
+        CUSTOM_THEMES_STATE_KEY,
+        importedThemes.map((item) => serializeThemeSettings(item)),
+    );
 }
 
 async function deleteImportedThemeById(context: vscode.ExtensionContext, themeId: string): Promise<boolean> {
-  const normalizedThemeId = normalizeThemeId(themeId);
-  const importedThemes = getImportedThemes(context);
-  const nextImportedThemes = importedThemes.filter((item) => normalizeThemeId(item.id) !== normalizedThemeId);
+    const normalizedThemeId = normalizeThemeId(themeId);
+    const importedThemes = getImportedThemes(context);
+    const nextImportedThemes = importedThemes.filter((item) => normalizeThemeId(item.id) !== normalizedThemeId);
 
-  if (nextImportedThemes.length === importedThemes.length) {
-    return false;
-  }
+    if (nextImportedThemes.length === importedThemes.length) {
+        return false;
+    }
 
-  await context.globalState.update(
-    CUSTOM_THEMES_STATE_KEY,
-    nextImportedThemes.map((item) => serializeThemeSettings(item))
-  );
-  return true;
+    await context.globalState.update(
+        CUSTOM_THEMES_STATE_KEY,
+        nextImportedThemes.map((item) => serializeThemeSettings(item)),
+    );
+    return true;
 }
 
 function isBuiltInThemeId(themeId: string): boolean {
-  const normalizedThemeId = normalizeThemeId(themeId);
-  return themePresets.some((item) => normalizeThemeId(item.id) === normalizedThemeId);
+    const normalizedThemeId = normalizeThemeId(themeId);
+    return themePresets.some((item) => normalizeThemeId(item.id) === normalizedThemeId);
 }
 
 function normalizeThemeId(id: string): string {
-  return id.trim().toLowerCase();
+    return id.trim().toLowerCase();
 }
 
 export function deactivate(): void {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,740 +1,919 @@
-import * as path from "node:path";
-import { pathToFileURL } from "node:url";
-import * as vscode from "vscode";
-import { createGitApiWatcher } from "./git/gitApiWatch";
-import { AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS, AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS, AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS, AgentReviewHandoffController } from "./agents/reviewHandoff";
-import { areAgentReviewTextsEquivalent, findLikelyAgentReviewState, getComparableFileUri, isLikelyAgentReviewUri, resolveAgentReviewRedirectState } from "./agents/reviewState";
-import { getComparableResourceKey, getOpenTextDocumentForComparableKey, getOpenTextDocumentForUri, getPreferredCommandUri, parseGitUriQuery, resolveWorktreeUriFromGitUri } from "./agents/resourceMatching";
-import { AgentReviewOverrideController } from "./agents/reviewOverrides";
-import { EXTENSION_CONFIG_SECTION, GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY, LINE_NUMBERS_LEGACY_SETTING_KEY, LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY, LINE_NUMBERS_SETTING_KEY, OUTLINE_VISIBLE_KEY, VIM_MODE_SETTING_KEY, syncEditorAssociations, type ExportHtmlImageMode, getExportHtmlImageMode, getExportEditorFontEnvironment, getExportPdfBrowserPath, getGitChangesGutterEnabled, getGitDiffLineHighlightsEnabled, getLineNumbersEnabled, getOutlinePosition, getOutlineVisible, getThemeSettings, getVimModeEnabled, getVimKeybindings, getVimLeaderKey, isMarkdownDocumentPath, migrateLegacyToggleSettings, resetThemeSettingsToDefault } from "./shared/extensionConfig";
-import { createPanelSessionController, type ExportFormat, type PanelSession } from "./extension/panelSession";
-import { serializeThemeSettings, themePresets, type ThemeSettings, validateThemePayload } from "./shared/themeDefaults";
-import { runWithTimedUiTimeout, showTimedErrorMessage, showTimedInformationMessage, showTimedQuickPick, showTimedWarningMessage, showTimedWarningMessageWithItems } from "./shared/timedUi";
-import type { ExportStyleEnvironment } from "./export/runtime";
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as vscode from 'vscode';
+import { createGitApiWatcher } from './git/gitApiWatch';
+import {
+  AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS,
+  AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS,
+  AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS,
+  AgentReviewHandoffController
+} from './agents/reviewHandoff';
+import {
+  areAgentReviewTextsEquivalent,
+  findLikelyAgentReviewState,
+  getComparableFileUri,
+  isLikelyAgentReviewUri,
+  resolveAgentReviewRedirectState
+} from './agents/reviewState';
+import {
+  getComparableResourceKey,
+  getOpenTextDocumentForComparableKey,
+  getOpenTextDocumentForUri,
+  getPreferredCommandUri,
+  parseGitUriQuery,
+  resolveWorktreeUriFromGitUri
+} from './agents/resourceMatching';
+import { AgentReviewOverrideController } from './agents/reviewOverrides';
+import {
+  EXTENSION_CONFIG_SECTION,
+  GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY,
+  GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY,
+  GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY,
+  GIT_CHANGES_GUTTER_SETTING_KEY,
+  GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY,
+  LINE_NUMBERS_LEGACY_SETTING_KEY,
+  LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY,
+  LINE_NUMBERS_SETTING_KEY,
+  OUTLINE_VISIBLE_KEY,
+  VIM_MODE_BEHAVIOR_SETTING_KEY,
+  VIM_MODE_SETTING_KEY,
+  syncEditorAssociations,
+  type ExportHtmlImageMode,
+  getExportHtmlImageMode,
+  getExportEditorFontEnvironment,
+  getExportPdfBrowserPath,
+  getGitChangesGutterEnabled,
+  getGitDiffLineHighlightsEnabled,
+  getLineNumbersEnabled,
+  getOutlinePosition,
+  getOutlineVisible,
+  getThemeSettings,
+  getVimKeybindings,
+  getVimLeaderKey,
+  getVimModeEnabled,
+  isMarkdownDocumentPath,
+  migrateLegacyToggleSettings,
+  resetThemeSettingsToDefault
+} from './shared/extensionConfig';
+import { createPanelSessionController, type ExportFormat, type PanelSession } from './extension/panelSession';
+import { serializeThemeSettings, themePresets, type ThemeSettings, validateThemePayload } from './shared/themeDefaults';
+import {
+  runWithTimedUiTimeout,
+  showTimedErrorMessage,
+  showTimedInformationMessage,
+  showTimedQuickPick,
+  showTimedWarningMessage,
+  showTimedWarningMessageWithItems
+} from './shared/timedUi';
+import type { ExportStyleEnvironment } from './export/runtime';
 
-const VIEW_TYPE = "markdownEditorOptimized.editor";
-const ACTIVE_EDITOR_CONTEXT_KEY = "markdownEditorOptimized.activeEditor";
-const FIND_OPTIONS_STATE_KEY = "findOptions";
-const CUSTOM_THEMES_STATE_KEY = "customThemes";
+const VIEW_TYPE = 'markdownEditorOptimized.editor';
+const ACTIVE_EDITOR_CONTEXT_KEY = 'markdownEditorOptimized.activeEditor';
+const FIND_OPTIONS_STATE_KEY = 'findOptions';
+const CUSTOM_THEMES_STATE_KEY = 'customThemes';
 
 type FindOptionsState = {
-    wholeWord: boolean;
-    caseSensitive: boolean;
+  wholeWord: boolean;
+  caseSensitive: boolean;
 };
 
-type ThemeSource = "built-in" | "imported";
+type ThemeSource = 'built-in' | 'imported';
 
 type ThemeQuickPickItem = vscode.QuickPickItem & {
-    theme: ThemeSettings;
-    source: ThemeSource;
+  theme: ThemeSettings;
+  source: ThemeSource;
 };
 
 type ImportedThemeQuickPickItem = vscode.QuickPickItem & {
-    theme: ThemeSettings;
+  theme: ThemeSettings;
 };
 
 type ExportRuntimeModule = {
-    renderExportHtmlDocument: (options: {
-        markdownText: string;
-        sourceDocumentPath: string;
-        outputFilePath: string;
-        target: ExportFormat;
-        htmlImageMode: ExportHtmlImageMode;
-        theme: ThemeSettings;
-        styleEnvironment?: ExportStyleEnvironment;
-        editorFontEnvironment?: {
-            editorFontFamily?: string;
-            editorFontWeight?: string;
-            editorFontSizePx?: number;
-        };
-        mermaidRuntimeSrc: string;
-        katexStylesHref: string;
-        baseHref: string;
-        title: string;
-    }) => { htmlDocument: string; hasMermaid: boolean; hasMath: boolean };
-    writeFinalizedHtmlExport: (options: { htmlDocument: string; outputHtmlPath: string; browserExecutablePath?: string; puppeteerRuntimeModulePath?: string; timeoutMs?: number; skipHeadlessFinalize?: boolean }) => Promise<void>;
-    renderPdfFromHtmlExport: (options: { htmlDocument: string; outputPdfPath: string; browserExecutablePath?: string; puppeteerRuntimeModulePath?: string; timeoutMs?: number }) => Promise<void>;
+  renderExportHtmlDocument: (options: {
+    markdownText: string;
+    sourceDocumentPath: string;
+    outputFilePath: string;
+    target: ExportFormat;
+    htmlImageMode: ExportHtmlImageMode;
+    theme: ThemeSettings;
+    styleEnvironment?: ExportStyleEnvironment;
+    editorFontEnvironment?: {
+      editorFontFamily?: string;
+      editorFontWeight?: string;
+      editorFontSizePx?: number;
+    };
+    mermaidRuntimeSrc: string;
+    katexStylesHref: string;
+    baseHref: string;
+    title: string;
+  }) => { htmlDocument: string; hasMermaid: boolean; hasMath: boolean };
+  writeFinalizedHtmlExport: (options: {
+    htmlDocument: string;
+    outputHtmlPath: string;
+    browserExecutablePath?: string;
+    puppeteerRuntimeModulePath?: string;
+    timeoutMs?: number;
+    skipHeadlessFinalize?: boolean;
+  }) => Promise<void>;
+  renderPdfFromHtmlExport: (options: {
+    htmlDocument: string;
+    outputPdfPath: string;
+    browserExecutablePath?: string;
+    puppeteerRuntimeModulePath?: string;
+    timeoutMs?: number;
+  }) => Promise<void>;
 };
 
 let exportRuntimeModulePromise: Promise<ExportRuntimeModule> | null = null;
 
 export function activate(context: vscode.ExtensionContext): void {
-    void vscode.commands.executeCommand("setContext", ACTIVE_EDITOR_CONTEXT_KEY, false);
-    const useAsDefault = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>("useAsDefault", true);
-    void syncEditorAssociations(useAsDefault);
+  void vscode.commands.executeCommand('setContext', ACTIVE_EDITOR_CONTEXT_KEY, false);
+  const useAsDefault = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>('useAsDefault', true);
+  void syncEditorAssociations(useAsDefault);
 
-    const agentReviewHandoff = new AgentReviewHandoffController({
-        viewType: VIEW_TYPE,
+  const agentReviewHandoff = new AgentReviewHandoffController({
+    viewType: VIEW_TYPE,
+    getComparableResourceKey,
+    getOpenTextDocumentForUri,
+    hasLikelyReviewState: (targetUri, targetText) =>
+      Boolean(findLikelyAgentReviewState(targetUri, getComparableResourceKey, getOpenTextDocumentForUri, targetText))
+  });
+  const agentReviewOverrides = new AgentReviewOverrideController(context, {
+    getComparableResourceKey,
+    getOpenTextDocumentForComparableKey,
+    isLikelyAgentReviewUri
+  });
+  void agentReviewOverrides.syncNow();
+
+  const provider = new MarkdownWebviewProvider(context, agentReviewHandoff);
+  void provider.initializeGitWatcher();
+
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider(VIEW_TYPE, provider, {
+      supportsMultipleEditorsPerDocument: false,
+      webviewOptions: { retainContextWhenHidden: true }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.useAsDefault`)) {
+        const shouldUseAsDefault = vscode.workspace
+          .getConfiguration(EXTENSION_CONFIG_SECTION)
+          .get<boolean>('useAsDefault', true);
+        void syncEditorAssociations(shouldUseAsDefault);
+      }
+
+      void provider.handleConfigurationChanged(event);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument((document) => {
+      if (!isLikelyAgentReviewUri(document.uri)) {
+        return;
+      }
+      void agentReviewOverrides.syncNow();
+      void provider.redirectOpenEditorsForCopilotReview(document.uri);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidCloseTextDocument((document) => {
+      if (!isLikelyAgentReviewUri(document.uri)) {
+        return;
+      }
+      agentReviewOverrides.scheduleSync(AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS);
+      const targetUri = getComparableFileUri(document.uri, getComparableResourceKey);
+      if (targetUri) {
+        const targetPath = (targetUri.path || targetUri.fsPath || '').toLowerCase();
+        if (isMarkdownDocumentPath(targetPath)) {
+          const openTargetDocument = getOpenTextDocumentForUri(targetUri);
+          const reviewApplied = areAgentReviewTextsEquivalent(document.getText(), openTargetDocument?.getText());
+          if (reviewApplied && agentReviewHandoff.hasOpenNativeTextTabForUri(targetUri)) {
+            agentReviewHandoff.scheduleDeferredReopen(targetUri);
+          }
+        }
+
+        agentReviewHandoff.notePendingMEOtabDedup(targetUri);
+        agentReviewHandoff.scheduleMEOtabDedup(targetUri, AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS);
+      }
+      agentReviewHandoff.scheduleFlushDeferredReopens(AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      const isAgentReviewDocument = isLikelyAgentReviewUri(event.document.uri);
+      if (isAgentReviewDocument) {
+        agentReviewOverrides.scheduleSync();
+      }
+      if (!agentReviewHandoff.hasRecentMEOOwnedFileChangeForUri(event.document.uri)) {
+        void provider.redirectOpenEditorsForCopilotReview(event.document.uri);
+      }
+
+      const shouldReevaluate = agentReviewHandoff.shouldReevaluateDeferredReopen(
+        event.document.uri,
+        isAgentReviewDocument
+      );
+      if (!shouldReevaluate) {
+        return;
+      }
+
+      if (!isAgentReviewDocument) {
+        agentReviewOverrides.scheduleSync();
+      }
+      agentReviewHandoff.scheduleFlushDeferredReopens();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.window.tabGroups.onDidChangeTabs((event) => {
+      agentReviewHandoff.noteRecentTextDiffActivity(event.opened);
+      agentReviewHandoff.noteRecentTextDiffActivity(event.changed);
+      void agentReviewHandoff.flushPendingMEOtabDedups();
+      if (!agentReviewHandoff.hasPendingDeferredReopens()) {
+        return;
+      }
+      agentReviewHandoff.scheduleFlushDeferredReopens();
+    })
+  );
+
+  void migrateLegacyToggleSettings(context);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.open', async (uriLike?: unknown) => {
+      const targetUri = getPreferredCommandUri(uriLike);
+      if (!targetUri) {
+        return;
+      }
+      const targetPath = (targetUri.path || targetUri.fsPath || '').toLowerCase();
+      if (!isMarkdownDocumentPath(targetPath)) {
+        return;
+      }
+      const pendingReview = findLikelyAgentReviewState(
+        targetUri,
         getComparableResourceKey,
         getOpenTextDocumentForUri,
-        hasLikelyReviewState: (targetUri, targetText) => Boolean(findLikelyAgentReviewState(targetUri, getComparableResourceKey, getOpenTextDocumentForUri, targetText)),
-    });
-    const agentReviewOverrides = new AgentReviewOverrideController(context, {
-        getComparableResourceKey,
-        getOpenTextDocumentForComparableKey,
-        isLikelyAgentReviewUri,
-    });
-    void agentReviewOverrides.syncNow();
+        getOpenTextDocumentForUri(targetUri)?.getText()
+      );
+      if (pendingReview) {
+        agentReviewHandoff.scheduleDeferredReopen(targetUri);
+        return;
+      }
+      await vscode.commands.executeCommand('vscode.openWith', targetUri, VIEW_TYPE);
+    })
+  );
 
-    const provider = new MarkdownWebviewProvider(context, agentReviewHandoff);
-    void provider.initializeGitWatcher();
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.setDefaultEditor', async () => {
+      await syncEditorAssociations(true);
+      void showTimedInformationMessage('Markdown Editor Optimized is now set as the default editor for Markdown files.');
+    })
+  );
 
-    context.subscriptions.push(
-        vscode.window.registerCustomEditorProvider(VIEW_TYPE, provider, {
-            supportsMultipleEditorsPerDocument: false,
-            webviewOptions: { retainContextWhenHidden: true },
-        }),
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.resetThemeToDefault', async () => {
+      await resetThemeSettingsToDefault();
+      provider.notifyThemeChanged();
+      void showTimedInformationMessage('Markdown Editor Optimized theme was reset to default.');
+    })
+  );
 
-    context.subscriptions.push(
-        vscode.workspace.onDidChangeConfiguration((event) => {
-            if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.useAsDefault`)) {
-                const shouldUseAsDefault = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>("useAsDefault", true);
-                void syncEditorAssociations(shouldUseAsDefault);
-            }
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.selectTheme', async () => {
+      const themeItems = buildThemeQuickPickItems(context);
+      const selectedTheme = await showTimedQuickPick(
+        themeItems,
+        { title: 'Select Theme', placeHolder: 'Select & apply a theme preset.' },
+        0
+      );
 
-            void provider.handleConfigurationChanged(event);
-        }),
-    );
+      if (!selectedTheme) {
+        return;
+      }
 
-    context.subscriptions.push(
-        vscode.workspace.onDidOpenTextDocument((document) => {
-            if (!isLikelyAgentReviewUri(document.uri)) {
-                return;
-            }
-            void agentReviewOverrides.syncNow();
-            void provider.redirectOpenEditorsForCopilotReview(document.uri);
-        }),
-    );
+      const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+      try {
+        await config.update('theme', serializeThemeSettings(selectedTheme.theme), vscode.ConfigurationTarget.Global);
+      } catch {
+        void showTimedErrorMessage('Failed to apply theme preset.');
+        return;
+      }
 
-    context.subscriptions.push(
-        vscode.workspace.onDidCloseTextDocument((document) => {
-            if (!isLikelyAgentReviewUri(document.uri)) {
-                return;
-            }
-            agentReviewOverrides.scheduleSync(AGENT_REVIEW_FILE_OVERRIDE_CLEANUP_DELAY_MS);
-            const targetUri = getComparableFileUri(document.uri, getComparableResourceKey);
-            if (targetUri) {
-                const targetPath = (targetUri.path || targetUri.fsPath || "").toLowerCase();
-                if (isMarkdownDocumentPath(targetPath)) {
-                    const openTargetDocument = getOpenTextDocumentForUri(targetUri);
-                    const reviewApplied = areAgentReviewTextsEquivalent(document.getText(), openTargetDocument?.getText());
-                    if (reviewApplied && agentReviewHandoff.hasOpenNativeTextTabForUri(targetUri)) {
-                        agentReviewHandoff.scheduleDeferredReopen(targetUri);
-                    }
-                }
+      provider.notifyThemeChanged();
+      const sourceSuffix = selectedTheme.source === 'imported' ? ' (imported)' : '';
+      void showTimedInformationMessage(`Selected theme: ${selectedTheme.theme.name}${sourceSuffix}`);
+    })
+  );
 
-                agentReviewHandoff.notePendingMEOtabDedup(targetUri);
-                agentReviewHandoff.scheduleMEOtabDedup(targetUri, AGENT_REVIEW_POST_REOPEN_DEDUP_DELAY_MS);
-            }
-            agentReviewHandoff.scheduleFlushDeferredReopens(AGENT_REVIEW_REOPEN_ON_CLOSE_DELAY_MS);
-        }),
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.importTheme', async () => {
+      const openFiles = await vscode.window.showOpenDialog({
+        title: 'Import Theme JSON',
+        filters: { 'Theme JSON': ['json'] },
+        canSelectMany: false
+      });
 
-    context.subscriptions.push(
-        vscode.workspace.onDidChangeTextDocument((event) => {
-            const isAgentReviewDocument = isLikelyAgentReviewUri(event.document.uri);
-            if (isAgentReviewDocument) {
-                agentReviewOverrides.scheduleSync();
-            }
-            if (!agentReviewHandoff.hasRecentMEOOwnedFileChangeForUri(event.document.uri)) {
-                void provider.redirectOpenEditorsForCopilotReview(event.document.uri);
-            }
+      if (!openFiles?.length) {
+        return;
+      }
 
-            const shouldReevaluate = agentReviewHandoff.shouldReevaluateDeferredReopen(event.document.uri, isAgentReviewDocument);
-            if (!shouldReevaluate) {
-                return;
-            }
+      const fileUri = openFiles[0];
+      try {
+        const fileContent = await vscode.workspace.fs.readFile(fileUri);
+        const payload = JSON.parse(new TextDecoder().decode(fileContent));
+        const validated = validateThemePayload(payload);
+        if (!validated.success) {
+          void showTimedErrorMessage(
+            `Invalid theme file: ${validated.errors[0] || 'payload does not match schema.'}`
+          );
+          return;
+        }
 
-            if (!isAgentReviewDocument) {
-                agentReviewOverrides.scheduleSync();
-            }
-            agentReviewHandoff.scheduleFlushDeferredReopens();
-        }),
-    );
+        const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+        await config.update('theme', serializeThemeSettings(validated.theme), vscode.ConfigurationTarget.Global);
+        await upsertImportedTheme(context, validated.theme);
+        provider.notifyThemeChanged();
+        void showTimedInformationMessage(`Imported theme: ${validated.theme.name}`);
+      } catch (error) {
+        void showTimedErrorMessage(`Failed to import theme: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    })
+  );
 
-    context.subscriptions.push(
-        vscode.window.tabGroups.onDidChangeTabs((event) => {
-            agentReviewHandoff.noteRecentTextDiffActivity(event.opened);
-            agentReviewHandoff.noteRecentTextDiffActivity(event.changed);
-            void agentReviewHandoff.flushPendingMEOtabDedups();
-            if (!agentReviewHandoff.hasPendingDeferredReopens()) {
-                return;
-            }
-            agentReviewHandoff.scheduleFlushDeferredReopens();
-        }),
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.exportTheme', async () => {
+      const uri = await vscode.window.showSaveDialog({
+        title: 'Export Theme JSON',
+        filters: { 'Theme JSON': ['json'] },
+        defaultUri: vscode.Uri.file('meo-theme.json'),
+        saveLabel: 'Export Theme'
+      });
 
-    void migrateLegacyToggleSettings(context);
+      if (!uri) {
+        return;
+      }
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.open", async (uriLike?: unknown) => {
-            const targetUri = getPreferredCommandUri(uriLike);
-            if (!targetUri) {
-                return;
-            }
-            const targetPath = (targetUri.path || targetUri.fsPath || "").toLowerCase();
-            if (!isMarkdownDocumentPath(targetPath)) {
-                return;
-            }
-            const pendingReview = findLikelyAgentReviewState(targetUri, getComparableResourceKey, getOpenTextDocumentForUri, getOpenTextDocumentForUri(targetUri)?.getText());
-            if (pendingReview) {
-                agentReviewHandoff.scheduleDeferredReopen(targetUri);
-                return;
-            }
-            await vscode.commands.executeCommand("vscode.openWith", targetUri, VIEW_TYPE);
-        }),
-    );
+      const theme = serializeThemeSettings(getThemeSettings());
+      try {
+        await vscode.workspace.fs.writeFile(
+          uri,
+          new TextEncoder().encode(`${JSON.stringify(theme, null, 2)}\n`)
+        );
+        void showTimedInformationMessage(`Theme exported to ${uri.fsPath}`);
+      } catch (error) {
+        void showTimedErrorMessage(`Failed to export theme: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    })
+  );
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.setDefaultEditor", async () => {
-            await syncEditorAssociations(true);
-            void showTimedInformationMessage("Markdown Editor Optimized is now set as the default editor for Markdown files.");
-        }),
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.deleteImportedTheme', async () => {
+      const importedThemes = getImportedThemes(context);
+      if (!importedThemes.length) {
+        void showTimedInformationMessage('No imported themes to delete.');
+        return;
+      }
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.resetThemeToDefault", async () => {
-            await resetThemeSettingsToDefault();
-            provider.notifyThemeChanged();
-            void showTimedInformationMessage("Markdown Editor Optimized theme was reset to default.");
-        }),
-    );
+      const selected = await showTimedQuickPick(
+        importedThemes.map((theme) => ({
+          label: theme.name,
+          description: theme.id,
+          theme
+        } satisfies ImportedThemeQuickPickItem)),
+        {
+          title: 'Delete Imported Theme',
+          placeHolder: 'Select an imported theme to delete'
+        }
+      );
+      if (!selected) {
+        return;
+      }
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.selectTheme", async () => {
-            const themeItems = buildThemeQuickPickItems(context);
-            const selectedTheme = await showTimedQuickPick(themeItems, { title: "Select Theme", placeHolder: "Select & apply a theme preset." }, 0);
+      const confirm = await showTimedWarningMessageWithItems(
+        `Delete imported theme "${selected.theme.name}"?`,
+        { modal: true },
+        ['Delete'] as const
+      );
+      if (confirm !== 'Delete') {
+        return;
+      }
 
-            if (!selectedTheme) {
-                return;
-            }
+      const deleted = await deleteImportedThemeById(context, selected.theme.id);
+      if (!deleted) {
+        void showTimedWarningMessage(`Could not find imported theme "${selected.theme.name}" to delete.`);
+        return;
+      }
 
-            const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-            try {
-                await config.update("theme", serializeThemeSettings(selectedTheme.theme), vscode.ConfigurationTarget.Global);
-            } catch {
-                void showTimedErrorMessage("Failed to apply theme preset.");
-                return;
-            }
+      const currentTheme = getThemeSettings();
+      const deletingActiveTheme = normalizeThemeId(currentTheme.id) === normalizeThemeId(selected.theme.id);
+      const collidesWithBuiltIn = isBuiltInThemeId(selected.theme.id);
+      if (deletingActiveTheme && !collidesWithBuiltIn) {
+        const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+        await config.update('theme', serializeThemeSettings(themePresets[0] as ThemeSettings), vscode.ConfigurationTarget.Global);
+        provider.notifyThemeChanged();
+        void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}. Active theme reset to ${themePresets[0].name}.`);
+        return;
+      }
 
-            provider.notifyThemeChanged();
-            const sourceSuffix = selectedTheme.source === "imported" ? " (imported)" : "";
-            void showTimedInformationMessage(`Selected theme: ${selectedTheme.theme.name}${sourceSuffix}`);
-        }),
-    );
+      void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}`);
+    })
+  );
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.importTheme", async () => {
-            const openFiles = await vscode.window.showOpenDialog({
-                title: "Import Theme JSON",
-                filters: { "Theme JSON": ["json"] },
-                canSelectMany: false,
-            });
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.toggleMode', async () => {
+      await provider.toggleActiveEditorMode();
+    })
+  );
 
-            if (!openFiles?.length) {
-                return;
-            }
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.exportHtml', async () => {
+      await provider.exportActiveDocument('html');
+    })
+  );
 
-            const fileUri = openFiles[0];
-            try {
-                const fileContent = await vscode.workspace.fs.readFile(fileUri);
-                const payload = JSON.parse(new TextDecoder().decode(fileContent));
-                const validated = validateThemePayload(payload);
-                if (!validated.success) {
-                    void showTimedErrorMessage(`Invalid theme file: ${validated.errors[0] || "payload does not match schema."}`);
-                    return;
-                }
-
-                const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-                await config.update("theme", serializeThemeSettings(validated.theme), vscode.ConfigurationTarget.Global);
-                await upsertImportedTheme(context, validated.theme);
-                provider.notifyThemeChanged();
-                void showTimedInformationMessage(`Imported theme: ${validated.theme.name}`);
-            } catch (error) {
-                void showTimedErrorMessage(`Failed to import theme: ${error instanceof Error ? error.message : String(error)}`);
-            }
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.exportTheme", async () => {
-            const uri = await vscode.window.showSaveDialog({
-                title: "Export Theme JSON",
-                filters: { "Theme JSON": ["json"] },
-                defaultUri: vscode.Uri.file("meo-theme.json"),
-                saveLabel: "Export Theme",
-            });
-
-            if (!uri) {
-                return;
-            }
-
-            const theme = serializeThemeSettings(getThemeSettings());
-            try {
-                await vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(`${JSON.stringify(theme, null, 2)}\n`));
-                void showTimedInformationMessage(`Theme exported to ${uri.fsPath}`);
-            } catch (error) {
-                void showTimedErrorMessage(`Failed to export theme: ${error instanceof Error ? error.message : String(error)}`);
-            }
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.deleteImportedTheme", async () => {
-            const importedThemes = getImportedThemes(context);
-            if (!importedThemes.length) {
-                void showTimedInformationMessage("No imported themes to delete.");
-                return;
-            }
-
-            const selected = await showTimedQuickPick(
-                importedThemes.map(
-                    (theme) =>
-                        ({
-                            label: theme.name,
-                            description: theme.id,
-                            theme,
-                        }) satisfies ImportedThemeQuickPickItem,
-                ),
-                {
-                    title: "Delete Imported Theme",
-                    placeHolder: "Select an imported theme to delete",
-                },
-            );
-            if (!selected) {
-                return;
-            }
-
-            const confirm = await showTimedWarningMessageWithItems(`Delete imported theme "${selected.theme.name}"?`, { modal: true }, ["Delete"] as const);
-            if (confirm !== "Delete") {
-                return;
-            }
-
-            const deleted = await deleteImportedThemeById(context, selected.theme.id);
-            if (!deleted) {
-                void showTimedWarningMessage(`Could not find imported theme "${selected.theme.name}" to delete.`);
-                return;
-            }
-
-            const currentTheme = getThemeSettings();
-            const deletingActiveTheme = normalizeThemeId(currentTheme.id) === normalizeThemeId(selected.theme.id);
-            const collidesWithBuiltIn = isBuiltInThemeId(selected.theme.id);
-            if (deletingActiveTheme && !collidesWithBuiltIn) {
-                const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-                await config.update("theme", serializeThemeSettings(themePresets[0] as ThemeSettings), vscode.ConfigurationTarget.Global);
-                provider.notifyThemeChanged();
-                void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}. Active theme reset to ${themePresets[0].name}.`);
-                return;
-            }
-
-            void showTimedInformationMessage(`Deleted imported theme: ${selected.theme.name}`);
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.toggleMode", async () => {
-            await provider.toggleActiveEditorMode();
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.exportHtml", async () => {
-            await provider.exportActiveDocument("html");
-        }),
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("markdownEditorOptimized.exportPdf", async () => {
-            await provider.exportActiveDocument("pdf");
-        }),
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.exportPdf', async () => {
+      await provider.exportActiveDocument('pdf');
+    })
+  );
 }
 
 class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
-    private readonly activePanels = new Set<vscode.WebviewPanel>();
-    private readonly panelSessions = new Map<vscode.WebviewPanel, PanelSession>();
-    private lastActivePanel: vscode.WebviewPanel | null = null;
+  private readonly activePanels = new Set<vscode.WebviewPanel>();
+  private readonly panelSessions = new Map<vscode.WebviewPanel, PanelSession>();
+  private lastActivePanel: vscode.WebviewPanel | null = null;
 
-    constructor(
-        private readonly context: vscode.ExtensionContext,
-        private readonly agentReviewHandoff: AgentReviewHandoffController,
-    ) {}
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly agentReviewHandoff: AgentReviewHandoffController
+  ) {}
 
-    async initializeGitWatcher(): Promise<void> {
-        const watcher = await createGitApiWatcher((repoRootFsPath) => {
-            for (const session of this.panelSessions.values()) {
-                if (session.getGitRepoRoot() !== repoRootFsPath) {
-                    continue;
-                }
-                session.refreshGitBaseline({ forceReload: true });
-            }
-        });
-        if (watcher) {
-            this.context.subscriptions.push(watcher);
+  async initializeGitWatcher(): Promise<void> {
+    const watcher = await createGitApiWatcher((repoRootFsPath) => {
+      for (const session of this.panelSessions.values()) {
+        if (session.getGitRepoRoot() !== repoRootFsPath) {
+          continue;
         }
+        session.refreshGitBaseline({ forceReload: true });
+      }
+    });
+    if (watcher) {
+      this.context.subscriptions.push(watcher);
+    }
+  }
+
+  async exportActiveDocument(format: ExportFormat): Promise<void> {
+    const session = this.getActiveSession();
+    if (!session) {
+      void showTimedWarningMessage('Open a Markdown file in Markdown Editor Optimized before exporting.');
+      return;
     }
 
-    async exportActiveDocument(format: ExportFormat): Promise<void> {
-        const session = this.getActiveSession();
-        if (!session) {
-            void showTimedWarningMessage("Open a Markdown file in Markdown Editor Optimized before exporting.");
-            return;
-        }
+    await this.exportSessionDocument(session, format);
+  }
 
-        await this.exportSessionDocument(session, format);
+  async redirectOpenEditorsForCopilotReview(triggerUri: vscode.Uri): Promise<void> {
+    const reviewState = resolveAgentReviewRedirectState(
+      triggerUri,
+      getComparableResourceKey,
+      getOpenTextDocumentForUri
+    );
+    if (!reviewState) {
+      return;
     }
 
-    async redirectOpenEditorsForCopilotReview(triggerUri: vscode.Uri): Promise<void> {
-        const reviewState = resolveAgentReviewRedirectState(triggerUri, getComparableResourceKey, getOpenTextDocumentForUri);
-        if (!reviewState) {
-            return;
-        }
-
-        const reviewKey = getComparableResourceKey(reviewState.uri);
-        if (!reviewKey) {
-            return;
-        }
-
-        for (const session of Array.from(this.panelSessions.values())) {
-            if (getComparableResourceKey(session.documentUri) !== reviewKey) {
-                continue;
-            }
-
-            if (this.agentReviewHandoff.hasRecentTextDiffActivityForUri(session.documentUri)) {
-                continue;
-            }
-
-            if (this.agentReviewHandoff.hasOpenTextDiffTabForUri(session.documentUri)) {
-                continue;
-            }
-
-            if (areAgentReviewTextsEquivalent(reviewState.text, session.document.getText())) {
-                continue;
-            }
-
-            this.agentReviewHandoff.scheduleDeferredReopen(session.documentUri);
-            await this.redirectCopilotReviewToNativeEditor(session.document, session.panel);
-        }
+    const reviewKey = getComparableResourceKey(reviewState.uri);
+    if (!reviewKey) {
+      return;
     }
 
-    async handleConfigurationChanged(event: vscode.ConfigurationChangeEvent): Promise<void> {
-        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY}`)) {
-            this.broadcast({ type: "lineNumbersChanged", enabled: getLineNumbersEnabled(this.context) });
-        }
+    for (const session of Array.from(this.panelSessions.values())) {
+      if (getComparableResourceKey(session.documentUri) !== reviewKey) {
+        continue;
+      }
 
-        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY}`) || event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY}`)) {
-            this.broadcast({ type: "gitChangesGutterChanged", enabled: getGitChangesGutterEnabled(this.context) });
-        }
+      if (this.agentReviewHandoff.hasRecentTextDiffActivityForUri(session.documentUri)) {
+        continue;
+      }
 
-        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY}`)) {
-            this.broadcast({ type: "gitDiffLineHighlightsChanged", enabled: getGitDiffLineHighlightsEnabled() });
-        }
+      if (this.agentReviewHandoff.hasOpenTextDiffTabForUri(session.documentUri)) {
+        continue;
+      }
 
-        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_SETTING_KEY}`) || event.affectsConfiguration("vim.enable")) {
-            this.broadcast({ type: "vimModeChanged", enabled: getVimModeEnabled(this.context) });
-        }
+      if (areAgentReviewTextsEquivalent(reviewState.text, session.document.getText())) {
+        continue;
+      }
 
-        if (event.affectsConfiguration("vim.normalModeKeyBindings") || event.affectsConfiguration("vim.normalModeKeyBindingsNonRecursive") || event.affectsConfiguration("vim.insertModeKeyBindings") || event.affectsConfiguration("vim.insertModeKeyBindingsNonRecursive") || event.affectsConfiguration("vim.visualModeKeyBindings") || event.affectsConfiguration("vim.visualModeKeyBindingsNonRecursive") || event.affectsConfiguration("vim.leader")) {
-            this.broadcast({ type: "vimKeybindingsChanged", keybindings: getVimKeybindings(), leaderKey: getVimLeaderKey() });
-        }
+      this.agentReviewHandoff.scheduleDeferredReopen(session.documentUri);
+      await this.redirectCopilotReviewToNativeEditor(session.document, session.panel);
+    }
+  }
 
-        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.outline.position`)) {
-            this.broadcast({ type: "outlinePositionChanged", position: getOutlinePosition() });
-        }
-
-        if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`)) {
-            this.broadcast({ type: "themeChanged", theme: getThemeSettings() });
-        }
+  async handleConfigurationChanged(event: vscode.ConfigurationChangeEvent): Promise<void> {
+    if (
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_SETTING_KEY}`) ||
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_SETTING_KEY}`) ||
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY}`)
+    ) {
+      this.broadcast({ type: 'lineNumbersChanged', enabled: getLineNumbersEnabled(this.context) });
     }
 
-    notifyThemeChanged(): void {
-        this.broadcast({ type: "themeChanged", theme: getThemeSettings() });
+    if (
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_SETTING_KEY}`) ||
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY}`) ||
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY}`) ||
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY}`)
+    ) {
+      this.broadcast({ type: 'gitChangesGutterChanged', enabled: getGitChangesGutterEnabled(this.context) });
     }
 
-    async toggleActiveEditorMode(): Promise<void> {
-        const session = this.getActiveSession();
-        if (!session) {
-            return;
-        }
-
-        this.lastActivePanel = session.panel;
-        await session.ensureInitDelivered();
-        await session.panel.webview.postMessage({ type: "toggleMode" });
+    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY}`)) {
+      this.broadcast({ type: 'gitDiffLineHighlightsChanged', enabled: getGitDiffLineHighlightsEnabled() });
     }
 
-    async resolveCustomTextEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel, _token: vscode.CancellationToken): Promise<void> {
-        const pendingReview = findLikelyAgentReviewState(document.uri, getComparableResourceKey, getOpenTextDocumentForUri, document.getText());
-        if (pendingReview) {
-            this.agentReviewHandoff.scheduleDeferredReopen(document.uri);
-            await this.redirectCopilotReviewToNativeEditor(document, panel, true);
-            return;
-        }
+    if (
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_BEHAVIOR_SETTING_KEY}`) ||
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_SETTING_KEY}`) ||
+      event.affectsConfiguration('vim.enable')
+    ) {
+      this.broadcast({ type: 'vimModeChanged', enabled: getVimModeEnabled(this.context) });
+    }
 
-        if (await this.redirectGitResourceToNativeEditor(document, panel)) {
-            return;
-        }
+    if (
+      event.affectsConfiguration('vim.normalModeKeyBindings') ||
+      event.affectsConfiguration('vim.normalModeKeyBindingsNonRecursive') ||
+      event.affectsConfiguration('vim.insertModeKeyBindings') ||
+      event.affectsConfiguration('vim.insertModeKeyBindingsNonRecursive') ||
+      event.affectsConfiguration('vim.visualModeKeyBindings') ||
+      event.affectsConfiguration('vim.visualModeKeyBindingsNonRecursive') ||
+      event.affectsConfiguration('vim.leader')
+    ) {
+      this.broadcast({ type: 'vimKeybindingsChanged', keybindings: getVimKeybindings(), leaderKey: getVimLeaderKey() });
+    }
 
-        this.activePanels.add(panel);
+    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.outline.position`)) {
+      this.broadcast({ type: 'outlinePositionChanged', position: getOutlinePosition() });
+    }
 
-        const documentUri = resolveWorktreeUri(document);
-        const distRoot = vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist");
-        panel.webview.options = {
-            enableScripts: true,
-            localResourceRoots: collectLocalResourceRoots(distRoot, documentUri),
-        };
+    if (
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`)
+    ) {
+      this.broadcast({ type: 'themeChanged', theme: getThemeSettings() });
+    }
+  }
 
-        const controller = createPanelSessionController({
-            panel,
-            document,
-            documentUri,
-            context: this.context,
-            agentReviewHandoff: this.agentReviewHandoff,
-            onExportDocument: (session, format) => this.exportSessionDocument(session, format),
-            getFindOptions: () => this.getFindOptions(),
-            setFindOptions: (options) => this.setFindOptions(options),
-            setOutlineVisible: (visible) => this.setOutlineVisible(visible),
-            onPanelActivated: (activePanel) => {
-                this.lastActivePanel = activePanel;
-            },
-            onPanelViewStateChanged: () => {
-                this.updateActiveEditorContext();
-            },
-            onPanelDisposed: (disposedPanel) => {
-                this.activePanels.delete(disposedPanel);
-                this.panelSessions.delete(disposedPanel);
-                if (this.lastActivePanel === disposedPanel) {
-                    this.lastActivePanel = null;
-                }
-                this.updateActiveEditorContext();
-            },
-        });
+  notifyThemeChanged(): void {
+    this.broadcast({ type: 'themeChanged', theme: getThemeSettings() });
+  }
 
-        panel.webview.html = this.getWebviewHtml(panel.webview);
-        this.panelSessions.set(panel, controller.session);
-        if (panel.active) {
-            this.lastActivePanel = panel;
+  async toggleActiveEditorMode(): Promise<void> {
+    const session = this.getActiveSession();
+    if (!session) {
+      return;
+    }
+
+    this.lastActivePanel = session.panel;
+    await session.ensureInitDelivered();
+    await session.panel.webview.postMessage({ type: 'toggleMode' });
+  }
+
+  async resolveCustomTextEditor(
+    document: vscode.TextDocument,
+    panel: vscode.WebviewPanel,
+    _token: vscode.CancellationToken
+  ): Promise<void> {
+    const pendingReview = findLikelyAgentReviewState(
+      document.uri,
+      getComparableResourceKey,
+      getOpenTextDocumentForUri,
+      document.getText()
+    );
+    if (pendingReview) {
+      this.agentReviewHandoff.scheduleDeferredReopen(document.uri);
+      await this.redirectCopilotReviewToNativeEditor(document, panel, true);
+      return;
+    }
+
+    if (await this.redirectGitResourceToNativeEditor(document, panel)) {
+      return;
+    }
+
+    this.activePanels.add(panel);
+
+    const documentUri = resolveWorktreeUri(document);
+    const distRoot = vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist');
+    panel.webview.options = {
+      enableScripts: true,
+      localResourceRoots: collectLocalResourceRoots(distRoot, documentUri)
+    };
+
+    const controller = createPanelSessionController({
+      panel,
+      document,
+      documentUri,
+      context: this.context,
+      agentReviewHandoff: this.agentReviewHandoff,
+      onExportDocument: (session, format) => this.exportSessionDocument(session, format),
+      getFindOptions: () => this.getFindOptions(),
+      setFindOptions: (options) => this.setFindOptions(options),
+      setOutlineVisible: (visible) => this.setOutlineVisible(visible),
+      onPanelActivated: (activePanel) => {
+        this.lastActivePanel = activePanel;
+      },
+      onPanelViewStateChanged: () => {
+        this.updateActiveEditorContext();
+      },
+      onPanelDisposed: (disposedPanel) => {
+        this.activePanels.delete(disposedPanel);
+        this.panelSessions.delete(disposedPanel);
+        if (this.lastActivePanel === disposedPanel) {
+          this.lastActivePanel = null;
         }
         this.updateActiveEditorContext();
+      }
+    });
+
+    panel.webview.html = this.getWebviewHtml(panel.webview);
+    this.panelSessions.set(panel, controller.session);
+    if (panel.active) {
+      this.lastActivePanel = panel;
+    }
+    this.updateActiveEditorContext();
+  }
+
+  private broadcast(message: Record<string, unknown>): void {
+    for (const panel of this.activePanels) {
+      void panel.webview.postMessage(message);
+    }
+  }
+
+  private getFindOptions(): FindOptionsState {
+    const stored = this.context.globalState.get<Partial<FindOptionsState> | undefined>(FIND_OPTIONS_STATE_KEY);
+    return {
+      wholeWord: stored?.wholeWord === true,
+      caseSensitive: stored?.caseSensitive === true
+    };
+  }
+
+  private async setFindOptions(options: FindOptionsState): Promise<void> {
+    const nextOptions: FindOptionsState = {
+      wholeWord: options.wholeWord === true,
+      caseSensitive: options.caseSensitive === true
+    };
+    const currentOptions = this.getFindOptions();
+    if (
+      currentOptions.wholeWord === nextOptions.wholeWord &&
+      currentOptions.caseSensitive === nextOptions.caseSensitive
+    ) {
+      return;
     }
 
-    private broadcast(message: Record<string, unknown>): void {
-        for (const panel of this.activePanels) {
-            void panel.webview.postMessage(message);
-        }
+    await this.context.globalState.update(FIND_OPTIONS_STATE_KEY, nextOptions);
+    this.broadcast({ type: 'findOptionsChanged', findOptions: nextOptions });
+  }
+
+  private async setOutlineVisible(visible: boolean): Promise<void> {
+    const nextVisible = visible === true;
+    if (getOutlineVisible(this.context) === nextVisible) {
+      return;
     }
 
-    private getFindOptions(): FindOptionsState {
-        const stored = this.context.globalState.get<Partial<FindOptionsState> | undefined>(FIND_OPTIONS_STATE_KEY);
-        return {
-            wholeWord: stored?.wholeWord === true,
-            caseSensitive: stored?.caseSensitive === true,
-        };
+    await this.context.globalState.update(OUTLINE_VISIBLE_KEY, nextVisible);
+    this.broadcast({ type: 'outlineVisibilityChanged', visible: nextVisible });
+  }
+
+  private updateActiveEditorContext(): void {
+    const hasActiveMEOEditor = Array.from(this.panelSessions.keys()).some((panel) => panel.active);
+    void vscode.commands.executeCommand('setContext', ACTIVE_EDITOR_CONTEXT_KEY, hasActiveMEOEditor);
+  }
+
+  private getActiveSession(): PanelSession | null {
+    if (this.lastActivePanel && this.panelSessions.has(this.lastActivePanel)) {
+      return this.panelSessions.get(this.lastActivePanel) ?? null;
     }
 
-    private async setFindOptions(options: FindOptionsState): Promise<void> {
-        const nextOptions: FindOptionsState = {
-            wholeWord: options.wholeWord === true,
-            caseSensitive: options.caseSensitive === true,
-        };
-        const currentOptions = this.getFindOptions();
-        if (currentOptions.wholeWord === nextOptions.wholeWord && currentOptions.caseSensitive === nextOptions.caseSensitive) {
-            return;
-        }
-
-        await this.context.globalState.update(FIND_OPTIONS_STATE_KEY, nextOptions);
-        this.broadcast({ type: "findOptionsChanged", findOptions: nextOptions });
+    for (const panel of this.activePanels) {
+      if (panel.active && this.panelSessions.has(panel)) {
+        this.lastActivePanel = panel;
+        return this.panelSessions.get(panel) ?? null;
+      }
     }
 
-    private async setOutlineVisible(visible: boolean): Promise<void> {
-        const nextVisible = visible === true;
-        if (getOutlineVisible(this.context) === nextVisible) {
-            return;
-        }
+    const first = this.panelSessions.values().next();
+    return first.done ? null : first.value;
+  }
 
-        await this.context.globalState.update(OUTLINE_VISIBLE_KEY, nextVisible);
-        this.broadcast({ type: "outlineVisibilityChanged", visible: nextVisible });
+  private async exportSessionDocument(session: PanelSession, format: ExportFormat): Promise<void> {
+    this.lastActivePanel = session.panel;
+
+    if (session.documentUri.scheme !== 'file') {
+      void showTimedWarningMessage('Export is only supported for local Markdown files in the current version.');
+      return;
     }
 
-    private updateActiveEditorContext(): void {
-        const hasActiveMEOEditor = Array.from(this.panelSessions.keys()).some((panel) => panel.active);
-        void vscode.commands.executeCommand("setContext", ACTIVE_EDITOR_CONTEXT_KEY, hasActiveMEOEditor);
+    const saveUri = await this.promptExportTargetUri(session.documentUri, format);
+    if (!saveUri) {
+      return;
     }
 
-    private getActiveSession(): PanelSession | null {
-        if (this.lastActivePanel && this.panelSessions.has(this.lastActivePanel)) {
-            return this.panelSessions.get(this.lastActivePanel) ?? null;
-        }
+    try {
+      await runWithTimedUiTimeout(() =>
+        vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+            title: format === 'html' ? 'Exporting Markdown to HTML' : 'Exporting Markdown to PDF'
+          },
+          async (progress) => {
+            progress.report({ message: 'Collecting editor content…' });
+            const snapshot = await session.requestExportSnapshot();
 
-        for (const panel of this.activePanels) {
-            if (panel.active && this.panelSessions.has(panel)) {
-                this.lastActivePanel = panel;
-                return this.panelSessions.get(panel) ?? null;
+            progress.report({ message: 'Rendering export document…' });
+            const exportRuntime = await loadExportRuntimeModule(this.context.extensionUri);
+            const exportRender = await this.buildExportHtmlDocument(exportRuntime, {
+              markdownText: snapshot.text,
+              sourceDocumentUri: session.documentUri,
+              outputFileUri: saveUri,
+              target: format,
+              htmlImageMode: getExportHtmlImageMode(),
+              styleEnvironment: snapshot.environment
+            });
+
+            const browserExecutablePath = getExportPdfBrowserPath();
+            const puppeteerRuntimeModulePath = vscode.Uri.joinPath(
+              this.context.extensionUri,
+              'dist',
+              'puppeteer-runtime.js'
+            ).fsPath;
+            progress.report({ message: format === 'html' ? 'Finalizing HTML…' : 'Rendering PDF in headless browser…' });
+
+            if (format === 'html') {
+              await exportRuntime.writeFinalizedHtmlExport({
+                htmlDocument: exportRender.htmlDocument,
+                outputHtmlPath: saveUri.fsPath,
+                browserExecutablePath,
+                puppeteerRuntimeModulePath,
+                skipHeadlessFinalize: !exportRender.hasMermaid
+              });
+              return;
             }
-        }
 
-        const first = this.panelSessions.values().next();
-        return first.done ? null : first.value;
+            await exportRuntime.renderPdfFromHtmlExport({
+              htmlDocument: exportRender.htmlDocument,
+              outputPdfPath: saveUri.fsPath,
+              browserExecutablePath,
+              puppeteerRuntimeModulePath
+            });
+          }
+        )
+      );
+
+      void vscode.window.setStatusBarMessage(
+        `${format.toUpperCase()} export completed: ${saveUri.fsPath}`,
+        5000
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Export failed';
+      void showTimedErrorMessage(`${format.toUpperCase()} export failed: ${message}`);
+    }
+  }
+
+  private async promptExportTargetUri(documentUri: vscode.Uri, format: ExportFormat): Promise<vscode.Uri | undefined> {
+    const defaultUri = vscode.Uri.file(replaceFileExtension(documentUri.fsPath, format === 'html' ? '.html' : '.pdf'));
+    return vscode.window.showSaveDialog({
+      defaultUri,
+      filters: format === 'html'
+        ? { HTML: ['html', 'htm'] }
+        : { PDF: ['pdf'] },
+      saveLabel: format === 'html' ? 'Export HTML' : 'Export PDF'
+    });
+  }
+
+  private async buildExportHtmlDocument(
+    exportRuntime: ExportRuntimeModule,
+    params: {
+      markdownText: string;
+      sourceDocumentUri: vscode.Uri;
+      outputFileUri: vscode.Uri;
+      target: ExportFormat;
+      htmlImageMode: ExportHtmlImageMode;
+      styleEnvironment?: ExportStyleEnvironment;
+    }
+  ): Promise<{ htmlDocument: string; hasMermaid: boolean; hasMath: boolean }> {
+    const mermaidRuntimeSrc = pathToFileURL(
+      vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'mermaid.min.js').fsPath
+    ).toString();
+    const katexStylesHref = pathToFileURL(
+      vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'katex', 'katex.min.css').fsPath
+    ).toString();
+    const baseHref = pathToFileURL(`${path.dirname(params.outputFileUri.fsPath)}${path.sep}`).toString();
+    return exportRuntime.renderExportHtmlDocument({
+      markdownText: params.markdownText,
+      sourceDocumentPath: params.sourceDocumentUri.fsPath,
+      outputFilePath: params.outputFileUri.fsPath,
+      target: params.target,
+      htmlImageMode: params.htmlImageMode,
+      theme: getThemeSettings(),
+      styleEnvironment: params.styleEnvironment,
+      editorFontEnvironment: getExportEditorFontEnvironment(),
+      mermaidRuntimeSrc,
+      katexStylesHref,
+      baseHref,
+      title: path.basename(params.outputFileUri.fsPath)
+    });
+  }
+
+  private async redirectGitResourceToNativeEditor(
+    document: vscode.TextDocument,
+    panel: vscode.WebviewPanel
+  ): Promise<boolean> {
+    if (document.uri.scheme !== 'git') {
+      return false;
     }
 
-    private async exportSessionDocument(session: PanelSession, format: ExportFormat): Promise<void> {
-        this.lastActivePanel = session.panel;
+    const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
+    const editorOptions = {
+      preserveFocus: false,
+      preview: true,
+      override: 'default'
+    };
+    const existingDiff = findDiffContextForGitUri(document.uri);
 
-        if (session.documentUri.scheme !== "file") {
-            void showTimedWarningMessage("Export is only supported for local Markdown files in the current version.");
-            return;
-        }
-
-        const saveUri = await this.promptExportTargetUri(session.documentUri, format);
-        if (!saveUri) {
-            return;
-        }
-
-        try {
-            await runWithTimedUiTimeout(() =>
-                vscode.window.withProgress(
-                    {
-                        location: vscode.ProgressLocation.Notification,
-                        cancellable: false,
-                        title: format === "html" ? "Exporting Markdown to HTML" : "Exporting Markdown to PDF",
-                    },
-                    async (progress) => {
-                        progress.report({ message: "Collecting editor content…" });
-                        const snapshot = await session.requestExportSnapshot();
-
-                        progress.report({ message: "Rendering export document…" });
-                        const exportRuntime = await loadExportRuntimeModule(this.context.extensionUri);
-                        const exportRender = await this.buildExportHtmlDocument(exportRuntime, {
-                            markdownText: snapshot.text,
-                            sourceDocumentUri: session.documentUri,
-                            outputFileUri: saveUri,
-                            target: format,
-                            htmlImageMode: getExportHtmlImageMode(),
-                            styleEnvironment: snapshot.environment,
-                        });
-
-                        const browserExecutablePath = getExportPdfBrowserPath();
-                        const puppeteerRuntimeModulePath = vscode.Uri.joinPath(this.context.extensionUri, "dist", "puppeteer-runtime.js").fsPath;
-                        progress.report({ message: format === "html" ? "Finalizing HTML…" : "Rendering PDF in headless browser…" });
-
-                        if (format === "html") {
-                            await exportRuntime.writeFinalizedHtmlExport({
-                                htmlDocument: exportRender.htmlDocument,
-                                outputHtmlPath: saveUri.fsPath,
-                                browserExecutablePath,
-                                puppeteerRuntimeModulePath,
-                                skipHeadlessFinalize: !exportRender.hasMermaid,
-                            });
-                            return;
-                        }
-
-                        await exportRuntime.renderPdfFromHtmlExport({
-                            htmlDocument: exportRender.htmlDocument,
-                            outputPdfPath: saveUri.fsPath,
-                            browserExecutablePath,
-                            puppeteerRuntimeModulePath,
-                        });
-                    },
-                ),
-            );
-
-            void vscode.window.setStatusBarMessage(`${format.toUpperCase()} export completed: ${saveUri.fsPath}`, 5000);
-        } catch (error) {
-            const message = error instanceof Error ? error.message : "Export failed";
-            void showTimedErrorMessage(`${format.toUpperCase()} export failed: ${message}`);
-        }
+    if (existingDiff) {
+      await vscode.commands.executeCommand(
+        '_workbench.diff',
+        existingDiff.original,
+        existingDiff.modified,
+        existingDiff.title,
+        [viewColumn, editorOptions]
+      );
+      panel.dispose();
+      return true;
     }
 
-    private async promptExportTargetUri(documentUri: vscode.Uri, format: ExportFormat): Promise<vscode.Uri | undefined> {
-        const defaultUri = vscode.Uri.file(replaceFileExtension(documentUri.fsPath, format === "html" ? ".html" : ".pdf"));
-        return vscode.window.showSaveDialog({
-            defaultUri,
-            filters: format === "html" ? { HTML: ["html", "htm"] } : { PDF: ["pdf"] },
-            saveLabel: format === "html" ? "Export HTML" : "Export PDF",
-        });
+    const ref = getGitUriRef(document.uri);
+    if (isWorkingTreeOrIndexRef(ref)) {
+      const targetUri = resolveWorktreeUri(document);
+      const title = getNativeWorkingTreeTitle(document.uri, targetUri);
+
+      await vscode.commands.executeCommand(
+        '_workbench.diff',
+        document.uri,
+        targetUri,
+        title,
+        [viewColumn, editorOptions]
+      );
+      panel.dispose();
+      return true;
     }
 
-    private async buildExportHtmlDocument(
-        exportRuntime: ExportRuntimeModule,
-        params: {
-            markdownText: string;
-            sourceDocumentUri: vscode.Uri;
-            outputFileUri: vscode.Uri;
-            target: ExportFormat;
-            htmlImageMode: ExportHtmlImageMode;
-            styleEnvironment?: ExportStyleEnvironment;
-        },
-    ): Promise<{ htmlDocument: string; hasMermaid: boolean; hasMath: boolean }> {
-        const mermaidRuntimeSrc = pathToFileURL(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "mermaid.min.js").fsPath).toString();
-        const katexStylesHref = pathToFileURL(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "katex", "katex.min.css").fsPath).toString();
-        const baseHref = pathToFileURL(`${path.dirname(params.outputFileUri.fsPath)}${path.sep}`).toString();
-        return exportRuntime.renderExportHtmlDocument({
-            markdownText: params.markdownText,
-            sourceDocumentPath: params.sourceDocumentUri.fsPath,
-            outputFilePath: params.outputFileUri.fsPath,
-            target: params.target,
-            htmlImageMode: params.htmlImageMode,
-            theme: getThemeSettings(),
-            styleEnvironment: params.styleEnvironment,
-            editorFontEnvironment: getExportEditorFontEnvironment(),
-            mermaidRuntimeSrc,
-            katexStylesHref,
-            baseHref,
-            title: path.basename(params.outputFileUri.fsPath),
-        });
-    }
+    return false;
+  }
 
-    private async redirectGitResourceToNativeEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel): Promise<boolean> {
-        if (document.uri.scheme !== "git") {
-            return false;
-        }
+  private async redirectCopilotReviewToNativeEditor(
+    document: vscode.TextDocument,
+    panel: vscode.WebviewPanel,
+    preserveFocus = false
+  ): Promise<void> {
+    const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
+    await vscode.commands.executeCommand(
+      'vscode.openWith',
+      document.uri,
+      'default',
+      {
+        viewColumn,
+        preserveFocus,
+        preview: true
+      }
+    );
+    panel.dispose();
+  }
 
-        const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
-        const editorOptions = {
-            preserveFocus: false,
-            preview: true,
-            override: "default",
-        };
-        const existingDiff = findDiffContextForGitUri(document.uri);
+  private getWebviewHtml(webview: vscode.Webview): string {
+    const scriptUri = webview
+      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'index.js'))
+      .toString();
+    const styleUri = webview
+      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'index.css'))
+      .toString();
+    const katexStyleUri = webview
+      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'katex', 'katex.min.css'))
+      .toString();
+    const mermaidRuntimeUri = webview
+      .asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'dist', 'mermaid.min.js'))
+      .toString();
+    const nonce = getNonce();
+    const csp = [
+      "default-src 'none'",
+      `img-src ${webview.cspSource} https:`,
+      `font-src ${webview.cspSource}`,
+      `style-src ${webview.cspSource} 'unsafe-inline'`,
+      `script-src ${webview.cspSource} 'nonce-${nonce}'`
+    ].join('; ');
 
-        if (existingDiff) {
-            await vscode.commands.executeCommand("_workbench.diff", existingDiff.original, existingDiff.modified, existingDiff.title, [viewColumn, editorOptions]);
-            panel.dispose();
-            return true;
-        }
-
-        const ref = getGitUriRef(document.uri);
-        if (isWorkingTreeOrIndexRef(ref)) {
-            const targetUri = resolveWorktreeUri(document);
-            const title = getNativeWorkingTreeTitle(document.uri, targetUri);
-
-            await vscode.commands.executeCommand("_workbench.diff", document.uri, targetUri, title, [viewColumn, editorOptions]);
-            panel.dispose();
-            return true;
-        }
-
-        return false;
-    }
-
-    private async redirectCopilotReviewToNativeEditor(document: vscode.TextDocument, panel: vscode.WebviewPanel, preserveFocus = false): Promise<void> {
-        const viewColumn = panel.viewColumn ?? vscode.ViewColumn.Active;
-        await vscode.commands.executeCommand("vscode.openWith", document.uri, "default", {
-            viewColumn,
-            preserveFocus,
-            preview: true,
-        });
-        panel.dispose();
-    }
-
-    private getWebviewHtml(webview: vscode.Webview): string {
-        const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "index.js")).toString();
-        const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "index.css")).toString();
-        const katexStyleUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "katex", "katex.min.css")).toString();
-        const mermaidRuntimeUri = webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, "webview", "dist", "mermaid.min.js")).toString();
-        const nonce = getNonce();
-        const csp = ["default-src 'none'", `img-src ${webview.cspSource} https:`, `font-src ${webview.cspSource}`, `style-src ${webview.cspSource} 'unsafe-inline'`, `script-src ${webview.cspSource} 'nonce-${nonce}'`].join("; ");
-
-        return `<!DOCTYPE html>
+    return `<!DOCTYPE html>
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
@@ -752,20 +931,20 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
         <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
       </body>
     </html>`;
-    }
+  }
 }
 
 function getNonce(): string {
-    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    let nonce = "";
-    for (let i = 0; i < 32; i += 1) {
-        nonce += chars[Math.floor(Math.random() * chars.length)];
-    }
-    return nonce;
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let nonce = '';
+  for (let i = 0; i < 32; i += 1) {
+    nonce += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return nonce;
 }
 
 function getWebviewPreloadShellCss(): string {
-    return `
+  return `
       html, body {
         margin: 0;
         padding: 0;
@@ -799,7 +978,7 @@ function getWebviewPreloadShellCss(): string {
 }
 
 function getWebviewPreloadShellMarkup(): string {
-    return `
+  return `
           <div class="mode-toolbar meo-preload-toolbar" role="presentation" aria-hidden="true"></div>
           <div class="editor-wrapper meo-preload-editor-shell" role="presentation" aria-hidden="true">
             <div class="editor-host"></div>
@@ -808,192 +987,198 @@ function getWebviewPreloadShellMarkup(): string {
 }
 
 async function loadExportRuntimeModule(extensionUri: vscode.Uri): Promise<ExportRuntimeModule> {
-    if (!exportRuntimeModulePromise) {
-        const runtimePath = vscode.Uri.joinPath(extensionUri, "dist", "export-runtime.js").fsPath;
-        const runtimeUrl = pathToFileURL(runtimePath).toString();
-        exportRuntimeModulePromise = import(runtimeUrl)
-            .then((mod: unknown) => unwrapExportRuntimeModule(mod))
-            .catch((error) => {
-                exportRuntimeModulePromise = null;
-                const message = error instanceof Error ? error.message : String(error);
-                throw new Error(`Failed to load export runtime (${runtimePath}). Run the extension build to regenerate it. ${message}`);
-            });
-    }
+  if (!exportRuntimeModulePromise) {
+    const runtimePath = vscode.Uri.joinPath(extensionUri, 'dist', 'export-runtime.js').fsPath;
+    const runtimeUrl = pathToFileURL(runtimePath).toString();
+    exportRuntimeModulePromise = import(runtimeUrl)
+      .then((mod: unknown) => unwrapExportRuntimeModule(mod))
+      .catch((error) => {
+        exportRuntimeModulePromise = null;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to load export runtime (${runtimePath}). Run the extension build to regenerate it. ${message}`);
+      });
+  }
 
-    return exportRuntimeModulePromise;
+  return exportRuntimeModulePromise;
 }
 
 function unwrapExportRuntimeModule(mod: unknown): ExportRuntimeModule {
-    let current: unknown = mod;
-    for (let i = 0; i < 5; i += 1) {
-        const candidate = current as Partial<ExportRuntimeModule> | undefined;
-        if (candidate && typeof candidate.renderExportHtmlDocument === "function" && typeof candidate.writeFinalizedHtmlExport === "function" && typeof candidate.renderPdfFromHtmlExport === "function") {
-            return candidate as ExportRuntimeModule;
-        }
-
-        if (!current || typeof current !== "object" || !("default" in current)) {
-            break;
-        }
-        current = (current as { default?: unknown }).default;
+  let current: unknown = mod;
+  for (let i = 0; i < 5; i += 1) {
+    const candidate = current as Partial<ExportRuntimeModule> | undefined;
+    if (
+      candidate &&
+      typeof candidate.renderExportHtmlDocument === 'function' &&
+      typeof candidate.writeFinalizedHtmlExport === 'function' &&
+      typeof candidate.renderPdfFromHtmlExport === 'function'
+    ) {
+      return candidate as ExportRuntimeModule;
     }
 
-    throw new Error("Loaded export runtime does not expose the expected export functions.");
+    if (!current || typeof current !== 'object' || !('default' in current)) {
+      break;
+    }
+    current = (current as { default?: unknown }).default;
+  }
+
+  throw new Error('Loaded export runtime does not expose the expected export functions.');
 }
 
 function collectLocalResourceRoots(distRoot: vscode.Uri, documentUri: vscode.Uri): vscode.Uri[] {
-    const roots = new Map<string, vscode.Uri>();
-    roots.set(distRoot.toString(), distRoot);
+  const roots = new Map<string, vscode.Uri>();
+  roots.set(distRoot.toString(), distRoot);
 
-    const documentDir = vscode.Uri.file(path.dirname(documentUri.fsPath));
-    roots.set(documentDir.toString(), documentDir);
+  const documentDir = vscode.Uri.file(path.dirname(documentUri.fsPath));
+  roots.set(documentDir.toString(), documentDir);
 
-    for (const folder of vscode.workspace.workspaceFolders ?? []) {
-        roots.set(folder.uri.toString(), folder.uri);
-    }
+  for (const folder of vscode.workspace.workspaceFolders ?? []) {
+    roots.set(folder.uri.toString(), folder.uri);
+  }
 
-    return Array.from(roots.values());
+  return Array.from(roots.values());
 }
 
-function replaceFileExtension(filePath: string, ext: ".html" | ".pdf"): string {
-    const parsed = path.parse(filePath);
-    return path.join(parsed.dir, `${parsed.name}${ext}`);
+function replaceFileExtension(filePath: string, ext: '.html' | '.pdf'): string {
+  const parsed = path.parse(filePath);
+  return path.join(parsed.dir, `${parsed.name}${ext}`);
 }
 
 function resolveWorktreeUri(document: vscode.TextDocument): vscode.Uri {
-    if (document.uri.scheme === "file") {
-        return document.uri;
-    }
+  if (document.uri.scheme === 'file') {
+    return document.uri;
+  }
 
-    return resolveWorktreeUriFromGitUri(document.uri) ?? document.uri;
+  return resolveWorktreeUriFromGitUri(document.uri) ?? document.uri;
 }
 
 function findDiffContextForGitUri(uri: vscode.Uri): { original: vscode.Uri; modified: vscode.Uri; title: string } | undefined {
-    const target = uri.toString();
+  const target = uri.toString();
 
-    for (const group of vscode.window.tabGroups.all) {
-        for (const tab of group.tabs) {
-            const input = tab.input;
-            if (!(input instanceof vscode.TabInputTextDiff)) {
-                continue;
-            }
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      if (!(input instanceof vscode.TabInputTextDiff)) {
+        continue;
+      }
 
-            const original = input.original;
-            const modified = input.modified;
-            if (original.toString() !== target && modified.toString() !== target) {
-                continue;
-            }
+      const original = input.original;
+      const modified = input.modified;
+      if (original.toString() !== target && modified.toString() !== target) {
+        continue;
+      }
 
-            return {
-                original,
-                modified,
-                title: tab.label,
-            };
-        }
+      return {
+        original,
+        modified,
+        title: tab.label
+      };
     }
+  }
 
-    return undefined;
+  return undefined;
 }
 
 function getGitUriRef(uri: vscode.Uri): string | undefined {
-    const query = parseGitUriQuery(uri.query);
-    return typeof query?.ref === "string" ? query.ref : undefined;
+  const query = parseGitUriQuery(uri.query);
+  return typeof query?.ref === 'string' ? query.ref : undefined;
 }
 
 function isWorkingTreeOrIndexRef(ref: string | undefined): boolean {
-    return ref === "~" || ref === "HEAD" || ref === "";
+  return ref === '~' || ref === 'HEAD' || ref === '';
 }
 
 function getNativeWorkingTreeTitle(gitUri: vscode.Uri, fileUri: vscode.Uri): string {
-    const fileName = vscode.workspace.asRelativePath(fileUri, false) || fileUri.path;
-    const ref = getGitUriRef(gitUri);
+  const fileName = vscode.workspace.asRelativePath(fileUri, false) || fileUri.path;
+  const ref = getGitUriRef(gitUri);
 
-    if (ref === "~") {
-        return `${fileName} (Working Tree)`;
-    }
+  if (ref === '~') {
+    return `${fileName} (Working Tree)`;
+  }
 
-    if (ref === "HEAD" || ref === "") {
-        return `${fileName} (Index)`;
-    }
+  if (ref === 'HEAD' || ref === '') {
+    return `${fileName} (Index)`;
+  }
 
-    return fileName;
+  return fileName;
 }
 
 function buildThemeQuickPickItems(context: vscode.ExtensionContext): ThemeQuickPickItem[] {
-    const builtInItems: ThemeQuickPickItem[] = themePresets.map((theme) => ({
-        label: theme.name,
-        description: theme.id,
-        detail: "Built-in",
-        theme,
-        source: "built-in",
-    }));
-    const importedItems: ThemeQuickPickItem[] = getImportedThemes(context).map((theme) => ({
-        label: theme.name,
-        description: theme.id,
-        detail: "Imported",
-        theme,
-        source: "imported",
-    }));
+  const builtInItems: ThemeQuickPickItem[] = themePresets.map((theme) => ({
+    label: theme.name,
+    description: theme.id,
+    detail: 'Built-in',
+    theme,
+    source: 'built-in'
+  }));
+  const importedItems: ThemeQuickPickItem[] = getImportedThemes(context).map((theme) => ({
+    label: theme.name,
+    description: theme.id,
+    detail: 'Imported',
+    theme,
+    source: 'imported'
+  }));
 
-    return [...builtInItems, ...importedItems];
+  return [...builtInItems, ...importedItems];
 }
 
 function getImportedThemes(context: vscode.ExtensionContext): ThemeSettings[] {
-    const raw = context.globalState.get<unknown>(CUSTOM_THEMES_STATE_KEY);
-    if (!Array.isArray(raw)) {
-        return [];
-    }
+  const raw = context.globalState.get<unknown>(CUSTOM_THEMES_STATE_KEY);
+  if (!Array.isArray(raw)) {
+    return [];
+  }
 
-    const themesById = new Map<string, ThemeSettings>();
-    for (const item of raw) {
-        const validated = validateThemePayload(item);
-        if (!validated.success) {
-            continue;
-        }
-        themesById.set(normalizeThemeId(validated.theme.id), validated.theme);
+  const themesById = new Map<string, ThemeSettings>();
+  for (const item of raw) {
+    const validated = validateThemePayload(item);
+    if (!validated.success) {
+      continue;
     }
+    themesById.set(normalizeThemeId(validated.theme.id), validated.theme);
+  }
 
-    return Array.from(themesById.values()).sort((a, b) => a.name.localeCompare(b.name));
+  return Array.from(themesById.values())
+    .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 async function upsertImportedTheme(context: vscode.ExtensionContext, theme: ThemeSettings): Promise<void> {
-    const importedThemes = getImportedThemes(context);
-    const existingIndex = importedThemes.findIndex((item) => normalizeThemeId(item.id) === normalizeThemeId(theme.id));
-    if (existingIndex >= 0) {
-        importedThemes[existingIndex] = theme;
-    } else {
-        importedThemes.push(theme);
-    }
+  const importedThemes = getImportedThemes(context);
+  const existingIndex = importedThemes.findIndex((item) => normalizeThemeId(item.id) === normalizeThemeId(theme.id));
+  if (existingIndex >= 0) {
+    importedThemes[existingIndex] = theme;
+  } else {
+    importedThemes.push(theme);
+  }
 
-    importedThemes.sort((a, b) => a.name.localeCompare(b.name));
-    await context.globalState.update(
-        CUSTOM_THEMES_STATE_KEY,
-        importedThemes.map((item) => serializeThemeSettings(item)),
-    );
+  importedThemes.sort((a, b) => a.name.localeCompare(b.name));
+  await context.globalState.update(
+    CUSTOM_THEMES_STATE_KEY,
+    importedThemes.map((item) => serializeThemeSettings(item))
+  );
 }
 
 async function deleteImportedThemeById(context: vscode.ExtensionContext, themeId: string): Promise<boolean> {
-    const normalizedThemeId = normalizeThemeId(themeId);
-    const importedThemes = getImportedThemes(context);
-    const nextImportedThemes = importedThemes.filter((item) => normalizeThemeId(item.id) !== normalizedThemeId);
+  const normalizedThemeId = normalizeThemeId(themeId);
+  const importedThemes = getImportedThemes(context);
+  const nextImportedThemes = importedThemes.filter((item) => normalizeThemeId(item.id) !== normalizedThemeId);
 
-    if (nextImportedThemes.length === importedThemes.length) {
-        return false;
-    }
+  if (nextImportedThemes.length === importedThemes.length) {
+    return false;
+  }
 
-    await context.globalState.update(
-        CUSTOM_THEMES_STATE_KEY,
-        nextImportedThemes.map((item) => serializeThemeSettings(item)),
-    );
-    return true;
+  await context.globalState.update(
+    CUSTOM_THEMES_STATE_KEY,
+    nextImportedThemes.map((item) => serializeThemeSettings(item))
+  );
+  return true;
 }
 
 function isBuiltInThemeId(themeId: string): boolean {
-    const normalizedThemeId = normalizeThemeId(themeId);
-    return themePresets.some((item) => normalizeThemeId(item.id) === normalizedThemeId);
+  const normalizedThemeId = normalizeThemeId(themeId);
+  return themePresets.some((item) => normalizeThemeId(item.id) === normalizedThemeId);
 }
 
 function normalizeThemeId(id: string): string {
-    return id.trim().toLowerCase();
+  return id.trim().toLowerCase();
 }
 
 export function deactivate(): void {}

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -1,1177 +1,1256 @@
-import * as path from "node:path";
-import * as vscode from "vscode";
-import type { AgentReviewHandoffController } from "../agents/reviewHandoff";
-import { EXTENSION_CONFIG_SECTION, LINE_NUMBERS_SETTING_KEY, GIT_CHANGES_GUTTER_SETTING_KEY, getLineNumbersEnabled, getGitChangesGutterEnabled, getGitDiffLineHighlightsEnabled, getOutlinePosition, getOutlineVisible, getRememberPositionLines, getThemeSettings, getVimModeEnabled, getVimKeybindings, getVimLeaderKey, type VimKeybinding } from "../shared/extensionConfig";
-import { openLink, resolveLocalLinkTargets, resolveWebviewImageSrc, resolveWikiLinkTargets } from "../shared/documentLinks";
-import { GitDocumentState, hashGitBaselinePayload } from "../git/documentState";
-import { openGitRevisionForLine, openGitWorktreeForLine, resolveGitBlameForRequest } from "../git/blameActions";
-import type { GitBaselinePayload, GitBlameLineResult } from "../git/types";
-import type { ExportStyleEnvironment } from "../export/runtime";
-import type { ThemeSettings } from "../shared/themeDefaults";
-import type { OutlinePosition } from "../shared/extensionConfig";
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import type { AgentReviewHandoffController } from '../agents/reviewHandoff';
+import {
+  EXTENSION_CONFIG_SECTION,
+  LINE_NUMBERS_SETTING_KEY,
+  GIT_CHANGES_GUTTER_SETTING_KEY,
+  getLineNumbersEnabled,
+  getGitChangesGutterEnabled,
+  getGitDiffLineHighlightsEnabled,
+  getOutlinePosition,
+  getOutlineVisible,
+  getRememberPositionLines,
+  getThemeSettings,
+  getVimKeybindings,
+  getVimLeaderKey,
+  getVimModeEnabled,
+  type VimKeybinding
+} from '../shared/extensionConfig';
+import { openLink, resolveLocalLinkTargets, resolveWebviewImageSrc, resolveWikiLinkTargets } from '../shared/documentLinks';
+import { GitDocumentState, hashGitBaselinePayload } from '../git/documentState';
+import { openGitRevisionForLine, openGitWorktreeForLine, resolveGitBlameForRequest } from '../git/blameActions';
+import type { GitBaselinePayload, GitBlameLineResult } from '../git/types';
+import type { ExportStyleEnvironment } from '../export/runtime';
+import type { ThemeSettings } from '../shared/themeDefaults';
+import type { OutlinePosition } from '../shared/extensionConfig';
 
-export type EditorMode = "live" | "source";
-export type ExportFormat = "html" | "pdf";
+export type EditorMode = 'live' | 'source';
+export type ExportFormat = 'html' | 'pdf';
 
 type FindOptions = {
-    wholeWord: boolean;
-    caseSensitive: boolean;
+  wholeWord: boolean;
+  caseSensitive: boolean;
 };
 
 type InitMessage = {
-    type: "init";
-    text: string;
-    version: number;
-    mode: EditorMode;
-    lineNumbers: boolean;
-    gitChangesGutter: boolean;
-    gitDiffLineHighlights: boolean;
-    vimMode: boolean;
-    vimKeybindings: VimKeybinding[];
-    vimLeader: string;
-    findOptions: FindOptions;
-    outlinePosition: OutlinePosition;
-    outlineVisible: boolean;
-    theme: ThemeSettings;
-    restoreTopLine?: number;
-    restoreTopLineOffset?: number;
+  type: 'init';
+  text: string;
+  version: number;
+  mode: EditorMode;
+  lineNumbers: boolean;
+  gitChangesGutter: boolean;
+  gitDiffLineHighlights: boolean;
+  vimMode: boolean;
+  vimKeybindings: VimKeybinding[];
+  vimLeader: string;
+  findOptions: FindOptions;
+  outlinePosition: OutlinePosition;
+  outlineVisible: boolean;
+  theme: ThemeSettings;
+  restoreTopLine?: number;
+  restoreTopLineOffset?: number;
 };
 
 type DocChangedMessage = {
-    type: "docChanged";
-    text: string;
-    version: number;
+  type: 'docChanged';
+  text: string;
+  version: number;
 };
 
 type AppliedMessage = {
-    type: "applied";
-    version: number;
+  type: 'applied';
+  version: number;
 };
 
 type RevealSelectionMessage = {
-    type: "revealSelection";
-    anchor: number;
-    head: number;
-    focus?: boolean;
+  type: 'revealSelection';
+  anchor: number;
+  head: number;
+  focus?: boolean;
 };
 
 type FocusEditorMessage = {
-    type: "focusEditor";
+  type: 'focusEditor';
 };
 
 type RevealSelectionPayload = {
-    anchor: number;
-    head: number;
+  anchor: number;
+  head: number;
 };
 
 type ApplyChangesMessage = {
-    type: "applyChanges";
-    baseVersion: number;
-    changes: Array<{ from: number; to: number; insert: string }>;
+  type: 'applyChanges';
+  baseVersion: number;
+  changes: Array<{ from: number; to: number; insert: string }>;
 };
 
 type DraftChangedMessage = {
-    type: "draftChanged";
-    text: string | null;
+  type: 'draftChanged';
+  text: string | null;
 };
 
 type SetModeMessage = {
-    type: "setMode";
-    mode: EditorMode;
+  type: 'setMode';
+  mode: EditorMode;
 };
 
 type OpenLinkMessage = {
-    type: "openLink";
-    href: string;
+  type: 'openLink';
+  href: string;
 };
 
 type ResolveImageSrcMessage = {
-    type: "resolveImageSrc";
-    requestId: string;
-    url: string;
+  type: 'resolveImageSrc';
+  requestId: string;
+  url: string;
 };
 
 type ResolveWikiLinksMessage = {
-    type: "resolveWikiLinks";
-    requestId: string;
-    targets: string[];
+  type: 'resolveWikiLinks';
+  requestId: string;
+  targets: string[];
 };
 
 type ResolveLocalLinksMessage = {
-    type: "resolveLocalLinks";
-    requestId: string;
-    targets: string[];
+  type: 'resolveLocalLinks';
+  requestId: string;
+  targets: string[];
 };
 
 type SaveDocumentMessage = {
-    type: "saveDocument";
+  type: 'saveDocument';
 };
 
 type ExportDocumentMessage = {
-    type: "exportDocument";
-    format: ExportFormat;
+  type: 'exportDocument';
+  format: ExportFormat;
 };
 
 type ExportSnapshotMessage = {
-    type: "exportSnapshot";
-    requestId: string;
-    text: string;
-    environment?: ExportStyleEnvironment;
+  type: 'exportSnapshot';
+  requestId: string;
+  text: string;
+  environment?: ExportStyleEnvironment;
 };
 
 type ExportSnapshotErrorMessage = {
-    type: "exportSnapshotError";
-    requestId: string;
-    message: string;
+  type: 'exportSnapshotError';
+  requestId: string;
+  message: string;
 };
 
 type SetLineNumbersMessage = {
-    type: "setLineNumbers";
-    visible?: boolean;
-    enabled?: boolean;
+  type: 'setLineNumbers';
+  visible?: boolean;
+  enabled?: boolean;
 };
 
 type SetGitChangesGutterMessage = {
-    type: "setGitChangesGutter";
-    visible?: boolean;
-    enabled?: boolean;
+  type: 'setGitChangesGutter';
+  visible?: boolean;
+  enabled?: boolean;
 };
 
 type SetOutlineVisibleMessage = {
-    type: "setOutlineVisible";
-    visible: boolean;
+  type: 'setOutlineVisible';
+  visible: boolean;
 };
 
 type SetFindOptionsMessage = {
-    type: "setFindOptions";
-    wholeWord?: boolean;
-    caseSensitive?: boolean;
-    findOptions?: Partial<FindOptions>;
+  type: 'setFindOptions';
+  wholeWord?: boolean;
+  caseSensitive?: boolean;
+  findOptions?: Partial<FindOptions>;
 };
 
 type ViewPositionChangedMessage = {
-    type: "viewPositionChanged";
-    topLine: number;
-    topLineOffset?: number;
+  type: 'viewPositionChanged';
+  topLine: number;
+  topLineOffset?: number;
 };
 
 type ResolvedImageSrcMessage = {
-    type: "resolvedImageSrc";
-    requestId: string;
-    resolvedUrl: string;
+  type: 'resolvedImageSrc';
+  requestId: string;
+  resolvedUrl: string;
 };
 
 type ResolvedWikiLinksMessage = {
-    type: "resolvedWikiLinks";
-    requestId: string;
-    results: Array<{ target: string; exists: boolean }>;
+  type: 'resolvedWikiLinks';
+  requestId: string;
+  results: Array<{ target: string; exists: boolean }>;
 };
 
 type ResolvedLocalLinksMessage = {
-    type: "resolvedLocalLinks";
-    requestId: string;
-    results: Array<{ target: string; exists: boolean }>;
+  type: 'resolvedLocalLinks';
+  requestId: string;
+  results: Array<{ target: string; exists: boolean }>;
 };
 
 type RequestExportSnapshotMessage = {
-    type: "requestExportSnapshot";
-    requestId: string;
+  type: 'requestExportSnapshot';
+  requestId: string;
 };
 
 type RequestGitBlameMessage = {
-    type: "requestGitBlame";
-    requestId: string;
-    lineNumber: number;
-    text?: string;
-    localEditGeneration: number;
+  type: 'requestGitBlame';
+  requestId: string;
+  lineNumber: number;
+  text?: string;
+  localEditGeneration: number;
 };
 
 type OpenGitRevisionForLineMessage = {
-    type: "openGitRevisionForLine";
-    lineNumber: number;
-    text?: string;
+  type: 'openGitRevisionForLine';
+  lineNumber: number;
+  text?: string;
 };
 
 type OpenGitWorktreeForLineMessage = {
-    type: "openGitWorktreeForLine";
-    lineNumber: number;
-    text?: string;
+  type: 'openGitWorktreeForLine';
+  lineNumber: number;
+  text?: string;
 };
 
 type SaveImageFromClipboardMessage = {
-    type: "saveImageFromClipboard";
-    requestId: string;
-    imageData: string;
-    fileName: string;
+  type: 'saveImageFromClipboard';
+  requestId: string;
+  imageData: string;
+  fileName: string;
 };
 
 type SavedImagePathMessage = {
-    type: "savedImagePath";
-    requestId: string;
-    success: boolean;
-    path?: string;
-    error?: string;
+  type: 'savedImagePath';
+  requestId: string;
+  success: boolean;
+  path?: string;
+  error?: string;
 };
 
 type GitBaselineChangedMessage = {
-    type: "gitBaselineChanged";
-    version: number;
-    payload: GitBaselinePayload;
+  type: 'gitBaselineChanged';
+  version: number;
+  payload: GitBaselinePayload;
 };
 
 type GitBlameResultMessage = {
-    type: "gitBlameResult";
-    requestId: string;
-    lineNumber: number;
-    localEditGeneration: number;
-    result: GitBlameLineResult;
+  type: 'gitBlameResult';
+  requestId: string;
+  lineNumber: number;
+  localEditGeneration: number;
+  result: GitBlameLineResult;
 };
 
-type WebviewMessage = ApplyChangesMessage | DraftChangedMessage | SetModeMessage | SetLineNumbersMessage | SetGitChangesGutterMessage | SetOutlineVisibleMessage | SetFindOptionsMessage | ViewPositionChangedMessage | OpenLinkMessage | ResolveImageSrcMessage | ResolveWikiLinksMessage | ResolveLocalLinksMessage | SaveDocumentMessage | ExportDocumentMessage | ExportSnapshotMessage | ExportSnapshotErrorMessage | RequestGitBlameMessage | OpenGitRevisionForLineMessage | OpenGitWorktreeForLineMessage | SaveImageFromClipboardMessage | { type: "ready" };
+type WebviewMessage =
+  | ApplyChangesMessage
+  | DraftChangedMessage
+  | SetModeMessage
+  | SetLineNumbersMessage
+  | SetGitChangesGutterMessage
+  | SetOutlineVisibleMessage
+  | SetFindOptionsMessage
+  | ViewPositionChangedMessage
+  | OpenLinkMessage
+  | ResolveImageSrcMessage
+  | ResolveWikiLinksMessage
+  | ResolveLocalLinksMessage
+  | SaveDocumentMessage
+  | ExportDocumentMessage
+  | ExportSnapshotMessage
+  | ExportSnapshotErrorMessage
+  | RequestGitBlameMessage
+  | OpenGitRevisionForLineMessage
+  | OpenGitWorktreeForLineMessage
+  | SaveImageFromClipboardMessage
+  | { type: 'ready' };
 
 type RefreshGitBaselineOptions = {
-    forcePost?: boolean;
-    forceReload?: boolean;
+  forcePost?: boolean;
+  forceReload?: boolean;
 };
 
 type PendingExportSnapshot = {
-    resolve: (value: { text: string; environment?: ExportStyleEnvironment }) => void;
-    reject: (error: Error) => void;
-    timer: ReturnType<typeof setTimeout>;
+  resolve: (value: { text: string; environment?: ExportStyleEnvironment }) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
 };
 
 type RememberedViewPosition = {
-    line: number;
-    lineOffset: number;
-    updatedAt: number;
+  line: number;
+  lineOffset: number;
+  updatedAt: number;
 };
 
-const REMEMBERED_VIEW_POSITIONS_STATE_KEY = "rememberedViewPositionsByDocument";
+const REMEMBERED_VIEW_POSITIONS_STATE_KEY = 'rememberedViewPositionsByDocument';
 const MAX_REMEMBERED_VIEW_POSITIONS = 300;
 const REMEMBERED_EOF_NEAR_THRESHOLD_LINES = 10;
 const REMEMBERED_EOF_BACKOFF_LINES = 10;
 
 type PanelSessionControllerParams = {
-    panel: vscode.WebviewPanel;
-    document: vscode.TextDocument;
-    documentUri: vscode.Uri;
-    context: vscode.ExtensionContext;
-    agentReviewHandoff: AgentReviewHandoffController;
-    onExportDocument: (session: PanelSession, format: ExportFormat) => Promise<void>;
-    getFindOptions: () => FindOptions;
-    setFindOptions: (options: FindOptions) => Promise<void>;
-    setOutlineVisible: (visible: boolean) => Promise<void>;
-    onPanelActivated: (panel: vscode.WebviewPanel) => void;
-    onPanelViewStateChanged: () => void;
-    onPanelDisposed: (panel: vscode.WebviewPanel) => void;
+  panel: vscode.WebviewPanel;
+  document: vscode.TextDocument;
+  documentUri: vscode.Uri;
+  context: vscode.ExtensionContext;
+  agentReviewHandoff: AgentReviewHandoffController;
+  onExportDocument: (session: PanelSession, format: ExportFormat) => Promise<void>;
+  getFindOptions: () => FindOptions;
+  setFindOptions: (options: FindOptions) => Promise<void>;
+  setOutlineVisible: (visible: boolean) => Promise<void>;
+  onPanelActivated: (panel: vscode.WebviewPanel) => void;
+  onPanelViewStateChanged: () => void;
+  onPanelDisposed: (panel: vscode.WebviewPanel) => void;
 };
 
 export type PanelSession = {
-    panel: vscode.WebviewPanel;
-    document: vscode.TextDocument;
-    documentUri: vscode.Uri;
-    gitDocumentState: GitDocumentState;
-    getMode: () => EditorMode;
-    ensureInitDelivered: () => Promise<void>;
-    requestExportSnapshot: () => Promise<{ text: string; environment?: ExportStyleEnvironment }>;
-    rejectPendingExportSnapshots: (reason: Error) => void;
-    refreshGitBaseline: (options?: RefreshGitBaselineOptions) => void;
-    getGitRepoRoot: () => string | null;
+  panel: vscode.WebviewPanel;
+  document: vscode.TextDocument;
+  documentUri: vscode.Uri;
+  gitDocumentState: GitDocumentState;
+  getMode: () => EditorMode;
+  ensureInitDelivered: () => Promise<void>;
+  requestExportSnapshot: () => Promise<{ text: string; environment?: ExportStyleEnvironment }>;
+  rejectPendingExportSnapshots: (reason: Error) => void;
+  refreshGitBaseline: (options?: RefreshGitBaselineOptions) => void;
+  getGitRepoRoot: () => string | null;
 };
 
 export type PanelSessionController = {
-    session: PanelSession;
-    handleMessage: (raw: WebviewMessage) => Promise<void>;
-    dispose: () => void;
+  session: PanelSession;
+  handleMessage: (raw: WebviewMessage) => Promise<void>;
+  dispose: () => void;
 };
 
 export function createPanelSessionController(params: PanelSessionControllerParams): PanelSessionController {
-    const { panel, document, documentUri, context, agentReviewHandoff, onExportDocument, getFindOptions, setFindOptions, setOutlineVisible, onPanelActivated, onPanelViewStateChanged, onPanelDisposed } = params;
+  const {
+    panel,
+    document,
+    documentUri,
+    context,
+    agentReviewHandoff,
+    onExportDocument,
+    getFindOptions,
+    setFindOptions,
+    setOutlineVisible,
+    onPanelActivated,
+    onPanelViewStateChanged,
+    onPanelDisposed
+  } = params;
 
-    const documentKey = document.uri.toString();
-    let mode: EditorMode = "live";
-    let applyQueue: Promise<void> = Promise.resolve();
-    let webviewReady = false;
-    let initDelivered = false;
-    let isApplyingOwnChange = false;
-    let gitRefreshRunning = false;
-    let gitRefreshPending = false;
-    let gitRefreshPendingForcePost = false;
-    let gitRefreshPendingForceReload = false;
-    let lastSentRevealSelectionKey: string | null = null;
-    let pendingRevealSelection: RevealSelectionPayload | null = null;
-    let pendingRestoreTopLine: number | null = null;
-    let pendingRestoreTopLineOffset = 0;
-    let pendingDraftText: string | null = null;
-    let lastSavedRememberedLine: number | null = null;
-    let lastSavedRememberedLineOffset = 0;
-    let disposed = false;
-    const workspaceRoot = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
-    const gitDocumentState = new GitDocumentState(documentUri.fsPath, workspaceRoot);
-    const pendingExportSnapshots = new Map<string, PendingExportSnapshot>();
+  const documentKey = document.uri.toString();
+  let mode: EditorMode = 'live';
+  let applyQueue: Promise<void> = Promise.resolve();
+  let webviewReady = false;
+  let initDelivered = false;
+  let isApplyingOwnChange = false;
+  let gitRefreshRunning = false;
+  let gitRefreshPending = false;
+  let gitRefreshPendingForcePost = false;
+  let gitRefreshPendingForceReload = false;
+  let lastSentRevealSelectionKey: string | null = null;
+  let pendingRevealSelection: RevealSelectionPayload | null = null;
+  let pendingRestoreTopLine: number | null = null;
+  let pendingRestoreTopLineOffset = 0;
+  let pendingDraftText: string | null = null;
+  let lastSavedRememberedLine: number | null = null;
+  let lastSavedRememberedLineOffset = 0;
+  let disposed = false;
+  const workspaceRoot = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
+  const gitDocumentState = new GitDocumentState(documentUri.fsPath, workspaceRoot);
+  const pendingExportSnapshots = new Map<string, PendingExportSnapshot>();
 
-    const enqueue = (task: () => Promise<void>): Promise<void> => {
-        applyQueue = applyQueue.then(task, task);
-        return applyQueue;
-    };
+  const enqueue = (task: () => Promise<void>): Promise<void> => {
+    applyQueue = applyQueue.then(task, task);
+    return applyQueue;
+  };
 
-    const reportBackgroundError = (contextLabel: string, error: unknown): void => {
-        if (disposed) {
-            return;
-        }
-        console.error(`[MEO panelSession] ${contextLabel}`, error);
-    };
-
-    const runBackground = (promise: Promise<unknown>, contextLabel: string): void => {
-        void promise.catch((error) => {
-            reportBackgroundError(contextLabel, error);
-        });
-    };
-
-    const postToWebview = async (message: Record<string, unknown>): Promise<boolean> => {
-        if (disposed) {
-            return false;
-        }
-        try {
-            return await panel.webview.postMessage(message);
-        } catch {
-            return false;
-        }
-    };
-
-    const applyPendingDraftIfNeeded = async (): Promise<boolean> => {
-        const draftText = pendingDraftText;
-        pendingDraftText = null;
-        if (draftText === null) {
-            return false;
-        }
-
-        const currentText = document.getText();
-        const normalizedCurrent = currentText.replace(/\r\n/g, "\n");
-        const normalizedDraft = draftText.replace(/\r\n/g, "\n");
-        if (normalizedCurrent === normalizedDraft) {
-            return false;
-        }
-
-        const edit = new vscode.WorkspaceEdit();
-        const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(currentText.length));
-        agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
-        edit.replace(document.uri, fullRange, draftText);
-        return vscode.workspace.applyEdit(edit);
-    };
-
-    const clearRememberedViewPosition = async (): Promise<void> => {
-        const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
-        if (!(documentKey in rememberedPositions)) {
-            return;
-        }
-        delete rememberedPositions[documentKey];
-        await context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, rememberedPositions);
-        lastSavedRememberedLine = null;
-        lastSavedRememberedLineOffset = 0;
-    };
-
-    const saveRememberedViewPosition = async (topLine: number, topLineOffset: number | undefined): Promise<void> => {
-        const minLines = getRememberPositionLines();
-        if (document.lineCount < minLines) {
-            await clearRememberedViewPosition();
-            return;
-        }
-
-        const normalizedRemembered = normalizeRememberedTopLine(topLine, topLineOffset, document.lineCount);
-        const clampedLine = normalizedRemembered.line;
-        const normalizedOffset = normalizedRemembered.lineOffset;
-        if (lastSavedRememberedLine === clampedLine && lastSavedRememberedLineOffset === normalizedOffset) {
-            return;
-        }
-
-        const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
-        const existing = rememberedPositions[documentKey];
-        if (existing?.line === clampedLine && existing.lineOffset === normalizedOffset) {
-            lastSavedRememberedLine = clampedLine;
-            lastSavedRememberedLineOffset = normalizedOffset;
-            return;
-        }
-
-        rememberedPositions[documentKey] = {
-            line: clampedLine,
-            lineOffset: normalizedOffset,
-            updatedAt: Date.now(),
-        };
-
-        await context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, pruneRememberedViewPositionMap(rememberedPositions));
-        lastSavedRememberedLine = clampedLine;
-        lastSavedRememberedLineOffset = normalizedOffset;
-    };
-
-    const sendInit = async (): Promise<boolean> => {
-        const message: InitMessage = {
-            type: "init",
-            text: document.getText(),
-            version: document.version,
-            mode,
-            lineNumbers: getLineNumbersEnabled(context),
-            gitChangesGutter: getGitChangesGutterEnabled(context),
-            gitDiffLineHighlights: getGitDiffLineHighlightsEnabled(),
-            vimMode: getVimModeEnabled(context),
-            vimKeybindings: getVimKeybindings(),
-            vimLeader: getVimLeaderKey(),
-            findOptions: getFindOptions(),
-            outlinePosition: getOutlinePosition(),
-            outlineVisible: getOutlineVisible(context),
-            theme: getThemeSettings(),
-            restoreTopLine: pendingRestoreTopLine ?? undefined,
-            restoreTopLineOffset: pendingRestoreTopLine === null ? undefined : pendingRestoreTopLineOffset,
-        };
-        return postToWebview(message);
-    };
-
-    const sendDocChanged = async (): Promise<boolean> => {
-        const message: DocChangedMessage = {
-            type: "docChanged",
-            text: document.getText(),
-            version: document.version,
-        };
-        return postToWebview(message);
-    };
-
-    const sendApplied = async (version: number): Promise<boolean> => {
-        const message: AppliedMessage = {
-            type: "applied",
-            version,
-        };
-        return postToWebview(message);
-    };
-
-    const sendGitBaselineChanged = async (options: RefreshGitBaselineOptions = {}): Promise<boolean> => {
-        if (!initDelivered) {
-            return false;
-        }
-
-        const payload = await gitDocumentState.resolveBaseline({
-            includeText: true,
-            force: options.forceReload === true,
-        });
-        gitDocumentState.noteBaselinePayload(payload);
-        const payloadHash = hashGitBaselinePayload(payload);
-        if (!options.forcePost && payloadHash === gitDocumentState.getLastSentBaselineHash()) {
-            return true;
-        }
-
-        const message: GitBaselineChangedMessage = {
-            type: "gitBaselineChanged",
-            version: document.version,
-            payload,
-        };
-        const posted = await postToWebview(message);
-        if (posted) {
-            gitDocumentState.setLastSentBaselineHash(payloadHash);
-        }
-        return posted;
-    };
-
-    const parseRevealOffsetFromUriFragment = (uri: vscode.Uri): number | null => {
-        const fragment = uri.fragment?.trim() ?? "";
-        if (!fragment) {
-            return null;
-        }
-
-        const match = /^(?:L)?(\d+)(?:(?:,|:|C)(\d+))?$/i.exec(fragment);
-        if (!match) {
-            return null;
-        }
-
-        const lineNumber = Number.parseInt(match[1], 10);
-        if (!Number.isFinite(lineNumber) || lineNumber < 1) {
-            return null;
-        }
-        const clampedLine = Math.min(lineNumber, document.lineCount);
-        const line = document.lineAt(clampedLine - 1);
-
-        const oneBasedColumn = match[2] ? Number.parseInt(match[2], 10) : 1;
-        const zeroBasedColumn = Number.isFinite(oneBasedColumn) && oneBasedColumn > 0 ? oneBasedColumn - 1 : 0;
-        const targetCharacter = Math.min(line.range.end.character, Math.max(0, zeroBasedColumn));
-        return document.offsetAt(new vscode.Position(clampedLine - 1, targetCharacter));
-    };
-
-    const ensureInitDelivered = async (): Promise<void> => {
-        if (disposed || initDelivered || !webviewReady) {
-            return;
-        }
-        const posted = await sendInit();
-        if (posted) {
-            initDelivered = true;
-        }
-    };
-
-    const requestExportSnapshot = async (): Promise<{ text: string; environment?: ExportStyleEnvironment }> => {
-        await ensureInitDelivered();
-        if (disposed) {
-            throw new Error("The editor was closed before export completed.");
-        }
-        const requestId = `export-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-
-        const response = new Promise<{ text: string; environment?: ExportStyleEnvironment }>((resolve, reject) => {
-            const timer = setTimeout(() => {
-                pendingExportSnapshots.delete(requestId);
-                reject(new Error("Timed out waiting for export snapshot from the editor."));
-            }, 20000);
-
-            pendingExportSnapshots.set(requestId, { resolve, reject, timer });
-        });
-
-        const message: RequestExportSnapshotMessage = {
-            type: "requestExportSnapshot",
-            requestId,
-        };
-        const posted = await postToWebview(message);
-        if (!posted) {
-            rejectPendingExportSnapshot(requestId, new Error("The editor webview is not ready to export."));
-        }
-
-        return response;
-    };
-
-    const rejectPendingExportSnapshot = (requestId: string, error: Error): void => {
-        const pending = pendingExportSnapshots.get(requestId);
-        if (!pending) {
-            return;
-        }
-        clearTimeout(pending.timer);
-        pendingExportSnapshots.delete(requestId);
-        pending.reject(error);
-    };
-
-    const resolvePendingExportSnapshot = (requestId: string, value: { text: string; environment?: ExportStyleEnvironment }): void => {
-        const pending = pendingExportSnapshots.get(requestId);
-        if (!pending) {
-            return;
-        }
-        clearTimeout(pending.timer);
-        pendingExportSnapshots.delete(requestId);
-        pending.resolve(value);
-    };
-
-    const rejectPendingExportSnapshots = (error: Error): void => {
-        for (const requestId of pendingExportSnapshots.keys()) {
-            rejectPendingExportSnapshot(requestId, error);
-        }
-    };
-
-    const runPendingGitRefreshes = async (): Promise<void> => {
-        if (gitRefreshRunning || !webviewReady) {
-            return;
-        }
-        gitRefreshRunning = true;
-        try {
-            while (gitRefreshPending) {
-                const nextOptions: RefreshGitBaselineOptions = {
-                    forcePost: gitRefreshPendingForcePost,
-                    forceReload: gitRefreshPendingForceReload,
-                };
-                gitRefreshPending = false;
-                gitRefreshPendingForcePost = false;
-                gitRefreshPendingForceReload = false;
-                try {
-                    await ensureInitDelivered();
-                    if (!initDelivered) {
-                        gitRefreshPending = true;
-                        gitRefreshPendingForcePost = gitRefreshPendingForcePost || nextOptions.forcePost === true;
-                        gitRefreshPendingForceReload = gitRefreshPendingForceReload || nextOptions.forceReload === true;
-                        return;
-                    }
-                    await sendGitBaselineChanged(nextOptions);
-                } catch {
-                    // Keep refresh coalescing alive across transient git/webview failures.
-                }
-            }
-        } finally {
-            gitRefreshRunning = false;
-            if (gitRefreshPending) {
-                runBackground(runPendingGitRefreshes(), "runPendingGitRefreshes.retry");
-            }
-        }
-    };
-
-    const refreshGitBaseline = (options: RefreshGitBaselineOptions = {}): void => {
-        if (options.forceReload) {
-            gitDocumentState.invalidate();
-        }
-        gitRefreshPending = true;
-        gitRefreshPendingForcePost = gitRefreshPendingForcePost || options.forcePost === true;
-        gitRefreshPendingForceReload = gitRefreshPendingForceReload || options.forceReload === true;
-        runBackground(runPendingGitRefreshes(), "runPendingGitRefreshes");
-    };
-
-    const isTextEditorForDocument = (textEditor: vscode.TextEditor | undefined): textEditor is vscode.TextEditor => {
-        if (!textEditor) {
-            return false;
-        }
-        return textEditor.document.uri.toString() === documentKey;
-    };
-
-    const revealSelectionForTextEditor = (textEditor: vscode.TextEditor): RevealSelectionPayload => {
-        const anchor = textEditor.document.offsetAt(textEditor.selection.start);
-        const head = textEditor.document.offsetAt(textEditor.selection.end);
-        return { anchor, head };
-    };
-
-    const getRevealSelectionKey = (selection: RevealSelectionPayload): string => {
-        return `${selection.anchor}:${selection.head}`;
-    };
-
-    const postRevealSelection = async (selection: RevealSelectionPayload): Promise<void> => {
-        if (!webviewReady) {
-            pendingRevealSelection = selection;
-            return;
-        }
-        await ensureInitDelivered();
-        if (!initDelivered) {
-            pendingRevealSelection = selection;
-            return;
-        }
-        const message: RevealSelectionMessage = {
-            type: "revealSelection",
-            anchor: selection.anchor,
-            head: selection.head,
-        };
-        const posted = await postToWebview(message);
-        if (posted) {
-            lastSentRevealSelectionKey = getRevealSelectionKey(selection);
-            pendingRevealSelection = null;
-        } else {
-            pendingRevealSelection = selection;
-        }
-    };
-
-    const flushPendingRevealSelection = async (): Promise<void> => {
-        if (pendingRevealSelection === null) {
-            return;
-        }
-        await postRevealSelection(pendingRevealSelection);
-    };
-
-    const postFocusEditor = async (): Promise<void> => {
-        if (!webviewReady) {
-            return;
-        }
-        await ensureInitDelivered();
-        if (!initDelivered) {
-            return;
-        }
-        const message: FocusEditorMessage = { type: "focusEditor" };
-        await postToWebview(message);
-    };
-
-    const sendRevealSelectionForEditor = async (textEditor: vscode.TextEditor | undefined): Promise<void> => {
-        if (!isTextEditorForDocument(textEditor)) {
-            return;
-        }
-
-        const selection = revealSelectionForTextEditor(textEditor);
-        if (lastSentRevealSelectionKey === getRevealSelectionKey(selection)) {
-            return;
-        }
-        await postRevealSelection(selection);
-    };
-
-    const findEditorForDocumentReveal = (): vscode.TextEditor | undefined => {
-        const active = vscode.window.activeTextEditor;
-        if (isTextEditorForDocument(active)) {
-            return active;
-        }
-        return vscode.window.visibleTextEditors.find((editor) => isTextEditorForDocument(editor));
-    };
-
-    const resolveRememberedTopLineForInit = (): { line: number; lineOffset: number } | null => {
-        const minLines = getRememberPositionLines();
-        if (document.lineCount < minLines) {
-            runBackground(clearRememberedViewPosition(), "clearRememberedViewPosition.initThreshold");
-            return null;
-        }
-
-        if (pendingRevealSelection !== null) {
-            return null;
-        }
-
-        const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
-        const remembered = rememberedPositions[documentKey];
-        if (!remembered) {
-            return null;
-        }
-
-        const normalizedRemembered = normalizeRememberedTopLine(remembered.line, remembered.lineOffset, document.lineCount);
-        const clampedLine = normalizedRemembered.line;
-        const lineOffset = normalizedRemembered.lineOffset;
-        if (normalizedRemembered.adjustedForEof && (remembered.line !== clampedLine || normalizeLineOffset(remembered.lineOffset) !== lineOffset)) {
-            rememberedPositions[documentKey] = {
-                line: clampedLine,
-                lineOffset,
-                updatedAt: Date.now(),
-            };
-            runBackground(context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, pruneRememberedViewPositionMap(rememberedPositions)), "saveRememberedViewPosition.eofBackoff");
-        }
-        lastSavedRememberedLine = clampedLine;
-        lastSavedRememberedLineOffset = lineOffset;
-        return {
-            line: clampedLine,
-            lineOffset,
-        };
-    };
-
-    const initialRevealEditor = findEditorForDocumentReveal();
-    if (initialRevealEditor) {
-        pendingRevealSelection = revealSelectionForTextEditor(initialRevealEditor);
-    } else {
-        const initialOffset = parseRevealOffsetFromUriFragment(document.uri);
-        pendingRevealSelection = initialOffset === null ? null : { anchor: initialOffset, head: initialOffset };
+  const reportBackgroundError = (contextLabel: string, error: unknown): void => {
+    if (disposed) {
+      return;
     }
-    const rememberedTopLine = resolveRememberedTopLineForInit();
-    if (rememberedTopLine) {
-        pendingRestoreTopLine = rememberedTopLine.line;
-        pendingRestoreTopLineOffset = rememberedTopLine.lineOffset;
+    console.error(`[MEO panelSession] ${contextLabel}`, error);
+  };
+
+  const runBackground = (promise: Promise<unknown>, contextLabel: string): void => {
+    void promise.catch((error) => {
+      reportBackgroundError(contextLabel, error);
+    });
+  };
+
+  const postToWebview = async (message: Record<string, unknown>): Promise<boolean> => {
+    if (disposed) {
+      return false;
+    }
+    try {
+      return await panel.webview.postMessage(message);
+    } catch {
+      return false;
+    }
+  };
+
+  const applyPendingDraftIfNeeded = async (): Promise<boolean> => {
+    const draftText = pendingDraftText;
+    pendingDraftText = null;
+    if (draftText === null) {
+      return false;
     }
 
-    const session: PanelSession = {
-        panel,
-        document,
-        documentUri,
-        gitDocumentState,
-        getMode: () => mode,
-        ensureInitDelivered,
-        requestExportSnapshot,
-        rejectPendingExportSnapshots,
-        refreshGitBaseline,
-        getGitRepoRoot: () => gitDocumentState.getRepoRoot(),
-    };
-
-    const handleMessage = async (raw: WebviewMessage): Promise<void> => {
-        if (disposed) {
-            return;
-        }
-        switch (raw.type) {
-            case "ready":
-                webviewReady = true;
-                await ensureInitDelivered();
-                await flushPendingRevealSelection();
-                gitRefreshPending = true;
-                gitRefreshPendingForcePost = true;
-                await runPendingGitRefreshes();
-                return;
-            case "setMode":
-                mode = raw.mode;
-                return;
-            case "setLineNumbers": {
-                const visible = raw.visible ?? raw.enabled;
-                if (typeof visible !== "boolean") {
-                    return;
-                }
-                await vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).update(LINE_NUMBERS_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
-                return;
-            }
-            case "setGitChangesGutter": {
-                const visible = raw.visible ?? raw.enabled;
-                if (typeof visible !== "boolean") {
-                    return;
-                }
-                await vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).update(GIT_CHANGES_GUTTER_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
-                return;
-            }
-            case "setOutlineVisible":
-                await setOutlineVisible(raw.visible);
-                return;
-            case "setFindOptions": {
-                const wholeWord = raw.findOptions?.wholeWord ?? raw.wholeWord;
-                const caseSensitive = raw.findOptions?.caseSensitive ?? raw.caseSensitive;
-                await setFindOptions({
-                    wholeWord: wholeWord === true,
-                    caseSensitive: caseSensitive === true,
-                });
-                return;
-            }
-            case "viewPositionChanged":
-                if (Number.isFinite(raw.topLine)) {
-                    await enqueue(async () => {
-                        await saveRememberedViewPosition(raw.topLine, raw.topLineOffset);
-                    });
-                }
-                return;
-            case "exportDocument":
-                await onExportDocument(session, raw.format);
-                return;
-            case "openLink":
-                await openLink(raw.href, documentUri);
-                return;
-            case "resolveImageSrc": {
-                const response: ResolvedImageSrcMessage = {
-                    type: "resolvedImageSrc",
-                    requestId: raw.requestId,
-                    resolvedUrl: resolveWebviewImageSrc(raw.url, documentUri, panel.webview),
-                };
-                await postToWebview(response);
-                return;
-            }
-            case "resolveWikiLinks": {
-                const response: ResolvedWikiLinksMessage = {
-                    type: "resolvedWikiLinks",
-                    requestId: raw.requestId,
-                    results: await resolveWikiLinkTargets(raw.targets, documentUri),
-                };
-                await postToWebview(response);
-                return;
-            }
-            case "resolveLocalLinks": {
-                const response: ResolvedLocalLinksMessage = {
-                    type: "resolvedLocalLinks",
-                    requestId: raw.requestId,
-                    results: await resolveLocalLinkTargets(raw.targets, documentUri),
-                };
-                await postToWebview(response);
-                return;
-            }
-            case "exportSnapshot":
-                resolvePendingExportSnapshot(raw.requestId, {
-                    text: raw.text,
-                    environment: raw.environment,
-                });
-                return;
-            case "exportSnapshotError":
-                rejectPendingExportSnapshot(raw.requestId, new Error(raw.message || "Failed to collect export snapshot."));
-                return;
-            case "requestGitBlame": {
-                const resolved = await resolveGitBlameForRequest(documentUri, raw, document.getText(), gitDocumentState);
-                const response: GitBlameResultMessage = {
-                    type: "gitBlameResult",
-                    requestId: raw.requestId,
-                    lineNumber: raw.lineNumber,
-                    localEditGeneration: raw.localEditGeneration,
-                    result: resolved.result,
-                };
-                await postToWebview(response);
-                return;
-            }
-            case "openGitRevisionForLine":
-                await openGitRevisionForLine(documentUri, raw, document.getText(), gitDocumentState);
-                return;
-            case "openGitWorktreeForLine":
-                await openGitWorktreeForLine(documentUri, raw, document.getText(), gitDocumentState);
-                return;
-            case "applyChanges":
-                agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
-                isApplyingOwnChange = true;
-                try {
-                    await enqueue(async () => {
-                        await applyDocumentChanges(document, raw, sendDocChanged, sendApplied);
-                    });
-                } finally {
-                    isApplyingOwnChange = false;
-                }
-                return;
-            case "draftChanged":
-                pendingDraftText = raw.text;
-                return;
-            case "saveDocument":
-                isApplyingOwnChange = true;
-                try {
-                    await enqueue(async () => {
-                        await document.save();
-                    });
-                } finally {
-                    isApplyingOwnChange = false;
-                }
-                return;
-            case "saveImageFromClipboard": {
-                const response = await handleSaveImageFromClipboard(raw, documentUri);
-                await postToWebview(response);
-                return;
-            }
-        }
-    };
-
-    const messageSubscription = panel.webview.onDidReceiveMessage((raw: WebviewMessage) => {
-        runBackground(handleMessage(raw), "handleMessage");
-    });
-
-    const documentChangeSubscription = vscode.workspace.onDidChangeTextDocument((event) => {
-        if (event.document.uri.toString() !== documentKey) {
-            return;
-        }
-
-        // Save/dirty-state transitions can emit document events without text edits.
-        if (event.contentChanges.length === 0) {
-            return;
-        }
-
-        if (isApplyingOwnChange) {
-            return;
-        }
-
-        runBackground(
-            enqueue(async () => {
-                await sendDocChanged();
-            }),
-            "sendDocChanged",
-        );
-    });
-
-    const documentSaveSubscription = vscode.workspace.onDidSaveTextDocument((savedDocument) => {
-        if (savedDocument.uri.toString() !== documentKey) {
-            return;
-        }
-        refreshGitBaseline({ forceReload: true });
-    });
-
-    const textEditorSelectionSubscription = vscode.window.onDidChangeTextEditorSelection((event) => {
-        if (!isTextEditorForDocument(event.textEditor)) {
-            return;
-        }
-        runBackground(sendRevealSelectionForEditor(event.textEditor), "sendRevealSelectionForEditor.selection");
-    });
-
-    const activeTextEditorSubscription = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
-        if (!isTextEditorForDocument(textEditor)) {
-            return;
-        }
-        runBackground(sendRevealSelectionForEditor(textEditor), "sendRevealSelectionForEditor.activeEditor");
-    });
-
-    const visibleTextEditorsSubscription = vscode.window.onDidChangeVisibleTextEditors(() => {
-        runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), "sendRevealSelectionForEditor.visibleEditors");
-    });
-
-    const viewStateSubscription = panel.onDidChangeViewState((event) => {
-        if (event.webviewPanel.active) {
-            onPanelActivated(event.webviewPanel);
-            refreshGitBaseline({ forcePost: true });
-            runBackground(flushPendingRevealSelection(), "flushPendingRevealSelection");
-            runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), "sendRevealSelectionForEditor.viewState");
-            runBackground(postFocusEditor(), "postFocusEditor");
-        }
-        onPanelViewStateChanged();
-    });
-
-    const disposeSubscription = panel.onDidDispose(() => {
-        dispose();
-    });
-
-    refreshGitBaseline({ forcePost: true });
-    runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), "sendRevealSelectionForEditor.startup");
-
-    const dispose = (): void => {
-        if (disposed) {
-            return;
-        }
-        disposed = true;
-
-        runBackground(
-            enqueue(async () => {
-                try {
-                    // Best-effort recovery for edits that never made it through the debounce/apply round-trip.
-                    await applyPendingDraftIfNeeded();
-                } catch {
-                    // Ignore dispose-time recovery failures to avoid surfacing noisy teardown errors.
-                }
-            }),
-            "disposeDraftRecovery",
-        );
-
-        rejectPendingExportSnapshots(new Error("The editor was closed before export completed."));
-        messageSubscription.dispose();
-        documentChangeSubscription.dispose();
-        documentSaveSubscription.dispose();
-        textEditorSelectionSubscription.dispose();
-        activeTextEditorSubscription.dispose();
-        visibleTextEditorsSubscription.dispose();
-        viewStateSubscription.dispose();
-        disposeSubscription.dispose();
-        onPanelDisposed(panel);
-    };
-
-    return {
-        session,
-        handleMessage,
-        dispose,
-    };
-}
-
-function clampLineNumber(value: number, maxLine: number): number {
-    const numeric = Number.isFinite(value) ? Math.floor(value) : 1;
-    const max = Math.max(1, Math.floor(maxLine));
-    return Math.max(1, Math.min(numeric, max));
-}
-
-function normalizeLineOffset(value: number | undefined): number {
-    const numeric = typeof value === "number" && Number.isFinite(value) ? value : 0;
-    return Math.max(0, Math.round(numeric * 100) / 100);
-}
-
-function normalizeRememberedTopLine(line: number, lineOffset: number | undefined, maxLine: number): { line: number; lineOffset: number; adjustedForEof: boolean } {
-    const clampedLine = clampLineNumber(line, maxLine);
-    const normalizedOffset = normalizeLineOffset(lineOffset);
-    const nearEndLine = Math.max(1, maxLine - REMEMBERED_EOF_NEAR_THRESHOLD_LINES + 1);
-    if (clampedLine < nearEndLine) {
-        return {
-            line: clampedLine,
-            lineOffset: normalizedOffset,
-            adjustedForEof: false,
-        };
-    }
-    return {
-        line: Math.max(1, clampedLine - REMEMBERED_EOF_BACKOFF_LINES),
-        lineOffset: 0,
-        adjustedForEof: true,
-    };
-}
-
-function getRememberedViewPositionMap(workspaceState: vscode.Memento): Record<string, RememberedViewPosition> {
-    const stored = workspaceState.get<unknown>(REMEMBERED_VIEW_POSITIONS_STATE_KEY);
-    if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
-        return {};
-    }
-
-    const entries: Record<string, RememberedViewPosition> = {};
-    for (const [key, value] of Object.entries(stored as Record<string, unknown>)) {
-        if (typeof key !== "string" || !key) {
-            continue;
-        }
-        if (!value || typeof value !== "object" || Array.isArray(value)) {
-            continue;
-        }
-        const record = value as Partial<RememberedViewPosition>;
-        const line = Number(record.line);
-        const lineOffset = Number(record.lineOffset);
-        const updatedAt = Number(record.updatedAt);
-        if (!Number.isFinite(line) || !Number.isFinite(updatedAt)) {
-            continue;
-        }
-        entries[key] = {
-            line: Math.max(1, Math.floor(line)),
-            lineOffset: normalizeLineOffset(lineOffset),
-            updatedAt: Math.floor(updatedAt),
-        };
-    }
-    return entries;
-}
-
-function pruneRememberedViewPositionMap(entries: Record<string, RememberedViewPosition>): Record<string, RememberedViewPosition> {
-    const sortedEntries = Object.entries(entries)
-        .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
-        .slice(0, MAX_REMEMBERED_VIEW_POSITIONS);
-    return Object.fromEntries(sortedEntries);
-}
-
-async function applyDocumentChanges(document: vscode.TextDocument, message: ApplyChangesMessage, sendDocChanged: () => Promise<boolean>, sendApplied: (version: number) => Promise<boolean>): Promise<void> {
-    if (message.baseVersion !== document.version) {
-        await sendDocChanged();
-        return;
+    const currentText = document.getText();
+    const normalizedCurrent = currentText.replace(/\r\n/g, '\n');
+    const normalizedDraft = draftText.replace(/\r\n/g, '\n');
+    if (normalizedCurrent === normalizedDraft) {
+      return false;
     }
 
     const edit = new vscode.WorkspaceEdit();
-    const sortedChanges = [...message.changes].sort((a, b) => b.from - a.from);
-    const documentText = document.getText();
-    const mappedOffsetCache = new Map<number, number>();
-    const mapOffset = (offset: number): number => {
-        const cached = mappedOffsetCache.get(offset);
-        if (typeof cached === "number") {
-            return cached;
-        }
-        const mapped = mapNormalizedOffsetToDocumentOffset(documentText, offset);
-        mappedOffsetCache.set(offset, mapped);
-        return mapped;
+    const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(currentText.length));
+    agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
+    edit.replace(document.uri, fullRange, draftText);
+    return vscode.workspace.applyEdit(edit);
+  };
+
+  const clearRememberedViewPosition = async (): Promise<void> => {
+    const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
+    if (!(documentKey in rememberedPositions)) {
+      return;
+    }
+    delete rememberedPositions[documentKey];
+    await context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, rememberedPositions);
+    lastSavedRememberedLine = null;
+    lastSavedRememberedLineOffset = 0;
+  };
+
+  const saveRememberedViewPosition = async (topLine: number, topLineOffset: number | undefined): Promise<void> => {
+    const minLines = getRememberPositionLines();
+    if (document.lineCount < minLines) {
+      await clearRememberedViewPosition();
+      return;
+    }
+
+    const normalizedRemembered = normalizeRememberedTopLine(topLine, topLineOffset, document.lineCount);
+    const clampedLine = normalizedRemembered.line;
+    const normalizedOffset = normalizedRemembered.lineOffset;
+    if (lastSavedRememberedLine === clampedLine && lastSavedRememberedLineOffset === normalizedOffset) {
+      return;
+    }
+
+    const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
+    const existing = rememberedPositions[documentKey];
+    if (existing?.line === clampedLine && existing.lineOffset === normalizedOffset) {
+      lastSavedRememberedLine = clampedLine;
+      lastSavedRememberedLineOffset = normalizedOffset;
+      return;
+    }
+
+    rememberedPositions[documentKey] = {
+      line: clampedLine,
+      lineOffset: normalizedOffset,
+      updatedAt: Date.now()
     };
 
-    for (const change of sortedChanges) {
-        // Webview offsets are LF-normalized; remap to real document offsets before applying edits.
-        const mappedFrom = mapOffset(change.from);
-        const mappedTo = mapOffset(change.to);
-        const startOffset = Math.min(mappedFrom, mappedTo);
-        const endOffset = Math.max(mappedFrom, mappedTo);
-        const range = new vscode.Range(document.positionAt(startOffset), document.positionAt(endOffset));
-        edit.replace(document.uri, range, change.insert);
+    await context.workspaceState.update(
+      REMEMBERED_VIEW_POSITIONS_STATE_KEY,
+      pruneRememberedViewPositionMap(rememberedPositions)
+    );
+    lastSavedRememberedLine = clampedLine;
+    lastSavedRememberedLineOffset = normalizedOffset;
+  };
+
+  const sendInit = async (): Promise<boolean> => {
+    const message: InitMessage = {
+      type: 'init',
+      text: document.getText(),
+      version: document.version,
+      mode,
+      lineNumbers: getLineNumbersEnabled(context),
+      gitChangesGutter: getGitChangesGutterEnabled(context),
+      gitDiffLineHighlights: getGitDiffLineHighlightsEnabled(),
+      vimMode: getVimModeEnabled(context),
+      vimKeybindings: getVimKeybindings(),
+      vimLeader: getVimLeaderKey(),
+      findOptions: getFindOptions(),
+      outlinePosition: getOutlinePosition(),
+      outlineVisible: getOutlineVisible(context),
+      theme: getThemeSettings(),
+      restoreTopLine: pendingRestoreTopLine ?? undefined,
+      restoreTopLineOffset: pendingRestoreTopLine === null ? undefined : pendingRestoreTopLineOffset
+    };
+    return postToWebview(message);
+  };
+
+  const sendDocChanged = async (): Promise<boolean> => {
+    const message: DocChangedMessage = {
+      type: 'docChanged',
+      text: document.getText(),
+      version: document.version
+    };
+    return postToWebview(message);
+  };
+
+  const sendApplied = async (version: number): Promise<boolean> => {
+    const message: AppliedMessage = {
+      type: 'applied',
+      version
+    };
+    return postToWebview(message);
+  };
+
+  const sendGitBaselineChanged = async (options: RefreshGitBaselineOptions = {}): Promise<boolean> => {
+    if (!initDelivered) {
+      return false;
     }
 
-    const applied = await vscode.workspace.applyEdit(edit);
+    const payload = await gitDocumentState.resolveBaseline({
+      includeText: true,
+      force: options.forceReload === true
+    });
+    gitDocumentState.noteBaselinePayload(payload);
+    const payloadHash = hashGitBaselinePayload(payload);
+    if (!options.forcePost && payloadHash === gitDocumentState.getLastSentBaselineHash()) {
+      return true;
+    }
 
-    if (!applied) {
-        await sendDocChanged();
+    const message: GitBaselineChangedMessage = {
+      type: 'gitBaselineChanged',
+      version: document.version,
+      payload
+    };
+    const posted = await postToWebview(message);
+    if (posted) {
+      gitDocumentState.setLastSentBaselineHash(payloadHash);
+    }
+    return posted;
+  };
+
+  const parseRevealOffsetFromUriFragment = (uri: vscode.Uri): number | null => {
+    const fragment = uri.fragment?.trim() ?? '';
+    if (!fragment) {
+      return null;
+    }
+
+    const match = /^(?:L)?(\d+)(?:(?:,|:|C)(\d+))?$/i.exec(fragment);
+    if (!match) {
+      return null;
+    }
+
+    const lineNumber = Number.parseInt(match[1], 10);
+    if (!Number.isFinite(lineNumber) || lineNumber < 1) {
+      return null;
+    }
+    const clampedLine = Math.min(lineNumber, document.lineCount);
+    const line = document.lineAt(clampedLine - 1);
+
+    const oneBasedColumn = match[2] ? Number.parseInt(match[2], 10) : 1;
+    const zeroBasedColumn = Number.isFinite(oneBasedColumn) && oneBasedColumn > 0 ? oneBasedColumn - 1 : 0;
+    const targetCharacter = Math.min(line.range.end.character, Math.max(0, zeroBasedColumn));
+    return document.offsetAt(new vscode.Position(clampedLine - 1, targetCharacter));
+  };
+
+  const ensureInitDelivered = async (): Promise<void> => {
+    if (disposed || initDelivered || !webviewReady) {
+      return;
+    }
+    const posted = await sendInit();
+    if (posted) {
+      initDelivered = true;
+    }
+  };
+
+  const requestExportSnapshot = async (): Promise<{ text: string; environment?: ExportStyleEnvironment }> => {
+    await ensureInitDelivered();
+    if (disposed) {
+      throw new Error('The editor was closed before export completed.');
+    }
+    const requestId = `export-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+    const response = new Promise<{ text: string; environment?: ExportStyleEnvironment }>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingExportSnapshots.delete(requestId);
+        reject(new Error('Timed out waiting for export snapshot from the editor.'));
+      }, 20000);
+
+      pendingExportSnapshots.set(requestId, { resolve, reject, timer });
+    });
+
+    const message: RequestExportSnapshotMessage = {
+      type: 'requestExportSnapshot',
+      requestId
+    };
+    const posted = await postToWebview(message);
+    if (!posted) {
+      rejectPendingExportSnapshot(requestId, new Error('The editor webview is not ready to export.'));
+    }
+
+    return response;
+  };
+
+  const rejectPendingExportSnapshot = (requestId: string, error: Error): void => {
+    const pending = pendingExportSnapshots.get(requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingExportSnapshots.delete(requestId);
+    pending.reject(error);
+  };
+
+  const resolvePendingExportSnapshot = (
+    requestId: string,
+    value: { text: string; environment?: ExportStyleEnvironment }
+  ): void => {
+    const pending = pendingExportSnapshots.get(requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingExportSnapshots.delete(requestId);
+    pending.resolve(value);
+  };
+
+  const rejectPendingExportSnapshots = (error: Error): void => {
+    for (const requestId of pendingExportSnapshots.keys()) {
+      rejectPendingExportSnapshot(requestId, error);
+    }
+  };
+
+  const runPendingGitRefreshes = async (): Promise<void> => {
+    if (gitRefreshRunning || !webviewReady) {
+      return;
+    }
+    gitRefreshRunning = true;
+    try {
+      while (gitRefreshPending) {
+        const nextOptions: RefreshGitBaselineOptions = {
+          forcePost: gitRefreshPendingForcePost,
+          forceReload: gitRefreshPendingForceReload
+        };
+        gitRefreshPending = false;
+        gitRefreshPendingForcePost = false;
+        gitRefreshPendingForceReload = false;
+        try {
+          await ensureInitDelivered();
+          if (!initDelivered) {
+            gitRefreshPending = true;
+            gitRefreshPendingForcePost = gitRefreshPendingForcePost || nextOptions.forcePost === true;
+            gitRefreshPendingForceReload = gitRefreshPendingForceReload || nextOptions.forceReload === true;
+            return;
+          }
+          await sendGitBaselineChanged(nextOptions);
+        } catch {
+          // Keep refresh coalescing alive across transient git/webview failures.
+        }
+      }
+    } finally {
+      gitRefreshRunning = false;
+      if (gitRefreshPending) {
+        runBackground(runPendingGitRefreshes(), 'runPendingGitRefreshes.retry');
+      }
+    }
+  };
+
+  const refreshGitBaseline = (options: RefreshGitBaselineOptions = {}): void => {
+    if (options.forceReload) {
+      gitDocumentState.invalidate();
+    }
+    gitRefreshPending = true;
+    gitRefreshPendingForcePost = gitRefreshPendingForcePost || options.forcePost === true;
+    gitRefreshPendingForceReload = gitRefreshPendingForceReload || options.forceReload === true;
+    runBackground(runPendingGitRefreshes(), 'runPendingGitRefreshes');
+  };
+
+  const isTextEditorForDocument = (textEditor: vscode.TextEditor | undefined): textEditor is vscode.TextEditor => {
+    if (!textEditor) {
+      return false;
+    }
+    return textEditor.document.uri.toString() === documentKey;
+  };
+
+  const revealSelectionForTextEditor = (textEditor: vscode.TextEditor): RevealSelectionPayload => {
+    const anchor = textEditor.document.offsetAt(textEditor.selection.start);
+    const head = textEditor.document.offsetAt(textEditor.selection.end);
+    return { anchor, head };
+  };
+
+  const getRevealSelectionKey = (selection: RevealSelectionPayload): string => {
+    return `${selection.anchor}:${selection.head}`;
+  };
+
+  const postRevealSelection = async (selection: RevealSelectionPayload): Promise<void> => {
+    if (!webviewReady) {
+      pendingRevealSelection = selection;
+      return;
+    }
+    await ensureInitDelivered();
+    if (!initDelivered) {
+      pendingRevealSelection = selection;
+      return;
+    }
+    const message: RevealSelectionMessage = {
+      type: 'revealSelection',
+      anchor: selection.anchor,
+      head: selection.head
+    };
+    const posted = await postToWebview(message);
+    if (posted) {
+      lastSentRevealSelectionKey = getRevealSelectionKey(selection);
+      pendingRevealSelection = null;
+    } else {
+      pendingRevealSelection = selection;
+    }
+  };
+
+  const flushPendingRevealSelection = async (): Promise<void> => {
+    if (pendingRevealSelection === null) {
+      return;
+    }
+    await postRevealSelection(pendingRevealSelection);
+  };
+
+  const postFocusEditor = async (): Promise<void> => {
+    if (!webviewReady) {
+      return;
+    }
+    await ensureInitDelivered();
+    if (!initDelivered) {
+      return;
+    }
+    const message: FocusEditorMessage = { type: 'focusEditor' };
+    await postToWebview(message);
+  };
+
+  const sendRevealSelectionForEditor = async (textEditor: vscode.TextEditor | undefined): Promise<void> => {
+    if (!isTextEditorForDocument(textEditor)) {
+      return;
+    }
+
+    const selection = revealSelectionForTextEditor(textEditor);
+    if (lastSentRevealSelectionKey === getRevealSelectionKey(selection)) {
+      return;
+    }
+    await postRevealSelection(selection);
+  };
+
+  const findEditorForDocumentReveal = (): vscode.TextEditor | undefined => {
+    const active = vscode.window.activeTextEditor;
+    if (isTextEditorForDocument(active)) {
+      return active;
+    }
+    return vscode.window.visibleTextEditors.find((editor) => isTextEditorForDocument(editor));
+  };
+
+  const resolveRememberedTopLineForInit = (): { line: number; lineOffset: number } | null => {
+    const minLines = getRememberPositionLines();
+    if (document.lineCount < minLines) {
+      runBackground(clearRememberedViewPosition(), 'clearRememberedViewPosition.initThreshold');
+      return null;
+    }
+
+    if (pendingRevealSelection !== null) {
+      return null;
+    }
+
+    const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
+    const remembered = rememberedPositions[documentKey];
+    if (!remembered) {
+      return null;
+    }
+
+    const normalizedRemembered = normalizeRememberedTopLine(remembered.line, remembered.lineOffset, document.lineCount);
+    const clampedLine = normalizedRemembered.line;
+    const lineOffset = normalizedRemembered.lineOffset;
+    if (
+      normalizedRemembered.adjustedForEof &&
+      (remembered.line !== clampedLine || normalizeLineOffset(remembered.lineOffset) !== lineOffset)
+    ) {
+      rememberedPositions[documentKey] = {
+        line: clampedLine,
+        lineOffset,
+        updatedAt: Date.now()
+      };
+      runBackground(
+        context.workspaceState.update(
+          REMEMBERED_VIEW_POSITIONS_STATE_KEY,
+          pruneRememberedViewPositionMap(rememberedPositions)
+        ),
+        'saveRememberedViewPosition.eofBackoff'
+      );
+    }
+    lastSavedRememberedLine = clampedLine;
+    lastSavedRememberedLineOffset = lineOffset;
+    return {
+      line: clampedLine,
+      lineOffset
+    };
+  };
+
+  const initialRevealEditor = findEditorForDocumentReveal();
+  if (initialRevealEditor) {
+    pendingRevealSelection = revealSelectionForTextEditor(initialRevealEditor);
+  } else {
+    const initialOffset = parseRevealOffsetFromUriFragment(document.uri);
+    pendingRevealSelection = initialOffset === null ? null : { anchor: initialOffset, head: initialOffset };
+  }
+  const rememberedTopLine = resolveRememberedTopLineForInit();
+  if (rememberedTopLine) {
+    pendingRestoreTopLine = rememberedTopLine.line;
+    pendingRestoreTopLineOffset = rememberedTopLine.lineOffset;
+  }
+
+  const session: PanelSession = {
+    panel,
+    document,
+    documentUri,
+    gitDocumentState,
+    getMode: () => mode,
+    ensureInitDelivered,
+    requestExportSnapshot,
+    rejectPendingExportSnapshots,
+    refreshGitBaseline,
+    getGitRepoRoot: () => gitDocumentState.getRepoRoot()
+  };
+
+  const handleMessage = async (raw: WebviewMessage): Promise<void> => {
+    if (disposed) {
+      return;
+    }
+    switch (raw.type) {
+      case 'ready':
+        webviewReady = true;
+        await ensureInitDelivered();
+        await flushPendingRevealSelection();
+        gitRefreshPending = true;
+        gitRefreshPendingForcePost = true;
+        await runPendingGitRefreshes();
         return;
+      case 'setMode':
+        mode = raw.mode;
+        return;
+      case 'setLineNumbers': {
+        const visible = raw.visible ?? raw.enabled;
+        if (typeof visible !== 'boolean') {
+          return;
+        }
+        await vscode.workspace
+          .getConfiguration(EXTENSION_CONFIG_SECTION)
+          .update(LINE_NUMBERS_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
+        return;
+      }
+      case 'setGitChangesGutter': {
+        const visible = raw.visible ?? raw.enabled;
+        if (typeof visible !== 'boolean') {
+          return;
+        }
+        await vscode.workspace
+          .getConfiguration(EXTENSION_CONFIG_SECTION)
+          .update(GIT_CHANGES_GUTTER_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
+        return;
+      }
+      case 'setOutlineVisible':
+        await setOutlineVisible(raw.visible);
+        return;
+      case 'setFindOptions': {
+        const wholeWord = raw.findOptions?.wholeWord ?? raw.wholeWord;
+        const caseSensitive = raw.findOptions?.caseSensitive ?? raw.caseSensitive;
+        await setFindOptions({
+          wholeWord: wholeWord === true,
+          caseSensitive: caseSensitive === true
+        });
+        return;
+      }
+      case 'viewPositionChanged':
+        if (Number.isFinite(raw.topLine)) {
+          await enqueue(async () => {
+            await saveRememberedViewPosition(raw.topLine, raw.topLineOffset);
+          });
+        }
+        return;
+      case 'exportDocument':
+        await onExportDocument(session, raw.format);
+        return;
+      case 'openLink':
+        await openLink(raw.href, documentUri);
+        return;
+      case 'resolveImageSrc': {
+        const response: ResolvedImageSrcMessage = {
+          type: 'resolvedImageSrc',
+          requestId: raw.requestId,
+          resolvedUrl: resolveWebviewImageSrc(raw.url, documentUri, panel.webview)
+        };
+        await postToWebview(response);
+        return;
+      }
+      case 'resolveWikiLinks': {
+        const response: ResolvedWikiLinksMessage = {
+          type: 'resolvedWikiLinks',
+          requestId: raw.requestId,
+          results: await resolveWikiLinkTargets(raw.targets, documentUri)
+        };
+        await postToWebview(response);
+        return;
+      }
+      case 'resolveLocalLinks': {
+        const response: ResolvedLocalLinksMessage = {
+          type: 'resolvedLocalLinks',
+          requestId: raw.requestId,
+          results: await resolveLocalLinkTargets(raw.targets, documentUri)
+        };
+        await postToWebview(response);
+        return;
+      }
+      case 'exportSnapshot':
+        resolvePendingExportSnapshot(raw.requestId, {
+          text: raw.text,
+          environment: raw.environment
+        });
+        return;
+      case 'exportSnapshotError':
+        rejectPendingExportSnapshot(raw.requestId, new Error(raw.message || 'Failed to collect export snapshot.'));
+        return;
+      case 'requestGitBlame': {
+        const resolved = await resolveGitBlameForRequest(documentUri, raw, document.getText(), gitDocumentState);
+        const response: GitBlameResultMessage = {
+          type: 'gitBlameResult',
+          requestId: raw.requestId,
+          lineNumber: raw.lineNumber,
+          localEditGeneration: raw.localEditGeneration,
+          result: resolved.result
+        };
+        await postToWebview(response);
+        return;
+      }
+      case 'openGitRevisionForLine':
+        await openGitRevisionForLine(documentUri, raw, document.getText(), gitDocumentState);
+        return;
+      case 'openGitWorktreeForLine':
+        await openGitWorktreeForLine(documentUri, raw, document.getText(), gitDocumentState);
+        return;
+      case 'applyChanges':
+        agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
+        isApplyingOwnChange = true;
+        try {
+          await enqueue(async () => {
+            await applyDocumentChanges(document, raw, sendDocChanged, sendApplied);
+          });
+        } finally {
+          isApplyingOwnChange = false;
+        }
+        return;
+      case 'draftChanged':
+        pendingDraftText = raw.text;
+        return;
+      case 'saveDocument':
+        isApplyingOwnChange = true;
+        try {
+          await enqueue(async () => {
+            await document.save();
+          });
+        } finally {
+          isApplyingOwnChange = false;
+        }
+        return;
+      case 'saveImageFromClipboard': {
+        const response = await handleSaveImageFromClipboard(raw, documentUri);
+        await postToWebview(response);
+        return;
+      }
+    }
+  };
+
+  const messageSubscription = panel.webview.onDidReceiveMessage((raw: WebviewMessage) => {
+    runBackground(handleMessage(raw), 'handleMessage');
+  });
+
+  const documentChangeSubscription = vscode.workspace.onDidChangeTextDocument((event) => {
+    if (event.document.uri.toString() !== documentKey) {
+      return;
     }
 
-    await sendApplied(document.version);
+    // Save/dirty-state transitions can emit document events without text edits.
+    if (event.contentChanges.length === 0) {
+      return;
+    }
+
+    if (isApplyingOwnChange) {
+      return;
+    }
+
+    runBackground(enqueue(async () => {
+      await sendDocChanged();
+    }), 'sendDocChanged');
+  });
+
+  const documentSaveSubscription = vscode.workspace.onDidSaveTextDocument((savedDocument) => {
+    if (savedDocument.uri.toString() !== documentKey) {
+      return;
+    }
+    refreshGitBaseline({ forceReload: true });
+  });
+
+  const textEditorSelectionSubscription = vscode.window.onDidChangeTextEditorSelection((event) => {
+    if (!isTextEditorForDocument(event.textEditor)) {
+      return;
+    }
+    runBackground(sendRevealSelectionForEditor(event.textEditor), 'sendRevealSelectionForEditor.selection');
+  });
+
+  const activeTextEditorSubscription = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
+    if (!isTextEditorForDocument(textEditor)) {
+      return;
+    }
+    runBackground(sendRevealSelectionForEditor(textEditor), 'sendRevealSelectionForEditor.activeEditor');
+  });
+
+  const visibleTextEditorsSubscription = vscode.window.onDidChangeVisibleTextEditors(() => {
+    runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), 'sendRevealSelectionForEditor.visibleEditors');
+  });
+
+  const viewStateSubscription = panel.onDidChangeViewState((event) => {
+    if (event.webviewPanel.active) {
+      onPanelActivated(event.webviewPanel);
+      refreshGitBaseline({ forcePost: true });
+      runBackground(flushPendingRevealSelection(), 'flushPendingRevealSelection');
+      runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), 'sendRevealSelectionForEditor.viewState');
+      runBackground(postFocusEditor(), 'postFocusEditor');
+    }
+    onPanelViewStateChanged();
+  });
+
+  const disposeSubscription = panel.onDidDispose(() => {
+    dispose();
+  });
+
+  refreshGitBaseline({ forcePost: true });
+  runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), 'sendRevealSelectionForEditor.startup');
+
+  const dispose = (): void => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+
+    runBackground(enqueue(async () => {
+      try {
+        // Best-effort recovery for edits that never made it through the debounce/apply round-trip.
+        await applyPendingDraftIfNeeded();
+      } catch {
+        // Ignore dispose-time recovery failures to avoid surfacing noisy teardown errors.
+      }
+    }), 'disposeDraftRecovery');
+
+    rejectPendingExportSnapshots(new Error('The editor was closed before export completed.'));
+    messageSubscription.dispose();
+    documentChangeSubscription.dispose();
+    documentSaveSubscription.dispose();
+    textEditorSelectionSubscription.dispose();
+    activeTextEditorSubscription.dispose();
+    visibleTextEditorsSubscription.dispose();
+    viewStateSubscription.dispose();
+    disposeSubscription.dispose();
+    onPanelDisposed(panel);
+  };
+
+  return {
+    session,
+    handleMessage,
+    dispose
+  };
+}
+
+function clampLineNumber(value: number, maxLine: number): number {
+  const numeric = Number.isFinite(value) ? Math.floor(value) : 1;
+  const max = Math.max(1, Math.floor(maxLine));
+  return Math.max(1, Math.min(numeric, max));
+}
+
+function normalizeLineOffset(value: number | undefined): number {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+  return Math.max(0, Math.round(numeric * 100) / 100);
+}
+
+function normalizeRememberedTopLine(
+  line: number,
+  lineOffset: number | undefined,
+  maxLine: number
+): { line: number; lineOffset: number; adjustedForEof: boolean } {
+  const clampedLine = clampLineNumber(line, maxLine);
+  const normalizedOffset = normalizeLineOffset(lineOffset);
+  const nearEndLine = Math.max(1, maxLine - REMEMBERED_EOF_NEAR_THRESHOLD_LINES + 1);
+  if (clampedLine < nearEndLine) {
+    return {
+      line: clampedLine,
+      lineOffset: normalizedOffset,
+      adjustedForEof: false
+    };
+  }
+  return {
+    line: Math.max(1, clampedLine - REMEMBERED_EOF_BACKOFF_LINES),
+    lineOffset: 0,
+    adjustedForEof: true
+  };
+}
+
+function getRememberedViewPositionMap(workspaceState: vscode.Memento): Record<string, RememberedViewPosition> {
+  const stored = workspaceState.get<unknown>(REMEMBERED_VIEW_POSITIONS_STATE_KEY);
+  if (!stored || typeof stored !== 'object' || Array.isArray(stored)) {
+    return {};
+  }
+
+  const entries: Record<string, RememberedViewPosition> = {};
+  for (const [key, value] of Object.entries(stored as Record<string, unknown>)) {
+    if (typeof key !== 'string' || !key) {
+      continue;
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      continue;
+    }
+    const record = value as Partial<RememberedViewPosition>;
+    const line = Number(record.line);
+    const lineOffset = Number(record.lineOffset);
+    const updatedAt = Number(record.updatedAt);
+    if (!Number.isFinite(line) || !Number.isFinite(updatedAt)) {
+      continue;
+    }
+    entries[key] = {
+      line: Math.max(1, Math.floor(line)),
+      lineOffset: normalizeLineOffset(lineOffset),
+      updatedAt: Math.floor(updatedAt)
+    };
+  }
+  return entries;
+}
+
+function pruneRememberedViewPositionMap(
+  entries: Record<string, RememberedViewPosition>
+): Record<string, RememberedViewPosition> {
+  const sortedEntries = Object.entries(entries)
+    .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+    .slice(0, MAX_REMEMBERED_VIEW_POSITIONS);
+  return Object.fromEntries(sortedEntries);
+}
+
+async function applyDocumentChanges(
+  document: vscode.TextDocument,
+  message: ApplyChangesMessage,
+  sendDocChanged: () => Promise<boolean>,
+  sendApplied: (version: number) => Promise<boolean>
+): Promise<void> {
+  if (message.baseVersion !== document.version) {
+    await sendDocChanged();
+    return;
+  }
+
+  const edit = new vscode.WorkspaceEdit();
+  const sortedChanges = [...message.changes].sort((a, b) => b.from - a.from);
+  const documentText = document.getText();
+  const mappedOffsetCache = new Map<number, number>();
+  const mapOffset = (offset: number): number => {
+    const cached = mappedOffsetCache.get(offset);
+    if (typeof cached === 'number') {
+      return cached;
+    }
+    const mapped = mapNormalizedOffsetToDocumentOffset(documentText, offset);
+    mappedOffsetCache.set(offset, mapped);
+    return mapped;
+  };
+
+  for (const change of sortedChanges) {
+    // Webview offsets are LF-normalized; remap to real document offsets before applying edits.
+    const mappedFrom = mapOffset(change.from);
+    const mappedTo = mapOffset(change.to);
+    const startOffset = Math.min(mappedFrom, mappedTo);
+    const endOffset = Math.max(mappedFrom, mappedTo);
+    const range = new vscode.Range(
+      document.positionAt(startOffset),
+      document.positionAt(endOffset)
+    );
+    edit.replace(document.uri, range, change.insert);
+  }
+
+  const applied = await vscode.workspace.applyEdit(edit);
+
+  if (!applied) {
+    await sendDocChanged();
+    return;
+  }
+
+  await sendApplied(document.version);
 }
 
 function mapNormalizedOffsetToDocumentOffset(documentText: string, normalizedOffset: number): number {
-    const target = Number.isFinite(normalizedOffset) ? Math.max(0, normalizedOffset) : documentText.length;
-    if (target === 0) {
-        return 0;
-    }
+  const target = Number.isFinite(normalizedOffset) ? Math.max(0, normalizedOffset) : documentText.length;
+  if (target === 0) {
+    return 0;
+  }
 
-    let normalizedIndex = 0;
-    let documentIndex = 0;
+  let normalizedIndex = 0;
+  let documentIndex = 0;
 
-    while (documentIndex < documentText.length && normalizedIndex < target) {
-        if (documentText.charCodeAt(documentIndex) === 13) {
-            if (documentText.charCodeAt(documentIndex + 1) === 10) {
-                documentIndex += 2;
-            } else {
-                documentIndex += 1;
-            }
-            normalizedIndex += 1;
-            continue;
-        }
-
+  while (documentIndex < documentText.length && normalizedIndex < target) {
+    if (documentText.charCodeAt(documentIndex) === 13) {
+      if (documentText.charCodeAt(documentIndex + 1) === 10) {
+        documentIndex += 2;
+      } else {
         documentIndex += 1;
-        normalizedIndex += 1;
+      }
+      normalizedIndex += 1;
+      continue;
     }
 
-    return documentIndex;
+    documentIndex += 1;
+    normalizedIndex += 1;
+  }
+
+  return documentIndex;
 }
 
-async function handleSaveImageFromClipboard(message: SaveImageFromClipboardMessage, documentUri: vscode.Uri): Promise<SavedImagePathMessage> {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-        return {
-            type: "savedImagePath",
-            requestId: message.requestId,
-            success: false,
-            error: "No workspace folder open",
-        };
-    }
+async function handleSaveImageFromClipboard(
+  message: SaveImageFromClipboardMessage,
+  documentUri: vscode.Uri
+): Promise<SavedImagePathMessage> {
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    return {
+      type: 'savedImagePath',
+      requestId: message.requestId,
+      success: false,
+      error: 'No workspace folder open'
+    };
+  }
 
-    const workspaceRoot = (vscode.workspace.getWorkspaceFolder(documentUri) ?? workspaceFolders[0]).uri;
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    const imageFolder = config.get<string>("imageFolder", "assets");
+  const workspaceRoot = (vscode.workspace.getWorkspaceFolder(documentUri) ?? workspaceFolders[0]).uri;
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  const imageFolder = config.get<string>('imageFolder', 'assets');
+
+  try {
+    const base64Data = message.imageData.replace(/^data:image\/[^;]+;base64,/, '');
+    const imageBuffer = Buffer.from(base64Data, 'base64');
+
+    const assetsFolderUri = vscode.Uri.joinPath(workspaceRoot, imageFolder);
 
     try {
-        const base64Data = message.imageData.replace(/^data:image\/[^;]+;base64,/, "");
-        const imageBuffer = Buffer.from(base64Data, "base64");
-
-        const assetsFolderUri = vscode.Uri.joinPath(workspaceRoot, imageFolder);
-
-        try {
-            await vscode.workspace.fs.stat(assetsFolderUri);
-        } catch {
-            await vscode.workspace.fs.createDirectory(assetsFolderUri);
-        }
-
-        const filePath = vscode.Uri.joinPath(assetsFolderUri, message.fileName);
-        await vscode.workspace.fs.writeFile(filePath, imageBuffer);
-
-        const relativePath = path.relative(path.dirname(documentUri.fsPath), filePath.fsPath);
-
-        return {
-            type: "savedImagePath",
-            requestId: message.requestId,
-            success: true,
-            path: relativePath.replace(/\\/g, "/"),
-        };
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : "Failed to save image";
-        return {
-            type: "savedImagePath",
-            requestId: message.requestId,
-            success: false,
-            error: errorMessage,
-        };
+      await vscode.workspace.fs.stat(assetsFolderUri);
+    } catch {
+      await vscode.workspace.fs.createDirectory(assetsFolderUri);
     }
+
+    const filePath = vscode.Uri.joinPath(assetsFolderUri, message.fileName);
+    await vscode.workspace.fs.writeFile(filePath, imageBuffer);
+
+    const relativePath = path.relative(path.dirname(documentUri.fsPath), filePath.fsPath);
+
+    return {
+      type: 'savedImagePath',
+      requestId: message.requestId,
+      success: true,
+      path: relativePath.replace(/\\/g, '/')
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to save image';
+    return {
+      type: 'savedImagePath',
+      requestId: message.requestId,
+      success: false,
+      error: errorMessage
+    };
+  }
 }

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -1,1249 +1,1177 @@
-import * as path from 'node:path';
-import * as vscode from 'vscode';
-import type { AgentReviewHandoffController } from '../agents/reviewHandoff';
-import {
-  EXTENSION_CONFIG_SECTION,
-  LINE_NUMBERS_SETTING_KEY,
-  GIT_CHANGES_GUTTER_SETTING_KEY,
-  getLineNumbersEnabled,
-  getGitChangesGutterEnabled,
-  getGitDiffLineHighlightsEnabled,
-  getOutlinePosition,
-  getOutlineVisible,
-  getRememberPositionLines,
-  getThemeSettings,
-  getVimModeEnabled
-} from '../shared/extensionConfig';
-import { openLink, resolveLocalLinkTargets, resolveWebviewImageSrc, resolveWikiLinkTargets } from '../shared/documentLinks';
-import { GitDocumentState, hashGitBaselinePayload } from '../git/documentState';
-import { openGitRevisionForLine, openGitWorktreeForLine, resolveGitBlameForRequest } from '../git/blameActions';
-import type { GitBaselinePayload, GitBlameLineResult } from '../git/types';
-import type { ExportStyleEnvironment } from '../export/runtime';
-import type { ThemeSettings } from '../shared/themeDefaults';
-import type { OutlinePosition } from '../shared/extensionConfig';
+import * as path from "node:path";
+import * as vscode from "vscode";
+import type { AgentReviewHandoffController } from "../agents/reviewHandoff";
+import { EXTENSION_CONFIG_SECTION, LINE_NUMBERS_SETTING_KEY, GIT_CHANGES_GUTTER_SETTING_KEY, getLineNumbersEnabled, getGitChangesGutterEnabled, getGitDiffLineHighlightsEnabled, getOutlinePosition, getOutlineVisible, getRememberPositionLines, getThemeSettings, getVimModeEnabled, getVimKeybindings, getVimLeaderKey, type VimKeybinding } from "../shared/extensionConfig";
+import { openLink, resolveLocalLinkTargets, resolveWebviewImageSrc, resolveWikiLinkTargets } from "../shared/documentLinks";
+import { GitDocumentState, hashGitBaselinePayload } from "../git/documentState";
+import { openGitRevisionForLine, openGitWorktreeForLine, resolveGitBlameForRequest } from "../git/blameActions";
+import type { GitBaselinePayload, GitBlameLineResult } from "../git/types";
+import type { ExportStyleEnvironment } from "../export/runtime";
+import type { ThemeSettings } from "../shared/themeDefaults";
+import type { OutlinePosition } from "../shared/extensionConfig";
 
-export type EditorMode = 'live' | 'source';
-export type ExportFormat = 'html' | 'pdf';
+export type EditorMode = "live" | "source";
+export type ExportFormat = "html" | "pdf";
 
 type FindOptions = {
-  wholeWord: boolean;
-  caseSensitive: boolean;
+    wholeWord: boolean;
+    caseSensitive: boolean;
 };
 
 type InitMessage = {
-  type: 'init';
-  text: string;
-  version: number;
-  mode: EditorMode;
-  lineNumbers: boolean;
-  gitChangesGutter: boolean;
-  gitDiffLineHighlights: boolean;
-  vimMode: boolean;
-  findOptions: FindOptions;
-  outlinePosition: OutlinePosition;
-  outlineVisible: boolean;
-  theme: ThemeSettings;
-  restoreTopLine?: number;
-  restoreTopLineOffset?: number;
+    type: "init";
+    text: string;
+    version: number;
+    mode: EditorMode;
+    lineNumbers: boolean;
+    gitChangesGutter: boolean;
+    gitDiffLineHighlights: boolean;
+    vimMode: boolean;
+    vimKeybindings: VimKeybinding[];
+    vimLeader: string;
+    findOptions: FindOptions;
+    outlinePosition: OutlinePosition;
+    outlineVisible: boolean;
+    theme: ThemeSettings;
+    restoreTopLine?: number;
+    restoreTopLineOffset?: number;
 };
 
 type DocChangedMessage = {
-  type: 'docChanged';
-  text: string;
-  version: number;
+    type: "docChanged";
+    text: string;
+    version: number;
 };
 
 type AppliedMessage = {
-  type: 'applied';
-  version: number;
+    type: "applied";
+    version: number;
 };
 
 type RevealSelectionMessage = {
-  type: 'revealSelection';
-  anchor: number;
-  head: number;
-  focus?: boolean;
+    type: "revealSelection";
+    anchor: number;
+    head: number;
+    focus?: boolean;
 };
 
 type FocusEditorMessage = {
-  type: 'focusEditor';
+    type: "focusEditor";
 };
 
 type RevealSelectionPayload = {
-  anchor: number;
-  head: number;
+    anchor: number;
+    head: number;
 };
 
 type ApplyChangesMessage = {
-  type: 'applyChanges';
-  baseVersion: number;
-  changes: Array<{ from: number; to: number; insert: string }>;
+    type: "applyChanges";
+    baseVersion: number;
+    changes: Array<{ from: number; to: number; insert: string }>;
 };
 
 type DraftChangedMessage = {
-  type: 'draftChanged';
-  text: string | null;
+    type: "draftChanged";
+    text: string | null;
 };
 
 type SetModeMessage = {
-  type: 'setMode';
-  mode: EditorMode;
+    type: "setMode";
+    mode: EditorMode;
 };
 
 type OpenLinkMessage = {
-  type: 'openLink';
-  href: string;
+    type: "openLink";
+    href: string;
 };
 
 type ResolveImageSrcMessage = {
-  type: 'resolveImageSrc';
-  requestId: string;
-  url: string;
+    type: "resolveImageSrc";
+    requestId: string;
+    url: string;
 };
 
 type ResolveWikiLinksMessage = {
-  type: 'resolveWikiLinks';
-  requestId: string;
-  targets: string[];
+    type: "resolveWikiLinks";
+    requestId: string;
+    targets: string[];
 };
 
 type ResolveLocalLinksMessage = {
-  type: 'resolveLocalLinks';
-  requestId: string;
-  targets: string[];
+    type: "resolveLocalLinks";
+    requestId: string;
+    targets: string[];
 };
 
 type SaveDocumentMessage = {
-  type: 'saveDocument';
+    type: "saveDocument";
 };
 
 type ExportDocumentMessage = {
-  type: 'exportDocument';
-  format: ExportFormat;
+    type: "exportDocument";
+    format: ExportFormat;
 };
 
 type ExportSnapshotMessage = {
-  type: 'exportSnapshot';
-  requestId: string;
-  text: string;
-  environment?: ExportStyleEnvironment;
+    type: "exportSnapshot";
+    requestId: string;
+    text: string;
+    environment?: ExportStyleEnvironment;
 };
 
 type ExportSnapshotErrorMessage = {
-  type: 'exportSnapshotError';
-  requestId: string;
-  message: string;
+    type: "exportSnapshotError";
+    requestId: string;
+    message: string;
 };
 
 type SetLineNumbersMessage = {
-  type: 'setLineNumbers';
-  visible?: boolean;
-  enabled?: boolean;
+    type: "setLineNumbers";
+    visible?: boolean;
+    enabled?: boolean;
 };
 
 type SetGitChangesGutterMessage = {
-  type: 'setGitChangesGutter';
-  visible?: boolean;
-  enabled?: boolean;
+    type: "setGitChangesGutter";
+    visible?: boolean;
+    enabled?: boolean;
 };
 
 type SetOutlineVisibleMessage = {
-  type: 'setOutlineVisible';
-  visible: boolean;
+    type: "setOutlineVisible";
+    visible: boolean;
 };
 
 type SetFindOptionsMessage = {
-  type: 'setFindOptions';
-  wholeWord?: boolean;
-  caseSensitive?: boolean;
-  findOptions?: Partial<FindOptions>;
+    type: "setFindOptions";
+    wholeWord?: boolean;
+    caseSensitive?: boolean;
+    findOptions?: Partial<FindOptions>;
 };
 
 type ViewPositionChangedMessage = {
-  type: 'viewPositionChanged';
-  topLine: number;
-  topLineOffset?: number;
+    type: "viewPositionChanged";
+    topLine: number;
+    topLineOffset?: number;
 };
 
 type ResolvedImageSrcMessage = {
-  type: 'resolvedImageSrc';
-  requestId: string;
-  resolvedUrl: string;
+    type: "resolvedImageSrc";
+    requestId: string;
+    resolvedUrl: string;
 };
 
 type ResolvedWikiLinksMessage = {
-  type: 'resolvedWikiLinks';
-  requestId: string;
-  results: Array<{ target: string; exists: boolean }>;
+    type: "resolvedWikiLinks";
+    requestId: string;
+    results: Array<{ target: string; exists: boolean }>;
 };
 
 type ResolvedLocalLinksMessage = {
-  type: 'resolvedLocalLinks';
-  requestId: string;
-  results: Array<{ target: string; exists: boolean }>;
+    type: "resolvedLocalLinks";
+    requestId: string;
+    results: Array<{ target: string; exists: boolean }>;
 };
 
 type RequestExportSnapshotMessage = {
-  type: 'requestExportSnapshot';
-  requestId: string;
+    type: "requestExportSnapshot";
+    requestId: string;
 };
 
 type RequestGitBlameMessage = {
-  type: 'requestGitBlame';
-  requestId: string;
-  lineNumber: number;
-  text?: string;
-  localEditGeneration: number;
+    type: "requestGitBlame";
+    requestId: string;
+    lineNumber: number;
+    text?: string;
+    localEditGeneration: number;
 };
 
 type OpenGitRevisionForLineMessage = {
-  type: 'openGitRevisionForLine';
-  lineNumber: number;
-  text?: string;
+    type: "openGitRevisionForLine";
+    lineNumber: number;
+    text?: string;
 };
 
 type OpenGitWorktreeForLineMessage = {
-  type: 'openGitWorktreeForLine';
-  lineNumber: number;
-  text?: string;
+    type: "openGitWorktreeForLine";
+    lineNumber: number;
+    text?: string;
 };
 
 type SaveImageFromClipboardMessage = {
-  type: 'saveImageFromClipboard';
-  requestId: string;
-  imageData: string;
-  fileName: string;
+    type: "saveImageFromClipboard";
+    requestId: string;
+    imageData: string;
+    fileName: string;
 };
 
 type SavedImagePathMessage = {
-  type: 'savedImagePath';
-  requestId: string;
-  success: boolean;
-  path?: string;
-  error?: string;
+    type: "savedImagePath";
+    requestId: string;
+    success: boolean;
+    path?: string;
+    error?: string;
 };
 
 type GitBaselineChangedMessage = {
-  type: 'gitBaselineChanged';
-  version: number;
-  payload: GitBaselinePayload;
+    type: "gitBaselineChanged";
+    version: number;
+    payload: GitBaselinePayload;
 };
 
 type GitBlameResultMessage = {
-  type: 'gitBlameResult';
-  requestId: string;
-  lineNumber: number;
-  localEditGeneration: number;
-  result: GitBlameLineResult;
+    type: "gitBlameResult";
+    requestId: string;
+    lineNumber: number;
+    localEditGeneration: number;
+    result: GitBlameLineResult;
 };
 
-type WebviewMessage =
-  | ApplyChangesMessage
-  | DraftChangedMessage
-  | SetModeMessage
-  | SetLineNumbersMessage
-  | SetGitChangesGutterMessage
-  | SetOutlineVisibleMessage
-  | SetFindOptionsMessage
-  | ViewPositionChangedMessage
-  | OpenLinkMessage
-  | ResolveImageSrcMessage
-  | ResolveWikiLinksMessage
-  | ResolveLocalLinksMessage
-  | SaveDocumentMessage
-  | ExportDocumentMessage
-  | ExportSnapshotMessage
-  | ExportSnapshotErrorMessage
-  | RequestGitBlameMessage
-  | OpenGitRevisionForLineMessage
-  | OpenGitWorktreeForLineMessage
-  | SaveImageFromClipboardMessage
-  | { type: 'ready' };
+type WebviewMessage = ApplyChangesMessage | DraftChangedMessage | SetModeMessage | SetLineNumbersMessage | SetGitChangesGutterMessage | SetOutlineVisibleMessage | SetFindOptionsMessage | ViewPositionChangedMessage | OpenLinkMessage | ResolveImageSrcMessage | ResolveWikiLinksMessage | ResolveLocalLinksMessage | SaveDocumentMessage | ExportDocumentMessage | ExportSnapshotMessage | ExportSnapshotErrorMessage | RequestGitBlameMessage | OpenGitRevisionForLineMessage | OpenGitWorktreeForLineMessage | SaveImageFromClipboardMessage | { type: "ready" };
 
 type RefreshGitBaselineOptions = {
-  forcePost?: boolean;
-  forceReload?: boolean;
+    forcePost?: boolean;
+    forceReload?: boolean;
 };
 
 type PendingExportSnapshot = {
-  resolve: (value: { text: string; environment?: ExportStyleEnvironment }) => void;
-  reject: (error: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
+    resolve: (value: { text: string; environment?: ExportStyleEnvironment }) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
 };
 
 type RememberedViewPosition = {
-  line: number;
-  lineOffset: number;
-  updatedAt: number;
+    line: number;
+    lineOffset: number;
+    updatedAt: number;
 };
 
-const REMEMBERED_VIEW_POSITIONS_STATE_KEY = 'rememberedViewPositionsByDocument';
+const REMEMBERED_VIEW_POSITIONS_STATE_KEY = "rememberedViewPositionsByDocument";
 const MAX_REMEMBERED_VIEW_POSITIONS = 300;
 const REMEMBERED_EOF_NEAR_THRESHOLD_LINES = 10;
 const REMEMBERED_EOF_BACKOFF_LINES = 10;
 
 type PanelSessionControllerParams = {
-  panel: vscode.WebviewPanel;
-  document: vscode.TextDocument;
-  documentUri: vscode.Uri;
-  context: vscode.ExtensionContext;
-  agentReviewHandoff: AgentReviewHandoffController;
-  onExportDocument: (session: PanelSession, format: ExportFormat) => Promise<void>;
-  getFindOptions: () => FindOptions;
-  setFindOptions: (options: FindOptions) => Promise<void>;
-  setOutlineVisible: (visible: boolean) => Promise<void>;
-  onPanelActivated: (panel: vscode.WebviewPanel) => void;
-  onPanelViewStateChanged: () => void;
-  onPanelDisposed: (panel: vscode.WebviewPanel) => void;
+    panel: vscode.WebviewPanel;
+    document: vscode.TextDocument;
+    documentUri: vscode.Uri;
+    context: vscode.ExtensionContext;
+    agentReviewHandoff: AgentReviewHandoffController;
+    onExportDocument: (session: PanelSession, format: ExportFormat) => Promise<void>;
+    getFindOptions: () => FindOptions;
+    setFindOptions: (options: FindOptions) => Promise<void>;
+    setOutlineVisible: (visible: boolean) => Promise<void>;
+    onPanelActivated: (panel: vscode.WebviewPanel) => void;
+    onPanelViewStateChanged: () => void;
+    onPanelDisposed: (panel: vscode.WebviewPanel) => void;
 };
 
 export type PanelSession = {
-  panel: vscode.WebviewPanel;
-  document: vscode.TextDocument;
-  documentUri: vscode.Uri;
-  gitDocumentState: GitDocumentState;
-  getMode: () => EditorMode;
-  ensureInitDelivered: () => Promise<void>;
-  requestExportSnapshot: () => Promise<{ text: string; environment?: ExportStyleEnvironment }>;
-  rejectPendingExportSnapshots: (reason: Error) => void;
-  refreshGitBaseline: (options?: RefreshGitBaselineOptions) => void;
-  getGitRepoRoot: () => string | null;
+    panel: vscode.WebviewPanel;
+    document: vscode.TextDocument;
+    documentUri: vscode.Uri;
+    gitDocumentState: GitDocumentState;
+    getMode: () => EditorMode;
+    ensureInitDelivered: () => Promise<void>;
+    requestExportSnapshot: () => Promise<{ text: string; environment?: ExportStyleEnvironment }>;
+    rejectPendingExportSnapshots: (reason: Error) => void;
+    refreshGitBaseline: (options?: RefreshGitBaselineOptions) => void;
+    getGitRepoRoot: () => string | null;
 };
 
 export type PanelSessionController = {
-  session: PanelSession;
-  handleMessage: (raw: WebviewMessage) => Promise<void>;
-  dispose: () => void;
+    session: PanelSession;
+    handleMessage: (raw: WebviewMessage) => Promise<void>;
+    dispose: () => void;
 };
 
 export function createPanelSessionController(params: PanelSessionControllerParams): PanelSessionController {
-  const {
-    panel,
-    document,
-    documentUri,
-    context,
-    agentReviewHandoff,
-    onExportDocument,
-    getFindOptions,
-    setFindOptions,
-    setOutlineVisible,
-    onPanelActivated,
-    onPanelViewStateChanged,
-    onPanelDisposed
-  } = params;
+    const { panel, document, documentUri, context, agentReviewHandoff, onExportDocument, getFindOptions, setFindOptions, setOutlineVisible, onPanelActivated, onPanelViewStateChanged, onPanelDisposed } = params;
 
-  const documentKey = document.uri.toString();
-  let mode: EditorMode = 'live';
-  let applyQueue: Promise<void> = Promise.resolve();
-  let webviewReady = false;
-  let initDelivered = false;
-  let isApplyingOwnChange = false;
-  let gitRefreshRunning = false;
-  let gitRefreshPending = false;
-  let gitRefreshPendingForcePost = false;
-  let gitRefreshPendingForceReload = false;
-  let lastSentRevealSelectionKey: string | null = null;
-  let pendingRevealSelection: RevealSelectionPayload | null = null;
-  let pendingRestoreTopLine: number | null = null;
-  let pendingRestoreTopLineOffset = 0;
-  let pendingDraftText: string | null = null;
-  let lastSavedRememberedLine: number | null = null;
-  let lastSavedRememberedLineOffset = 0;
-  let disposed = false;
-  const workspaceRoot = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
-  const gitDocumentState = new GitDocumentState(documentUri.fsPath, workspaceRoot);
-  const pendingExportSnapshots = new Map<string, PendingExportSnapshot>();
+    const documentKey = document.uri.toString();
+    let mode: EditorMode = "live";
+    let applyQueue: Promise<void> = Promise.resolve();
+    let webviewReady = false;
+    let initDelivered = false;
+    let isApplyingOwnChange = false;
+    let gitRefreshRunning = false;
+    let gitRefreshPending = false;
+    let gitRefreshPendingForcePost = false;
+    let gitRefreshPendingForceReload = false;
+    let lastSentRevealSelectionKey: string | null = null;
+    let pendingRevealSelection: RevealSelectionPayload | null = null;
+    let pendingRestoreTopLine: number | null = null;
+    let pendingRestoreTopLineOffset = 0;
+    let pendingDraftText: string | null = null;
+    let lastSavedRememberedLine: number | null = null;
+    let lastSavedRememberedLineOffset = 0;
+    let disposed = false;
+    const workspaceRoot = vscode.workspace.getWorkspaceFolder(document.uri)?.uri.fsPath;
+    const gitDocumentState = new GitDocumentState(documentUri.fsPath, workspaceRoot);
+    const pendingExportSnapshots = new Map<string, PendingExportSnapshot>();
 
-  const enqueue = (task: () => Promise<void>): Promise<void> => {
-    applyQueue = applyQueue.then(task, task);
-    return applyQueue;
-  };
-
-  const reportBackgroundError = (contextLabel: string, error: unknown): void => {
-    if (disposed) {
-      return;
-    }
-    console.error(`[MEO panelSession] ${contextLabel}`, error);
-  };
-
-  const runBackground = (promise: Promise<unknown>, contextLabel: string): void => {
-    void promise.catch((error) => {
-      reportBackgroundError(contextLabel, error);
-    });
-  };
-
-  const postToWebview = async (message: Record<string, unknown>): Promise<boolean> => {
-    if (disposed) {
-      return false;
-    }
-    try {
-      return await panel.webview.postMessage(message);
-    } catch {
-      return false;
-    }
-  };
-
-  const applyPendingDraftIfNeeded = async (): Promise<boolean> => {
-    const draftText = pendingDraftText;
-    pendingDraftText = null;
-    if (draftText === null) {
-      return false;
-    }
-
-    const currentText = document.getText();
-    const normalizedCurrent = currentText.replace(/\r\n/g, '\n');
-    const normalizedDraft = draftText.replace(/\r\n/g, '\n');
-    if (normalizedCurrent === normalizedDraft) {
-      return false;
-    }
-
-    const edit = new vscode.WorkspaceEdit();
-    const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(currentText.length));
-    agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
-    edit.replace(document.uri, fullRange, draftText);
-    return vscode.workspace.applyEdit(edit);
-  };
-
-  const clearRememberedViewPosition = async (): Promise<void> => {
-    const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
-    if (!(documentKey in rememberedPositions)) {
-      return;
-    }
-    delete rememberedPositions[documentKey];
-    await context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, rememberedPositions);
-    lastSavedRememberedLine = null;
-    lastSavedRememberedLineOffset = 0;
-  };
-
-  const saveRememberedViewPosition = async (topLine: number, topLineOffset: number | undefined): Promise<void> => {
-    const minLines = getRememberPositionLines();
-    if (document.lineCount < minLines) {
-      await clearRememberedViewPosition();
-      return;
-    }
-
-    const normalizedRemembered = normalizeRememberedTopLine(topLine, topLineOffset, document.lineCount);
-    const clampedLine = normalizedRemembered.line;
-    const normalizedOffset = normalizedRemembered.lineOffset;
-    if (lastSavedRememberedLine === clampedLine && lastSavedRememberedLineOffset === normalizedOffset) {
-      return;
-    }
-
-    const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
-    const existing = rememberedPositions[documentKey];
-    if (existing?.line === clampedLine && existing.lineOffset === normalizedOffset) {
-      lastSavedRememberedLine = clampedLine;
-      lastSavedRememberedLineOffset = normalizedOffset;
-      return;
-    }
-
-    rememberedPositions[documentKey] = {
-      line: clampedLine,
-      lineOffset: normalizedOffset,
-      updatedAt: Date.now()
+    const enqueue = (task: () => Promise<void>): Promise<void> => {
+        applyQueue = applyQueue.then(task, task);
+        return applyQueue;
     };
 
-    await context.workspaceState.update(
-      REMEMBERED_VIEW_POSITIONS_STATE_KEY,
-      pruneRememberedViewPositionMap(rememberedPositions)
-    );
-    lastSavedRememberedLine = clampedLine;
-    lastSavedRememberedLineOffset = normalizedOffset;
-  };
-
-  const sendInit = async (): Promise<boolean> => {
-    const message: InitMessage = {
-      type: 'init',
-      text: document.getText(),
-      version: document.version,
-      mode,
-      lineNumbers: getLineNumbersEnabled(context),
-      gitChangesGutter: getGitChangesGutterEnabled(context),
-      gitDiffLineHighlights: getGitDiffLineHighlightsEnabled(),
-      vimMode: getVimModeEnabled(context),
-      findOptions: getFindOptions(),
-      outlinePosition: getOutlinePosition(),
-      outlineVisible: getOutlineVisible(context),
-      theme: getThemeSettings(),
-      restoreTopLine: pendingRestoreTopLine ?? undefined,
-      restoreTopLineOffset: pendingRestoreTopLine === null ? undefined : pendingRestoreTopLineOffset
-    };
-    return postToWebview(message);
-  };
-
-  const sendDocChanged = async (): Promise<boolean> => {
-    const message: DocChangedMessage = {
-      type: 'docChanged',
-      text: document.getText(),
-      version: document.version
-    };
-    return postToWebview(message);
-  };
-
-  const sendApplied = async (version: number): Promise<boolean> => {
-    const message: AppliedMessage = {
-      type: 'applied',
-      version
-    };
-    return postToWebview(message);
-  };
-
-  const sendGitBaselineChanged = async (options: RefreshGitBaselineOptions = {}): Promise<boolean> => {
-    if (!initDelivered) {
-      return false;
-    }
-
-    const payload = await gitDocumentState.resolveBaseline({
-      includeText: true,
-      force: options.forceReload === true
-    });
-    gitDocumentState.noteBaselinePayload(payload);
-    const payloadHash = hashGitBaselinePayload(payload);
-    if (!options.forcePost && payloadHash === gitDocumentState.getLastSentBaselineHash()) {
-      return true;
-    }
-
-    const message: GitBaselineChangedMessage = {
-      type: 'gitBaselineChanged',
-      version: document.version,
-      payload
-    };
-    const posted = await postToWebview(message);
-    if (posted) {
-      gitDocumentState.setLastSentBaselineHash(payloadHash);
-    }
-    return posted;
-  };
-
-  const parseRevealOffsetFromUriFragment = (uri: vscode.Uri): number | null => {
-    const fragment = uri.fragment?.trim() ?? '';
-    if (!fragment) {
-      return null;
-    }
-
-    const match = /^(?:L)?(\d+)(?:(?:,|:|C)(\d+))?$/i.exec(fragment);
-    if (!match) {
-      return null;
-    }
-
-    const lineNumber = Number.parseInt(match[1], 10);
-    if (!Number.isFinite(lineNumber) || lineNumber < 1) {
-      return null;
-    }
-    const clampedLine = Math.min(lineNumber, document.lineCount);
-    const line = document.lineAt(clampedLine - 1);
-
-    const oneBasedColumn = match[2] ? Number.parseInt(match[2], 10) : 1;
-    const zeroBasedColumn = Number.isFinite(oneBasedColumn) && oneBasedColumn > 0 ? oneBasedColumn - 1 : 0;
-    const targetCharacter = Math.min(line.range.end.character, Math.max(0, zeroBasedColumn));
-    return document.offsetAt(new vscode.Position(clampedLine - 1, targetCharacter));
-  };
-
-  const ensureInitDelivered = async (): Promise<void> => {
-    if (disposed || initDelivered || !webviewReady) {
-      return;
-    }
-    const posted = await sendInit();
-    if (posted) {
-      initDelivered = true;
-    }
-  };
-
-  const requestExportSnapshot = async (): Promise<{ text: string; environment?: ExportStyleEnvironment }> => {
-    await ensureInitDelivered();
-    if (disposed) {
-      throw new Error('The editor was closed before export completed.');
-    }
-    const requestId = `export-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-
-    const response = new Promise<{ text: string; environment?: ExportStyleEnvironment }>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        pendingExportSnapshots.delete(requestId);
-        reject(new Error('Timed out waiting for export snapshot from the editor.'));
-      }, 20000);
-
-      pendingExportSnapshots.set(requestId, { resolve, reject, timer });
-    });
-
-    const message: RequestExportSnapshotMessage = {
-      type: 'requestExportSnapshot',
-      requestId
-    };
-    const posted = await postToWebview(message);
-    if (!posted) {
-      rejectPendingExportSnapshot(requestId, new Error('The editor webview is not ready to export.'));
-    }
-
-    return response;
-  };
-
-  const rejectPendingExportSnapshot = (requestId: string, error: Error): void => {
-    const pending = pendingExportSnapshots.get(requestId);
-    if (!pending) {
-      return;
-    }
-    clearTimeout(pending.timer);
-    pendingExportSnapshots.delete(requestId);
-    pending.reject(error);
-  };
-
-  const resolvePendingExportSnapshot = (
-    requestId: string,
-    value: { text: string; environment?: ExportStyleEnvironment }
-  ): void => {
-    const pending = pendingExportSnapshots.get(requestId);
-    if (!pending) {
-      return;
-    }
-    clearTimeout(pending.timer);
-    pendingExportSnapshots.delete(requestId);
-    pending.resolve(value);
-  };
-
-  const rejectPendingExportSnapshots = (error: Error): void => {
-    for (const requestId of pendingExportSnapshots.keys()) {
-      rejectPendingExportSnapshot(requestId, error);
-    }
-  };
-
-  const runPendingGitRefreshes = async (): Promise<void> => {
-    if (gitRefreshRunning || !webviewReady) {
-      return;
-    }
-    gitRefreshRunning = true;
-    try {
-      while (gitRefreshPending) {
-        const nextOptions: RefreshGitBaselineOptions = {
-          forcePost: gitRefreshPendingForcePost,
-          forceReload: gitRefreshPendingForceReload
-        };
-        gitRefreshPending = false;
-        gitRefreshPendingForcePost = false;
-        gitRefreshPendingForceReload = false;
-        try {
-          await ensureInitDelivered();
-          if (!initDelivered) {
-            gitRefreshPending = true;
-            gitRefreshPendingForcePost = gitRefreshPendingForcePost || nextOptions.forcePost === true;
-            gitRefreshPendingForceReload = gitRefreshPendingForceReload || nextOptions.forceReload === true;
+    const reportBackgroundError = (contextLabel: string, error: unknown): void => {
+        if (disposed) {
             return;
-          }
-          await sendGitBaselineChanged(nextOptions);
+        }
+        console.error(`[MEO panelSession] ${contextLabel}`, error);
+    };
+
+    const runBackground = (promise: Promise<unknown>, contextLabel: string): void => {
+        void promise.catch((error) => {
+            reportBackgroundError(contextLabel, error);
+        });
+    };
+
+    const postToWebview = async (message: Record<string, unknown>): Promise<boolean> => {
+        if (disposed) {
+            return false;
+        }
+        try {
+            return await panel.webview.postMessage(message);
         } catch {
-          // Keep refresh coalescing alive across transient git/webview failures.
+            return false;
         }
-      }
-    } finally {
-      gitRefreshRunning = false;
-      if (gitRefreshPending) {
-        runBackground(runPendingGitRefreshes(), 'runPendingGitRefreshes.retry');
-      }
-    }
-  };
-
-  const refreshGitBaseline = (options: RefreshGitBaselineOptions = {}): void => {
-    if (options.forceReload) {
-      gitDocumentState.invalidate();
-    }
-    gitRefreshPending = true;
-    gitRefreshPendingForcePost = gitRefreshPendingForcePost || options.forcePost === true;
-    gitRefreshPendingForceReload = gitRefreshPendingForceReload || options.forceReload === true;
-    runBackground(runPendingGitRefreshes(), 'runPendingGitRefreshes');
-  };
-
-  const isTextEditorForDocument = (textEditor: vscode.TextEditor | undefined): textEditor is vscode.TextEditor => {
-    if (!textEditor) {
-      return false;
-    }
-    return textEditor.document.uri.toString() === documentKey;
-  };
-
-  const revealSelectionForTextEditor = (textEditor: vscode.TextEditor): RevealSelectionPayload => {
-    const anchor = textEditor.document.offsetAt(textEditor.selection.start);
-    const head = textEditor.document.offsetAt(textEditor.selection.end);
-    return { anchor, head };
-  };
-
-  const getRevealSelectionKey = (selection: RevealSelectionPayload): string => {
-    return `${selection.anchor}:${selection.head}`;
-  };
-
-  const postRevealSelection = async (selection: RevealSelectionPayload): Promise<void> => {
-    if (!webviewReady) {
-      pendingRevealSelection = selection;
-      return;
-    }
-    await ensureInitDelivered();
-    if (!initDelivered) {
-      pendingRevealSelection = selection;
-      return;
-    }
-    const message: RevealSelectionMessage = {
-      type: 'revealSelection',
-      anchor: selection.anchor,
-      head: selection.head
     };
-    const posted = await postToWebview(message);
-    if (posted) {
-      lastSentRevealSelectionKey = getRevealSelectionKey(selection);
-      pendingRevealSelection = null;
-    } else {
-      pendingRevealSelection = selection;
-    }
-  };
 
-  const flushPendingRevealSelection = async (): Promise<void> => {
-    if (pendingRevealSelection === null) {
-      return;
-    }
-    await postRevealSelection(pendingRevealSelection);
-  };
-
-  const postFocusEditor = async (): Promise<void> => {
-    if (!webviewReady) {
-      return;
-    }
-    await ensureInitDelivered();
-    if (!initDelivered) {
-      return;
-    }
-    const message: FocusEditorMessage = { type: 'focusEditor' };
-    await postToWebview(message);
-  };
-
-  const sendRevealSelectionForEditor = async (textEditor: vscode.TextEditor | undefined): Promise<void> => {
-    if (!isTextEditorForDocument(textEditor)) {
-      return;
-    }
-
-    const selection = revealSelectionForTextEditor(textEditor);
-    if (lastSentRevealSelectionKey === getRevealSelectionKey(selection)) {
-      return;
-    }
-    await postRevealSelection(selection);
-  };
-
-  const findEditorForDocumentReveal = (): vscode.TextEditor | undefined => {
-    const active = vscode.window.activeTextEditor;
-    if (isTextEditorForDocument(active)) {
-      return active;
-    }
-    return vscode.window.visibleTextEditors.find((editor) => isTextEditorForDocument(editor));
-  };
-
-  const resolveRememberedTopLineForInit = (): { line: number; lineOffset: number } | null => {
-    const minLines = getRememberPositionLines();
-    if (document.lineCount < minLines) {
-      runBackground(clearRememberedViewPosition(), 'clearRememberedViewPosition.initThreshold');
-      return null;
-    }
-
-    if (pendingRevealSelection !== null) {
-      return null;
-    }
-
-    const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
-    const remembered = rememberedPositions[documentKey];
-    if (!remembered) {
-      return null;
-    }
-
-    const normalizedRemembered = normalizeRememberedTopLine(remembered.line, remembered.lineOffset, document.lineCount);
-    const clampedLine = normalizedRemembered.line;
-    const lineOffset = normalizedRemembered.lineOffset;
-    if (
-      normalizedRemembered.adjustedForEof &&
-      (remembered.line !== clampedLine || normalizeLineOffset(remembered.lineOffset) !== lineOffset)
-    ) {
-      rememberedPositions[documentKey] = {
-        line: clampedLine,
-        lineOffset,
-        updatedAt: Date.now()
-      };
-      runBackground(
-        context.workspaceState.update(
-          REMEMBERED_VIEW_POSITIONS_STATE_KEY,
-          pruneRememberedViewPositionMap(rememberedPositions)
-        ),
-        'saveRememberedViewPosition.eofBackoff'
-      );
-    }
-    lastSavedRememberedLine = clampedLine;
-    lastSavedRememberedLineOffset = lineOffset;
-    return {
-      line: clampedLine,
-      lineOffset
-    };
-  };
-
-  const initialRevealEditor = findEditorForDocumentReveal();
-  if (initialRevealEditor) {
-    pendingRevealSelection = revealSelectionForTextEditor(initialRevealEditor);
-  } else {
-    const initialOffset = parseRevealOffsetFromUriFragment(document.uri);
-    pendingRevealSelection = initialOffset === null ? null : { anchor: initialOffset, head: initialOffset };
-  }
-  const rememberedTopLine = resolveRememberedTopLineForInit();
-  if (rememberedTopLine) {
-    pendingRestoreTopLine = rememberedTopLine.line;
-    pendingRestoreTopLineOffset = rememberedTopLine.lineOffset;
-  }
-
-  const session: PanelSession = {
-    panel,
-    document,
-    documentUri,
-    gitDocumentState,
-    getMode: () => mode,
-    ensureInitDelivered,
-    requestExportSnapshot,
-    rejectPendingExportSnapshots,
-    refreshGitBaseline,
-    getGitRepoRoot: () => gitDocumentState.getRepoRoot()
-  };
-
-  const handleMessage = async (raw: WebviewMessage): Promise<void> => {
-    if (disposed) {
-      return;
-    }
-    switch (raw.type) {
-      case 'ready':
-        webviewReady = true;
-        await ensureInitDelivered();
-        await flushPendingRevealSelection();
-        gitRefreshPending = true;
-        gitRefreshPendingForcePost = true;
-        await runPendingGitRefreshes();
-        return;
-      case 'setMode':
-        mode = raw.mode;
-        return;
-      case 'setLineNumbers': {
-        const visible = raw.visible ?? raw.enabled;
-        if (typeof visible !== 'boolean') {
-          return;
+    const applyPendingDraftIfNeeded = async (): Promise<boolean> => {
+        const draftText = pendingDraftText;
+        pendingDraftText = null;
+        if (draftText === null) {
+            return false;
         }
-        await vscode.workspace
-          .getConfiguration(EXTENSION_CONFIG_SECTION)
-          .update(LINE_NUMBERS_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
-        return;
-      }
-      case 'setGitChangesGutter': {
-        const visible = raw.visible ?? raw.enabled;
-        if (typeof visible !== 'boolean') {
-          return;
+
+        const currentText = document.getText();
+        const normalizedCurrent = currentText.replace(/\r\n/g, "\n");
+        const normalizedDraft = draftText.replace(/\r\n/g, "\n");
+        if (normalizedCurrent === normalizedDraft) {
+            return false;
         }
-        await vscode.workspace
-          .getConfiguration(EXTENSION_CONFIG_SECTION)
-          .update(GIT_CHANGES_GUTTER_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
-        return;
-      }
-      case 'setOutlineVisible':
-        await setOutlineVisible(raw.visible);
-        return;
-      case 'setFindOptions': {
-        const wholeWord = raw.findOptions?.wholeWord ?? raw.wholeWord;
-        const caseSensitive = raw.findOptions?.caseSensitive ?? raw.caseSensitive;
-        await setFindOptions({
-          wholeWord: wholeWord === true,
-          caseSensitive: caseSensitive === true
-        });
-        return;
-      }
-      case 'viewPositionChanged':
-        if (Number.isFinite(raw.topLine)) {
-          await enqueue(async () => {
-            await saveRememberedViewPosition(raw.topLine, raw.topLineOffset);
-          });
-        }
-        return;
-      case 'exportDocument':
-        await onExportDocument(session, raw.format);
-        return;
-      case 'openLink':
-        await openLink(raw.href, documentUri);
-        return;
-      case 'resolveImageSrc': {
-        const response: ResolvedImageSrcMessage = {
-          type: 'resolvedImageSrc',
-          requestId: raw.requestId,
-          resolvedUrl: resolveWebviewImageSrc(raw.url, documentUri, panel.webview)
-        };
-        await postToWebview(response);
-        return;
-      }
-      case 'resolveWikiLinks': {
-        const response: ResolvedWikiLinksMessage = {
-          type: 'resolvedWikiLinks',
-          requestId: raw.requestId,
-          results: await resolveWikiLinkTargets(raw.targets, documentUri)
-        };
-        await postToWebview(response);
-        return;
-      }
-      case 'resolveLocalLinks': {
-        const response: ResolvedLocalLinksMessage = {
-          type: 'resolvedLocalLinks',
-          requestId: raw.requestId,
-          results: await resolveLocalLinkTargets(raw.targets, documentUri)
-        };
-        await postToWebview(response);
-        return;
-      }
-      case 'exportSnapshot':
-        resolvePendingExportSnapshot(raw.requestId, {
-          text: raw.text,
-          environment: raw.environment
-        });
-        return;
-      case 'exportSnapshotError':
-        rejectPendingExportSnapshot(raw.requestId, new Error(raw.message || 'Failed to collect export snapshot.'));
-        return;
-      case 'requestGitBlame': {
-        const resolved = await resolveGitBlameForRequest(documentUri, raw, document.getText(), gitDocumentState);
-        const response: GitBlameResultMessage = {
-          type: 'gitBlameResult',
-          requestId: raw.requestId,
-          lineNumber: raw.lineNumber,
-          localEditGeneration: raw.localEditGeneration,
-          result: resolved.result
-        };
-        await postToWebview(response);
-        return;
-      }
-      case 'openGitRevisionForLine':
-        await openGitRevisionForLine(documentUri, raw, document.getText(), gitDocumentState);
-        return;
-      case 'openGitWorktreeForLine':
-        await openGitWorktreeForLine(documentUri, raw, document.getText(), gitDocumentState);
-        return;
-      case 'applyChanges':
+
+        const edit = new vscode.WorkspaceEdit();
+        const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(currentText.length));
         agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
-        isApplyingOwnChange = true;
-        try {
-          await enqueue(async () => {
-            await applyDocumentChanges(document, raw, sendDocChanged, sendApplied);
-          });
-        } finally {
-          isApplyingOwnChange = false;
+        edit.replace(document.uri, fullRange, draftText);
+        return vscode.workspace.applyEdit(edit);
+    };
+
+    const clearRememberedViewPosition = async (): Promise<void> => {
+        const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
+        if (!(documentKey in rememberedPositions)) {
+            return;
         }
-        return;
-      case 'draftChanged':
-        pendingDraftText = raw.text;
-        return;
-      case 'saveDocument':
-        isApplyingOwnChange = true;
-        try {
-          await enqueue(async () => {
-            await document.save();
-          });
-        } finally {
-          isApplyingOwnChange = false;
+        delete rememberedPositions[documentKey];
+        await context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, rememberedPositions);
+        lastSavedRememberedLine = null;
+        lastSavedRememberedLineOffset = 0;
+    };
+
+    const saveRememberedViewPosition = async (topLine: number, topLineOffset: number | undefined): Promise<void> => {
+        const minLines = getRememberPositionLines();
+        if (document.lineCount < minLines) {
+            await clearRememberedViewPosition();
+            return;
         }
-        return;
-      case 'saveImageFromClipboard': {
-        const response = await handleSaveImageFromClipboard(raw, documentUri);
-        await postToWebview(response);
-        return;
-      }
+
+        const normalizedRemembered = normalizeRememberedTopLine(topLine, topLineOffset, document.lineCount);
+        const clampedLine = normalizedRemembered.line;
+        const normalizedOffset = normalizedRemembered.lineOffset;
+        if (lastSavedRememberedLine === clampedLine && lastSavedRememberedLineOffset === normalizedOffset) {
+            return;
+        }
+
+        const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
+        const existing = rememberedPositions[documentKey];
+        if (existing?.line === clampedLine && existing.lineOffset === normalizedOffset) {
+            lastSavedRememberedLine = clampedLine;
+            lastSavedRememberedLineOffset = normalizedOffset;
+            return;
+        }
+
+        rememberedPositions[documentKey] = {
+            line: clampedLine,
+            lineOffset: normalizedOffset,
+            updatedAt: Date.now(),
+        };
+
+        await context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, pruneRememberedViewPositionMap(rememberedPositions));
+        lastSavedRememberedLine = clampedLine;
+        lastSavedRememberedLineOffset = normalizedOffset;
+    };
+
+    const sendInit = async (): Promise<boolean> => {
+        const message: InitMessage = {
+            type: "init",
+            text: document.getText(),
+            version: document.version,
+            mode,
+            lineNumbers: getLineNumbersEnabled(context),
+            gitChangesGutter: getGitChangesGutterEnabled(context),
+            gitDiffLineHighlights: getGitDiffLineHighlightsEnabled(),
+            vimMode: getVimModeEnabled(context),
+            vimKeybindings: getVimKeybindings(),
+            vimLeader: getVimLeaderKey(),
+            findOptions: getFindOptions(),
+            outlinePosition: getOutlinePosition(),
+            outlineVisible: getOutlineVisible(context),
+            theme: getThemeSettings(),
+            restoreTopLine: pendingRestoreTopLine ?? undefined,
+            restoreTopLineOffset: pendingRestoreTopLine === null ? undefined : pendingRestoreTopLineOffset,
+        };
+        return postToWebview(message);
+    };
+
+    const sendDocChanged = async (): Promise<boolean> => {
+        const message: DocChangedMessage = {
+            type: "docChanged",
+            text: document.getText(),
+            version: document.version,
+        };
+        return postToWebview(message);
+    };
+
+    const sendApplied = async (version: number): Promise<boolean> => {
+        const message: AppliedMessage = {
+            type: "applied",
+            version,
+        };
+        return postToWebview(message);
+    };
+
+    const sendGitBaselineChanged = async (options: RefreshGitBaselineOptions = {}): Promise<boolean> => {
+        if (!initDelivered) {
+            return false;
+        }
+
+        const payload = await gitDocumentState.resolveBaseline({
+            includeText: true,
+            force: options.forceReload === true,
+        });
+        gitDocumentState.noteBaselinePayload(payload);
+        const payloadHash = hashGitBaselinePayload(payload);
+        if (!options.forcePost && payloadHash === gitDocumentState.getLastSentBaselineHash()) {
+            return true;
+        }
+
+        const message: GitBaselineChangedMessage = {
+            type: "gitBaselineChanged",
+            version: document.version,
+            payload,
+        };
+        const posted = await postToWebview(message);
+        if (posted) {
+            gitDocumentState.setLastSentBaselineHash(payloadHash);
+        }
+        return posted;
+    };
+
+    const parseRevealOffsetFromUriFragment = (uri: vscode.Uri): number | null => {
+        const fragment = uri.fragment?.trim() ?? "";
+        if (!fragment) {
+            return null;
+        }
+
+        const match = /^(?:L)?(\d+)(?:(?:,|:|C)(\d+))?$/i.exec(fragment);
+        if (!match) {
+            return null;
+        }
+
+        const lineNumber = Number.parseInt(match[1], 10);
+        if (!Number.isFinite(lineNumber) || lineNumber < 1) {
+            return null;
+        }
+        const clampedLine = Math.min(lineNumber, document.lineCount);
+        const line = document.lineAt(clampedLine - 1);
+
+        const oneBasedColumn = match[2] ? Number.parseInt(match[2], 10) : 1;
+        const zeroBasedColumn = Number.isFinite(oneBasedColumn) && oneBasedColumn > 0 ? oneBasedColumn - 1 : 0;
+        const targetCharacter = Math.min(line.range.end.character, Math.max(0, zeroBasedColumn));
+        return document.offsetAt(new vscode.Position(clampedLine - 1, targetCharacter));
+    };
+
+    const ensureInitDelivered = async (): Promise<void> => {
+        if (disposed || initDelivered || !webviewReady) {
+            return;
+        }
+        const posted = await sendInit();
+        if (posted) {
+            initDelivered = true;
+        }
+    };
+
+    const requestExportSnapshot = async (): Promise<{ text: string; environment?: ExportStyleEnvironment }> => {
+        await ensureInitDelivered();
+        if (disposed) {
+            throw new Error("The editor was closed before export completed.");
+        }
+        const requestId = `export-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+        const response = new Promise<{ text: string; environment?: ExportStyleEnvironment }>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                pendingExportSnapshots.delete(requestId);
+                reject(new Error("Timed out waiting for export snapshot from the editor."));
+            }, 20000);
+
+            pendingExportSnapshots.set(requestId, { resolve, reject, timer });
+        });
+
+        const message: RequestExportSnapshotMessage = {
+            type: "requestExportSnapshot",
+            requestId,
+        };
+        const posted = await postToWebview(message);
+        if (!posted) {
+            rejectPendingExportSnapshot(requestId, new Error("The editor webview is not ready to export."));
+        }
+
+        return response;
+    };
+
+    const rejectPendingExportSnapshot = (requestId: string, error: Error): void => {
+        const pending = pendingExportSnapshots.get(requestId);
+        if (!pending) {
+            return;
+        }
+        clearTimeout(pending.timer);
+        pendingExportSnapshots.delete(requestId);
+        pending.reject(error);
+    };
+
+    const resolvePendingExportSnapshot = (requestId: string, value: { text: string; environment?: ExportStyleEnvironment }): void => {
+        const pending = pendingExportSnapshots.get(requestId);
+        if (!pending) {
+            return;
+        }
+        clearTimeout(pending.timer);
+        pendingExportSnapshots.delete(requestId);
+        pending.resolve(value);
+    };
+
+    const rejectPendingExportSnapshots = (error: Error): void => {
+        for (const requestId of pendingExportSnapshots.keys()) {
+            rejectPendingExportSnapshot(requestId, error);
+        }
+    };
+
+    const runPendingGitRefreshes = async (): Promise<void> => {
+        if (gitRefreshRunning || !webviewReady) {
+            return;
+        }
+        gitRefreshRunning = true;
+        try {
+            while (gitRefreshPending) {
+                const nextOptions: RefreshGitBaselineOptions = {
+                    forcePost: gitRefreshPendingForcePost,
+                    forceReload: gitRefreshPendingForceReload,
+                };
+                gitRefreshPending = false;
+                gitRefreshPendingForcePost = false;
+                gitRefreshPendingForceReload = false;
+                try {
+                    await ensureInitDelivered();
+                    if (!initDelivered) {
+                        gitRefreshPending = true;
+                        gitRefreshPendingForcePost = gitRefreshPendingForcePost || nextOptions.forcePost === true;
+                        gitRefreshPendingForceReload = gitRefreshPendingForceReload || nextOptions.forceReload === true;
+                        return;
+                    }
+                    await sendGitBaselineChanged(nextOptions);
+                } catch {
+                    // Keep refresh coalescing alive across transient git/webview failures.
+                }
+            }
+        } finally {
+            gitRefreshRunning = false;
+            if (gitRefreshPending) {
+                runBackground(runPendingGitRefreshes(), "runPendingGitRefreshes.retry");
+            }
+        }
+    };
+
+    const refreshGitBaseline = (options: RefreshGitBaselineOptions = {}): void => {
+        if (options.forceReload) {
+            gitDocumentState.invalidate();
+        }
+        gitRefreshPending = true;
+        gitRefreshPendingForcePost = gitRefreshPendingForcePost || options.forcePost === true;
+        gitRefreshPendingForceReload = gitRefreshPendingForceReload || options.forceReload === true;
+        runBackground(runPendingGitRefreshes(), "runPendingGitRefreshes");
+    };
+
+    const isTextEditorForDocument = (textEditor: vscode.TextEditor | undefined): textEditor is vscode.TextEditor => {
+        if (!textEditor) {
+            return false;
+        }
+        return textEditor.document.uri.toString() === documentKey;
+    };
+
+    const revealSelectionForTextEditor = (textEditor: vscode.TextEditor): RevealSelectionPayload => {
+        const anchor = textEditor.document.offsetAt(textEditor.selection.start);
+        const head = textEditor.document.offsetAt(textEditor.selection.end);
+        return { anchor, head };
+    };
+
+    const getRevealSelectionKey = (selection: RevealSelectionPayload): string => {
+        return `${selection.anchor}:${selection.head}`;
+    };
+
+    const postRevealSelection = async (selection: RevealSelectionPayload): Promise<void> => {
+        if (!webviewReady) {
+            pendingRevealSelection = selection;
+            return;
+        }
+        await ensureInitDelivered();
+        if (!initDelivered) {
+            pendingRevealSelection = selection;
+            return;
+        }
+        const message: RevealSelectionMessage = {
+            type: "revealSelection",
+            anchor: selection.anchor,
+            head: selection.head,
+        };
+        const posted = await postToWebview(message);
+        if (posted) {
+            lastSentRevealSelectionKey = getRevealSelectionKey(selection);
+            pendingRevealSelection = null;
+        } else {
+            pendingRevealSelection = selection;
+        }
+    };
+
+    const flushPendingRevealSelection = async (): Promise<void> => {
+        if (pendingRevealSelection === null) {
+            return;
+        }
+        await postRevealSelection(pendingRevealSelection);
+    };
+
+    const postFocusEditor = async (): Promise<void> => {
+        if (!webviewReady) {
+            return;
+        }
+        await ensureInitDelivered();
+        if (!initDelivered) {
+            return;
+        }
+        const message: FocusEditorMessage = { type: "focusEditor" };
+        await postToWebview(message);
+    };
+
+    const sendRevealSelectionForEditor = async (textEditor: vscode.TextEditor | undefined): Promise<void> => {
+        if (!isTextEditorForDocument(textEditor)) {
+            return;
+        }
+
+        const selection = revealSelectionForTextEditor(textEditor);
+        if (lastSentRevealSelectionKey === getRevealSelectionKey(selection)) {
+            return;
+        }
+        await postRevealSelection(selection);
+    };
+
+    const findEditorForDocumentReveal = (): vscode.TextEditor | undefined => {
+        const active = vscode.window.activeTextEditor;
+        if (isTextEditorForDocument(active)) {
+            return active;
+        }
+        return vscode.window.visibleTextEditors.find((editor) => isTextEditorForDocument(editor));
+    };
+
+    const resolveRememberedTopLineForInit = (): { line: number; lineOffset: number } | null => {
+        const minLines = getRememberPositionLines();
+        if (document.lineCount < minLines) {
+            runBackground(clearRememberedViewPosition(), "clearRememberedViewPosition.initThreshold");
+            return null;
+        }
+
+        if (pendingRevealSelection !== null) {
+            return null;
+        }
+
+        const rememberedPositions = getRememberedViewPositionMap(context.workspaceState);
+        const remembered = rememberedPositions[documentKey];
+        if (!remembered) {
+            return null;
+        }
+
+        const normalizedRemembered = normalizeRememberedTopLine(remembered.line, remembered.lineOffset, document.lineCount);
+        const clampedLine = normalizedRemembered.line;
+        const lineOffset = normalizedRemembered.lineOffset;
+        if (normalizedRemembered.adjustedForEof && (remembered.line !== clampedLine || normalizeLineOffset(remembered.lineOffset) !== lineOffset)) {
+            rememberedPositions[documentKey] = {
+                line: clampedLine,
+                lineOffset,
+                updatedAt: Date.now(),
+            };
+            runBackground(context.workspaceState.update(REMEMBERED_VIEW_POSITIONS_STATE_KEY, pruneRememberedViewPositionMap(rememberedPositions)), "saveRememberedViewPosition.eofBackoff");
+        }
+        lastSavedRememberedLine = clampedLine;
+        lastSavedRememberedLineOffset = lineOffset;
+        return {
+            line: clampedLine,
+            lineOffset,
+        };
+    };
+
+    const initialRevealEditor = findEditorForDocumentReveal();
+    if (initialRevealEditor) {
+        pendingRevealSelection = revealSelectionForTextEditor(initialRevealEditor);
+    } else {
+        const initialOffset = parseRevealOffsetFromUriFragment(document.uri);
+        pendingRevealSelection = initialOffset === null ? null : { anchor: initialOffset, head: initialOffset };
     }
-  };
-
-  const messageSubscription = panel.webview.onDidReceiveMessage((raw: WebviewMessage) => {
-    runBackground(handleMessage(raw), 'handleMessage');
-  });
-
-  const documentChangeSubscription = vscode.workspace.onDidChangeTextDocument((event) => {
-    if (event.document.uri.toString() !== documentKey) {
-      return;
+    const rememberedTopLine = resolveRememberedTopLineForInit();
+    if (rememberedTopLine) {
+        pendingRestoreTopLine = rememberedTopLine.line;
+        pendingRestoreTopLineOffset = rememberedTopLine.lineOffset;
     }
 
-    // Save/dirty-state transitions can emit document events without text edits.
-    if (event.contentChanges.length === 0) {
-      return;
-    }
+    const session: PanelSession = {
+        panel,
+        document,
+        documentUri,
+        gitDocumentState,
+        getMode: () => mode,
+        ensureInitDelivered,
+        requestExportSnapshot,
+        rejectPendingExportSnapshots,
+        refreshGitBaseline,
+        getGitRepoRoot: () => gitDocumentState.getRepoRoot(),
+    };
 
-    if (isApplyingOwnChange) {
-      return;
-    }
+    const handleMessage = async (raw: WebviewMessage): Promise<void> => {
+        if (disposed) {
+            return;
+        }
+        switch (raw.type) {
+            case "ready":
+                webviewReady = true;
+                await ensureInitDelivered();
+                await flushPendingRevealSelection();
+                gitRefreshPending = true;
+                gitRefreshPendingForcePost = true;
+                await runPendingGitRefreshes();
+                return;
+            case "setMode":
+                mode = raw.mode;
+                return;
+            case "setLineNumbers": {
+                const visible = raw.visible ?? raw.enabled;
+                if (typeof visible !== "boolean") {
+                    return;
+                }
+                await vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).update(LINE_NUMBERS_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
+                return;
+            }
+            case "setGitChangesGutter": {
+                const visible = raw.visible ?? raw.enabled;
+                if (typeof visible !== "boolean") {
+                    return;
+                }
+                await vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).update(GIT_CHANGES_GUTTER_SETTING_KEY, visible, vscode.ConfigurationTarget.Global);
+                return;
+            }
+            case "setOutlineVisible":
+                await setOutlineVisible(raw.visible);
+                return;
+            case "setFindOptions": {
+                const wholeWord = raw.findOptions?.wholeWord ?? raw.wholeWord;
+                const caseSensitive = raw.findOptions?.caseSensitive ?? raw.caseSensitive;
+                await setFindOptions({
+                    wholeWord: wholeWord === true,
+                    caseSensitive: caseSensitive === true,
+                });
+                return;
+            }
+            case "viewPositionChanged":
+                if (Number.isFinite(raw.topLine)) {
+                    await enqueue(async () => {
+                        await saveRememberedViewPosition(raw.topLine, raw.topLineOffset);
+                    });
+                }
+                return;
+            case "exportDocument":
+                await onExportDocument(session, raw.format);
+                return;
+            case "openLink":
+                await openLink(raw.href, documentUri);
+                return;
+            case "resolveImageSrc": {
+                const response: ResolvedImageSrcMessage = {
+                    type: "resolvedImageSrc",
+                    requestId: raw.requestId,
+                    resolvedUrl: resolveWebviewImageSrc(raw.url, documentUri, panel.webview),
+                };
+                await postToWebview(response);
+                return;
+            }
+            case "resolveWikiLinks": {
+                const response: ResolvedWikiLinksMessage = {
+                    type: "resolvedWikiLinks",
+                    requestId: raw.requestId,
+                    results: await resolveWikiLinkTargets(raw.targets, documentUri),
+                };
+                await postToWebview(response);
+                return;
+            }
+            case "resolveLocalLinks": {
+                const response: ResolvedLocalLinksMessage = {
+                    type: "resolvedLocalLinks",
+                    requestId: raw.requestId,
+                    results: await resolveLocalLinkTargets(raw.targets, documentUri),
+                };
+                await postToWebview(response);
+                return;
+            }
+            case "exportSnapshot":
+                resolvePendingExportSnapshot(raw.requestId, {
+                    text: raw.text,
+                    environment: raw.environment,
+                });
+                return;
+            case "exportSnapshotError":
+                rejectPendingExportSnapshot(raw.requestId, new Error(raw.message || "Failed to collect export snapshot."));
+                return;
+            case "requestGitBlame": {
+                const resolved = await resolveGitBlameForRequest(documentUri, raw, document.getText(), gitDocumentState);
+                const response: GitBlameResultMessage = {
+                    type: "gitBlameResult",
+                    requestId: raw.requestId,
+                    lineNumber: raw.lineNumber,
+                    localEditGeneration: raw.localEditGeneration,
+                    result: resolved.result,
+                };
+                await postToWebview(response);
+                return;
+            }
+            case "openGitRevisionForLine":
+                await openGitRevisionForLine(documentUri, raw, document.getText(), gitDocumentState);
+                return;
+            case "openGitWorktreeForLine":
+                await openGitWorktreeForLine(documentUri, raw, document.getText(), gitDocumentState);
+                return;
+            case "applyChanges":
+                agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
+                isApplyingOwnChange = true;
+                try {
+                    await enqueue(async () => {
+                        await applyDocumentChanges(document, raw, sendDocChanged, sendApplied);
+                    });
+                } finally {
+                    isApplyingOwnChange = false;
+                }
+                return;
+            case "draftChanged":
+                pendingDraftText = raw.text;
+                return;
+            case "saveDocument":
+                isApplyingOwnChange = true;
+                try {
+                    await enqueue(async () => {
+                        await document.save();
+                    });
+                } finally {
+                    isApplyingOwnChange = false;
+                }
+                return;
+            case "saveImageFromClipboard": {
+                const response = await handleSaveImageFromClipboard(raw, documentUri);
+                await postToWebview(response);
+                return;
+            }
+        }
+    };
 
-    runBackground(enqueue(async () => {
-      await sendDocChanged();
-    }), 'sendDocChanged');
-  });
+    const messageSubscription = panel.webview.onDidReceiveMessage((raw: WebviewMessage) => {
+        runBackground(handleMessage(raw), "handleMessage");
+    });
 
-  const documentSaveSubscription = vscode.workspace.onDidSaveTextDocument((savedDocument) => {
-    if (savedDocument.uri.toString() !== documentKey) {
-      return;
-    }
-    refreshGitBaseline({ forceReload: true });
-  });
+    const documentChangeSubscription = vscode.workspace.onDidChangeTextDocument((event) => {
+        if (event.document.uri.toString() !== documentKey) {
+            return;
+        }
 
-  const textEditorSelectionSubscription = vscode.window.onDidChangeTextEditorSelection((event) => {
-    if (!isTextEditorForDocument(event.textEditor)) {
-      return;
-    }
-    runBackground(sendRevealSelectionForEditor(event.textEditor), 'sendRevealSelectionForEditor.selection');
-  });
+        // Save/dirty-state transitions can emit document events without text edits.
+        if (event.contentChanges.length === 0) {
+            return;
+        }
 
-  const activeTextEditorSubscription = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
-    if (!isTextEditorForDocument(textEditor)) {
-      return;
-    }
-    runBackground(sendRevealSelectionForEditor(textEditor), 'sendRevealSelectionForEditor.activeEditor');
-  });
+        if (isApplyingOwnChange) {
+            return;
+        }
 
-  const visibleTextEditorsSubscription = vscode.window.onDidChangeVisibleTextEditors(() => {
-    runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), 'sendRevealSelectionForEditor.visibleEditors');
-  });
+        runBackground(
+            enqueue(async () => {
+                await sendDocChanged();
+            }),
+            "sendDocChanged",
+        );
+    });
 
-  const viewStateSubscription = panel.onDidChangeViewState((event) => {
-    if (event.webviewPanel.active) {
-      onPanelActivated(event.webviewPanel);
-      refreshGitBaseline({ forcePost: true });
-      runBackground(flushPendingRevealSelection(), 'flushPendingRevealSelection');
-      runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), 'sendRevealSelectionForEditor.viewState');
-      runBackground(postFocusEditor(), 'postFocusEditor');
-    }
-    onPanelViewStateChanged();
-  });
+    const documentSaveSubscription = vscode.workspace.onDidSaveTextDocument((savedDocument) => {
+        if (savedDocument.uri.toString() !== documentKey) {
+            return;
+        }
+        refreshGitBaseline({ forceReload: true });
+    });
 
-  const disposeSubscription = panel.onDidDispose(() => {
-    dispose();
-  });
+    const textEditorSelectionSubscription = vscode.window.onDidChangeTextEditorSelection((event) => {
+        if (!isTextEditorForDocument(event.textEditor)) {
+            return;
+        }
+        runBackground(sendRevealSelectionForEditor(event.textEditor), "sendRevealSelectionForEditor.selection");
+    });
 
-  refreshGitBaseline({ forcePost: true });
-  runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), 'sendRevealSelectionForEditor.startup');
+    const activeTextEditorSubscription = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
+        if (!isTextEditorForDocument(textEditor)) {
+            return;
+        }
+        runBackground(sendRevealSelectionForEditor(textEditor), "sendRevealSelectionForEditor.activeEditor");
+    });
 
-  const dispose = (): void => {
-    if (disposed) {
-      return;
-    }
-    disposed = true;
+    const visibleTextEditorsSubscription = vscode.window.onDidChangeVisibleTextEditors(() => {
+        runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), "sendRevealSelectionForEditor.visibleEditors");
+    });
 
-    runBackground(enqueue(async () => {
-      try {
-        // Best-effort recovery for edits that never made it through the debounce/apply round-trip.
-        await applyPendingDraftIfNeeded();
-      } catch {
-        // Ignore dispose-time recovery failures to avoid surfacing noisy teardown errors.
-      }
-    }), 'disposeDraftRecovery');
+    const viewStateSubscription = panel.onDidChangeViewState((event) => {
+        if (event.webviewPanel.active) {
+            onPanelActivated(event.webviewPanel);
+            refreshGitBaseline({ forcePost: true });
+            runBackground(flushPendingRevealSelection(), "flushPendingRevealSelection");
+            runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), "sendRevealSelectionForEditor.viewState");
+            runBackground(postFocusEditor(), "postFocusEditor");
+        }
+        onPanelViewStateChanged();
+    });
 
-    rejectPendingExportSnapshots(new Error('The editor was closed before export completed.'));
-    messageSubscription.dispose();
-    documentChangeSubscription.dispose();
-    documentSaveSubscription.dispose();
-    textEditorSelectionSubscription.dispose();
-    activeTextEditorSubscription.dispose();
-    visibleTextEditorsSubscription.dispose();
-    viewStateSubscription.dispose();
-    disposeSubscription.dispose();
-    onPanelDisposed(panel);
-  };
+    const disposeSubscription = panel.onDidDispose(() => {
+        dispose();
+    });
 
-  return {
-    session,
-    handleMessage,
-    dispose
-  };
+    refreshGitBaseline({ forcePost: true });
+    runBackground(sendRevealSelectionForEditor(findEditorForDocumentReveal()), "sendRevealSelectionForEditor.startup");
+
+    const dispose = (): void => {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+
+        runBackground(
+            enqueue(async () => {
+                try {
+                    // Best-effort recovery for edits that never made it through the debounce/apply round-trip.
+                    await applyPendingDraftIfNeeded();
+                } catch {
+                    // Ignore dispose-time recovery failures to avoid surfacing noisy teardown errors.
+                }
+            }),
+            "disposeDraftRecovery",
+        );
+
+        rejectPendingExportSnapshots(new Error("The editor was closed before export completed."));
+        messageSubscription.dispose();
+        documentChangeSubscription.dispose();
+        documentSaveSubscription.dispose();
+        textEditorSelectionSubscription.dispose();
+        activeTextEditorSubscription.dispose();
+        visibleTextEditorsSubscription.dispose();
+        viewStateSubscription.dispose();
+        disposeSubscription.dispose();
+        onPanelDisposed(panel);
+    };
+
+    return {
+        session,
+        handleMessage,
+        dispose,
+    };
 }
 
 function clampLineNumber(value: number, maxLine: number): number {
-  const numeric = Number.isFinite(value) ? Math.floor(value) : 1;
-  const max = Math.max(1, Math.floor(maxLine));
-  return Math.max(1, Math.min(numeric, max));
+    const numeric = Number.isFinite(value) ? Math.floor(value) : 1;
+    const max = Math.max(1, Math.floor(maxLine));
+    return Math.max(1, Math.min(numeric, max));
 }
 
 function normalizeLineOffset(value: number | undefined): number {
-  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : 0;
-  return Math.max(0, Math.round(numeric * 100) / 100);
+    const numeric = typeof value === "number" && Number.isFinite(value) ? value : 0;
+    return Math.max(0, Math.round(numeric * 100) / 100);
 }
 
-function normalizeRememberedTopLine(
-  line: number,
-  lineOffset: number | undefined,
-  maxLine: number
-): { line: number; lineOffset: number; adjustedForEof: boolean } {
-  const clampedLine = clampLineNumber(line, maxLine);
-  const normalizedOffset = normalizeLineOffset(lineOffset);
-  const nearEndLine = Math.max(1, maxLine - REMEMBERED_EOF_NEAR_THRESHOLD_LINES + 1);
-  if (clampedLine < nearEndLine) {
+function normalizeRememberedTopLine(line: number, lineOffset: number | undefined, maxLine: number): { line: number; lineOffset: number; adjustedForEof: boolean } {
+    const clampedLine = clampLineNumber(line, maxLine);
+    const normalizedOffset = normalizeLineOffset(lineOffset);
+    const nearEndLine = Math.max(1, maxLine - REMEMBERED_EOF_NEAR_THRESHOLD_LINES + 1);
+    if (clampedLine < nearEndLine) {
+        return {
+            line: clampedLine,
+            lineOffset: normalizedOffset,
+            adjustedForEof: false,
+        };
+    }
     return {
-      line: clampedLine,
-      lineOffset: normalizedOffset,
-      adjustedForEof: false
+        line: Math.max(1, clampedLine - REMEMBERED_EOF_BACKOFF_LINES),
+        lineOffset: 0,
+        adjustedForEof: true,
     };
-  }
-  return {
-    line: Math.max(1, clampedLine - REMEMBERED_EOF_BACKOFF_LINES),
-    lineOffset: 0,
-    adjustedForEof: true
-  };
 }
 
 function getRememberedViewPositionMap(workspaceState: vscode.Memento): Record<string, RememberedViewPosition> {
-  const stored = workspaceState.get<unknown>(REMEMBERED_VIEW_POSITIONS_STATE_KEY);
-  if (!stored || typeof stored !== 'object' || Array.isArray(stored)) {
-    return {};
-  }
+    const stored = workspaceState.get<unknown>(REMEMBERED_VIEW_POSITIONS_STATE_KEY);
+    if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+        return {};
+    }
 
-  const entries: Record<string, RememberedViewPosition> = {};
-  for (const [key, value] of Object.entries(stored as Record<string, unknown>)) {
-    if (typeof key !== 'string' || !key) {
-      continue;
+    const entries: Record<string, RememberedViewPosition> = {};
+    for (const [key, value] of Object.entries(stored as Record<string, unknown>)) {
+        if (typeof key !== "string" || !key) {
+            continue;
+        }
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+            continue;
+        }
+        const record = value as Partial<RememberedViewPosition>;
+        const line = Number(record.line);
+        const lineOffset = Number(record.lineOffset);
+        const updatedAt = Number(record.updatedAt);
+        if (!Number.isFinite(line) || !Number.isFinite(updatedAt)) {
+            continue;
+        }
+        entries[key] = {
+            line: Math.max(1, Math.floor(line)),
+            lineOffset: normalizeLineOffset(lineOffset),
+            updatedAt: Math.floor(updatedAt),
+        };
     }
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      continue;
+    return entries;
+}
+
+function pruneRememberedViewPositionMap(entries: Record<string, RememberedViewPosition>): Record<string, RememberedViewPosition> {
+    const sortedEntries = Object.entries(entries)
+        .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
+        .slice(0, MAX_REMEMBERED_VIEW_POSITIONS);
+    return Object.fromEntries(sortedEntries);
+}
+
+async function applyDocumentChanges(document: vscode.TextDocument, message: ApplyChangesMessage, sendDocChanged: () => Promise<boolean>, sendApplied: (version: number) => Promise<boolean>): Promise<void> {
+    if (message.baseVersion !== document.version) {
+        await sendDocChanged();
+        return;
     }
-    const record = value as Partial<RememberedViewPosition>;
-    const line = Number(record.line);
-    const lineOffset = Number(record.lineOffset);
-    const updatedAt = Number(record.updatedAt);
-    if (!Number.isFinite(line) || !Number.isFinite(updatedAt)) {
-      continue;
-    }
-    entries[key] = {
-      line: Math.max(1, Math.floor(line)),
-      lineOffset: normalizeLineOffset(lineOffset),
-      updatedAt: Math.floor(updatedAt)
+
+    const edit = new vscode.WorkspaceEdit();
+    const sortedChanges = [...message.changes].sort((a, b) => b.from - a.from);
+    const documentText = document.getText();
+    const mappedOffsetCache = new Map<number, number>();
+    const mapOffset = (offset: number): number => {
+        const cached = mappedOffsetCache.get(offset);
+        if (typeof cached === "number") {
+            return cached;
+        }
+        const mapped = mapNormalizedOffsetToDocumentOffset(documentText, offset);
+        mappedOffsetCache.set(offset, mapped);
+        return mapped;
     };
-  }
-  return entries;
-}
 
-function pruneRememberedViewPositionMap(
-  entries: Record<string, RememberedViewPosition>
-): Record<string, RememberedViewPosition> {
-  const sortedEntries = Object.entries(entries)
-    .sort(([, left], [, right]) => right.updatedAt - left.updatedAt)
-    .slice(0, MAX_REMEMBERED_VIEW_POSITIONS);
-  return Object.fromEntries(sortedEntries);
-}
-
-async function applyDocumentChanges(
-  document: vscode.TextDocument,
-  message: ApplyChangesMessage,
-  sendDocChanged: () => Promise<boolean>,
-  sendApplied: (version: number) => Promise<boolean>
-): Promise<void> {
-  if (message.baseVersion !== document.version) {
-    await sendDocChanged();
-    return;
-  }
-
-  const edit = new vscode.WorkspaceEdit();
-  const sortedChanges = [...message.changes].sort((a, b) => b.from - a.from);
-  const documentText = document.getText();
-  const mappedOffsetCache = new Map<number, number>();
-  const mapOffset = (offset: number): number => {
-    const cached = mappedOffsetCache.get(offset);
-    if (typeof cached === 'number') {
-      return cached;
+    for (const change of sortedChanges) {
+        // Webview offsets are LF-normalized; remap to real document offsets before applying edits.
+        const mappedFrom = mapOffset(change.from);
+        const mappedTo = mapOffset(change.to);
+        const startOffset = Math.min(mappedFrom, mappedTo);
+        const endOffset = Math.max(mappedFrom, mappedTo);
+        const range = new vscode.Range(document.positionAt(startOffset), document.positionAt(endOffset));
+        edit.replace(document.uri, range, change.insert);
     }
-    const mapped = mapNormalizedOffsetToDocumentOffset(documentText, offset);
-    mappedOffsetCache.set(offset, mapped);
-    return mapped;
-  };
 
-  for (const change of sortedChanges) {
-    // Webview offsets are LF-normalized; remap to real document offsets before applying edits.
-    const mappedFrom = mapOffset(change.from);
-    const mappedTo = mapOffset(change.to);
-    const startOffset = Math.min(mappedFrom, mappedTo);
-    const endOffset = Math.max(mappedFrom, mappedTo);
-    const range = new vscode.Range(
-      document.positionAt(startOffset),
-      document.positionAt(endOffset)
-    );
-    edit.replace(document.uri, range, change.insert);
-  }
+    const applied = await vscode.workspace.applyEdit(edit);
 
-  const applied = await vscode.workspace.applyEdit(edit);
+    if (!applied) {
+        await sendDocChanged();
+        return;
+    }
 
-  if (!applied) {
-    await sendDocChanged();
-    return;
-  }
-
-  await sendApplied(document.version);
+    await sendApplied(document.version);
 }
 
 function mapNormalizedOffsetToDocumentOffset(documentText: string, normalizedOffset: number): number {
-  const target = Number.isFinite(normalizedOffset) ? Math.max(0, normalizedOffset) : documentText.length;
-  if (target === 0) {
-    return 0;
-  }
-
-  let normalizedIndex = 0;
-  let documentIndex = 0;
-
-  while (documentIndex < documentText.length && normalizedIndex < target) {
-    if (documentText.charCodeAt(documentIndex) === 13) {
-      if (documentText.charCodeAt(documentIndex + 1) === 10) {
-        documentIndex += 2;
-      } else {
-        documentIndex += 1;
-      }
-      normalizedIndex += 1;
-      continue;
+    const target = Number.isFinite(normalizedOffset) ? Math.max(0, normalizedOffset) : documentText.length;
+    if (target === 0) {
+        return 0;
     }
 
-    documentIndex += 1;
-    normalizedIndex += 1;
-  }
+    let normalizedIndex = 0;
+    let documentIndex = 0;
 
-  return documentIndex;
+    while (documentIndex < documentText.length && normalizedIndex < target) {
+        if (documentText.charCodeAt(documentIndex) === 13) {
+            if (documentText.charCodeAt(documentIndex + 1) === 10) {
+                documentIndex += 2;
+            } else {
+                documentIndex += 1;
+            }
+            normalizedIndex += 1;
+            continue;
+        }
+
+        documentIndex += 1;
+        normalizedIndex += 1;
+    }
+
+    return documentIndex;
 }
 
-async function handleSaveImageFromClipboard(
-  message: SaveImageFromClipboardMessage,
-  documentUri: vscode.Uri
-): Promise<SavedImagePathMessage> {
-  const workspaceFolders = vscode.workspace.workspaceFolders;
-  if (!workspaceFolders || workspaceFolders.length === 0) {
-    return {
-      type: 'savedImagePath',
-      requestId: message.requestId,
-      success: false,
-      error: 'No workspace folder open'
-    };
-  }
-
-  const workspaceRoot = (vscode.workspace.getWorkspaceFolder(documentUri) ?? workspaceFolders[0]).uri;
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  const imageFolder = config.get<string>('imageFolder', 'assets');
-
-  try {
-    const base64Data = message.imageData.replace(/^data:image\/[^;]+;base64,/, '');
-    const imageBuffer = Buffer.from(base64Data, 'base64');
-
-    const assetsFolderUri = vscode.Uri.joinPath(workspaceRoot, imageFolder);
-
-    try {
-      await vscode.workspace.fs.stat(assetsFolderUri);
-    } catch {
-      await vscode.workspace.fs.createDirectory(assetsFolderUri);
+async function handleSaveImageFromClipboard(message: SaveImageFromClipboardMessage, documentUri: vscode.Uri): Promise<SavedImagePathMessage> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return {
+            type: "savedImagePath",
+            requestId: message.requestId,
+            success: false,
+            error: "No workspace folder open",
+        };
     }
 
-    const filePath = vscode.Uri.joinPath(assetsFolderUri, message.fileName);
-    await vscode.workspace.fs.writeFile(filePath, imageBuffer);
+    const workspaceRoot = (vscode.workspace.getWorkspaceFolder(documentUri) ?? workspaceFolders[0]).uri;
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    const imageFolder = config.get<string>("imageFolder", "assets");
 
-    const relativePath = path.relative(path.dirname(documentUri.fsPath), filePath.fsPath);
+    try {
+        const base64Data = message.imageData.replace(/^data:image\/[^;]+;base64,/, "");
+        const imageBuffer = Buffer.from(base64Data, "base64");
 
-    return {
-      type: 'savedImagePath',
-      requestId: message.requestId,
-      success: true,
-      path: relativePath.replace(/\\/g, '/')
-    };
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : 'Failed to save image';
-    return {
-      type: 'savedImagePath',
-      requestId: message.requestId,
-      success: false,
-      error: errorMessage
-    };
-  }
+        const assetsFolderUri = vscode.Uri.joinPath(workspaceRoot, imageFolder);
+
+        try {
+            await vscode.workspace.fs.stat(assetsFolderUri);
+        } catch {
+            await vscode.workspace.fs.createDirectory(assetsFolderUri);
+        }
+
+        const filePath = vscode.Uri.joinPath(assetsFolderUri, message.fileName);
+        await vscode.workspace.fs.writeFile(filePath, imageBuffer);
+
+        const relativePath = path.relative(path.dirname(documentUri.fsPath), filePath.fsPath);
+
+        return {
+            type: "savedImagePath",
+            requestId: message.requestId,
+            success: true,
+            path: relativePath.replace(/\\/g, "/"),
+        };
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "Failed to save image";
+        return {
+            type: "savedImagePath",
+            requestId: message.requestId,
+            success: false,
+            error: errorMessage,
+        };
+    }
 }

--- a/src/shared/extensionConfig.ts
+++ b/src/shared/extensionConfig.ts
@@ -1,282 +1,287 @@
-import * as vscode from 'vscode';
-import {
-  defaultThemeSettings,
-  resolveTheme,
-  serializeThemeSettings,
-  type ThemeSettings,
-  validateThemePayload
-} from './themeDefaults';
+import * as vscode from "vscode";
+import { defaultThemeSettings, resolveTheme, serializeThemeSettings, type ThemeSettings, validateThemePayload } from "./themeDefaults";
 
-export const EXTENSION_CONFIG_SECTION = 'markdownEditorOptimized';
-export const LINE_NUMBERS_SETTING_KEY = 'lineNumbers.visible';
-export const GIT_CHANGES_GUTTER_SETTING_KEY = 'gitChanges.visible';
-export const GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY = 'gitChanges.lineHighlights';
-export const VIM_MODE_SETTING_KEY = 'vimMode.enabled';
-export const REMEMBER_POSITION_LINES_SETTING_KEY = 'rememberPosition.lines';
-export const LINE_NUMBERS_LEGACY_SETTING_KEY = 'lineNumbers.enabled';
-export const LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY = 'lineNumbers.visibility';
-export const GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY = 'gitChanges.visibility';
-export const GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY = 'gitChangesGutter.visibility';
-export const GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY = 'gitChangesGutter.enabled';
-export const LINE_NUMBERS_KEY = 'lineNumbersEnabled';
-export const GIT_CHANGES_GUTTER_KEY = 'gitChangesGutterEnabled';
-export const VIM_MODE_KEY = 'vimModeEnabled';
-export const OUTLINE_VISIBLE_KEY = 'outlineVisible';
-export const MARKDOWN_FILE_EXTENSIONS = ['.md', '.markdown', '.mdx', '.mdc'] as const;
+export const EXTENSION_CONFIG_SECTION = "markdownEditorOptimized";
+export const LINE_NUMBERS_SETTING_KEY = "lineNumbers.visible";
+export const GIT_CHANGES_GUTTER_SETTING_KEY = "gitChanges.visible";
+export const GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY = "gitChanges.lineHighlights";
+export const VIM_MODE_SETTING_KEY = "vimMode.enabled";
+export const REMEMBER_POSITION_LINES_SETTING_KEY = "rememberPosition.lines";
+export const LINE_NUMBERS_LEGACY_SETTING_KEY = "lineNumbers.enabled";
+export const LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY = "lineNumbers.visibility";
+export const GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY = "gitChanges.visibility";
+export const GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY = "gitChangesGutter.visibility";
+export const GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY = "gitChangesGutter.enabled";
+export const LINE_NUMBERS_KEY = "lineNumbersEnabled";
+export const GIT_CHANGES_GUTTER_KEY = "gitChangesGutterEnabled";
+export const VIM_MODE_KEY = "vimModeEnabled";
+export const OUTLINE_VISIBLE_KEY = "outlineVisible";
+export const MARKDOWN_FILE_EXTENSIONS = [".md", ".markdown", ".mdx", ".mdc"] as const;
 
-export type OutlinePosition = 'left' | 'right';
-export type ExportHtmlImageMode = 'embedded' | 'linked';
+export type OutlinePosition = "left" | "right";
+export type ExportHtmlImageMode = "embedded" | "linked";
 
 export function getThemeSettings(): ThemeSettings {
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  const themeValue = config.get<unknown>('theme');
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    const themeValue = config.get<unknown>("theme");
 
-  if (!themeValue) {
-    return defaultThemeSettings;
-  }
+    if (!themeValue) {
+        return defaultThemeSettings;
+    }
 
-  const result = validateThemePayload(themeValue);
-  if (!result.success) {
-    return resolveTheme(themeValue as Partial<ThemeSettings>);
-  }
+    const result = validateThemePayload(themeValue);
+    if (!result.success) {
+        return resolveTheme(themeValue as Partial<ThemeSettings>);
+    }
 
-  return result.theme;
+    return result.theme;
 }
 
 export function getLineNumbersEnabled(context: vscode.ExtensionContext): boolean {
-  return getToggleSettingValue(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY, [
-    LINE_NUMBERS_LEGACY_SETTING_KEY,
-    LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY
-  ]);
+    return getToggleSettingValue(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY, [LINE_NUMBERS_LEGACY_SETTING_KEY, LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY]);
 }
 
 export function getGitChangesGutterEnabled(context: vscode.ExtensionContext): boolean {
-  return getToggleSettingValue(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY, [
-    GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY,
-    GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY,
-    GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY
-  ]);
+    return getToggleSettingValue(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY, [GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY]);
 }
 
 export function getGitDiffLineHighlightsEnabled(): boolean {
-  return vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>(GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY, true);
+    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>(GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY, true);
 }
 
 export function getVimModeEnabled(context: vscode.ExtensionContext): boolean {
-  return getToggleSettingValue(context, VIM_MODE_SETTING_KEY, VIM_MODE_KEY, [], false);
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    if (hasExplicitConfigurationValue<boolean>(config, VIM_MODE_SETTING_KEY)) {
+        return config.get<boolean>(VIM_MODE_SETTING_KEY, false);
+    }
+    // Auto-detect: mirror VSCodeVim extension state when our setting is not explicitly set.
+    const vscodevim = vscode.extensions.getExtension("vscodevim.vim");
+    if (vscodevim) {
+        return vscode.workspace.getConfiguration("vim").get<boolean>("enable", true);
+    }
+    return context.globalState.get<boolean>(VIM_MODE_KEY, false);
+}
+
+export type VimKeybinding = {
+    before: string;
+    after: string;
+    mode: "normal" | "insert" | "visual";
+    recursive: boolean;
+};
+
+export function getVimLeaderKey(): string {
+    return vscode.workspace.getConfiguration("vim").get<string>("leader", "\\") || "\\";
+}
+
+export function getVimKeybindings(): VimKeybinding[] {
+    const config = vscode.workspace.getConfiguration("vim");
+    const modeMappings: Array<{ key: string; mode: "normal" | "insert" | "visual"; recursive: boolean }> = [
+        { key: "normalModeKeyBindings", mode: "normal", recursive: true },
+        { key: "normalModeKeyBindingsNonRecursive", mode: "normal", recursive: false },
+        { key: "insertModeKeyBindings", mode: "insert", recursive: true },
+        { key: "insertModeKeyBindingsNonRecursive", mode: "insert", recursive: false },
+        { key: "visualModeKeyBindings", mode: "visual", recursive: true },
+        { key: "visualModeKeyBindingsNonRecursive", mode: "visual", recursive: false },
+    ];
+    const result: VimKeybinding[] = [];
+    for (const { key, mode, recursive } of modeMappings) {
+        const bindings = config.get<Array<{ before?: unknown; after?: unknown }>>(key, []);
+        if (!Array.isArray(bindings)) {
+            continue;
+        }
+        for (const binding of bindings) {
+            if (!Array.isArray(binding.before) || !Array.isArray(binding.after)) {
+                continue;
+            }
+            const before = (binding.before as string[]).join("");
+            const after = (binding.after as string[]).join("");
+            if (!before || !after) {
+                continue;
+            }
+            result.push({ before, after, mode, recursive });
+        }
+    }
+    return result;
 }
 
 export function getRememberPositionLines(): number {
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  return normalizeRememberPositionLineCount(config.get<number>(REMEMBER_POSITION_LINES_SETTING_KEY, 100));
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    return normalizeRememberPositionLineCount(config.get<number>(REMEMBER_POSITION_LINES_SETTING_KEY, 100));
 }
 
 export function getOutlinePosition(): OutlinePosition {
-  const value = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<string>('outline.position', 'right');
-  return value === 'left' ? 'left' : 'right';
+    const value = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<string>("outline.position", "right");
+    return value === "left" ? "left" : "right";
 }
 
 export function getOutlineVisible(context: vscode.ExtensionContext): boolean {
-  return context.globalState.get<boolean>(OUTLINE_VISIBLE_KEY, false);
+    return context.globalState.get<boolean>(OUTLINE_VISIBLE_KEY, false);
 }
 
 export function getExportPdfBrowserPath(): string | undefined {
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  const settingKey = 'export.browserPath';
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    const settingKey = "export.browserPath";
 
-  if (hasExplicitConfigurationValue<string>(config, settingKey)) {
-    const configured = config.get<string>(settingKey, '');
-    const trimmed = `${configured ?? ''}`.trim();
-    return trimmed || undefined;
-  }
+    if (hasExplicitConfigurationValue<string>(config, settingKey)) {
+        const configured = config.get<string>(settingKey, "");
+        const trimmed = `${configured ?? ""}`.trim();
+        return trimmed || undefined;
+    }
 
-  const configured = config.get<string>(settingKey, '');
-  const trimmed = `${configured ?? ''}`.trim();
-  if (trimmed) {
-    return trimmed;
-  }
+    const configured = config.get<string>(settingKey, "");
+    const trimmed = `${configured ?? ""}`.trim();
+    if (trimmed) {
+        return trimmed;
+    }
 
-  const legacyConfigured = config.get<string>('export.pdf.browserPath', '');
-  const legacyTrimmed = `${legacyConfigured ?? ''}`.trim();
-  return legacyTrimmed || undefined;
+    const legacyConfigured = config.get<string>("export.pdf.browserPath", "");
+    const legacyTrimmed = `${legacyConfigured ?? ""}`.trim();
+    return legacyTrimmed || undefined;
 }
 
 export function getExportHtmlImageMode(): ExportHtmlImageMode {
-  const configured = vscode.workspace
-    .getConfiguration(EXTENSION_CONFIG_SECTION)
-    .get<string>('export.html.imageMode', 'embedded');
-  const normalized = `${configured ?? ''}`.trim().toLowerCase();
-  return normalized === 'linked' ? 'linked' : 'embedded';
+    const configured = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<string>("export.html.imageMode", "embedded");
+    const normalized = `${configured ?? ""}`.trim().toLowerCase();
+    return normalized === "linked" ? "linked" : "embedded";
 }
 
 export function getExportEditorFontEnvironment(): { editorFontFamily?: string; editorFontWeight?: string; editorFontSizePx?: number } {
-  const editorConfig = vscode.workspace.getConfiguration('editor');
-  const fontFamily = `${editorConfig.get<string>('fontFamily', '') ?? ''}`.trim() || undefined;
-  const editorFontWeight = `${editorConfig.get<string>('fontWeight', 'normal') ?? 'normal'}`.trim() || 'normal';
-  const fontSize = editorConfig.get<number>('fontSize');
-  return {
-    editorFontFamily: fontFamily,
-    editorFontWeight: editorFontWeight,
-    editorFontSizePx: typeof fontSize === 'number' && Number.isFinite(fontSize) ? fontSize : undefined
-  };
+    const editorConfig = vscode.workspace.getConfiguration("editor");
+    const fontFamily = `${editorConfig.get<string>("fontFamily", "") ?? ""}`.trim() || undefined;
+    const editorFontWeight = `${editorConfig.get<string>("fontWeight", "normal") ?? "normal"}`.trim() || "normal";
+    const fontSize = editorConfig.get<number>("fontSize");
+    return {
+        editorFontFamily: fontFamily,
+        editorFontWeight: editorFontWeight,
+        editorFontSizePx: typeof fontSize === "number" && Number.isFinite(fontSize) ? fontSize : undefined,
+    };
 }
 
 export function isMarkdownDocumentPath(filePath: string): boolean {
-  return MARKDOWN_FILE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
+    return MARKDOWN_FILE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
 }
 
 export function withMarkdownExtensions(basePath: string, preferExtensionlessFirst = false): string[] {
-  const extensionCandidates = MARKDOWN_FILE_EXTENSIONS.map((extension) => `${basePath}${extension}`);
-  return preferExtensionlessFirst ? [basePath, ...extensionCandidates] : [...extensionCandidates, basePath];
+    const extensionCandidates = MARKDOWN_FILE_EXTENSIONS.map((extension) => `${basePath}${extension}`);
+    return preferExtensionlessFirst ? [basePath, ...extensionCandidates] : [...extensionCandidates, basePath];
 }
 
 export async function migrateLegacyToggleSettings(context: vscode.ExtensionContext): Promise<void> {
-  await migrateLegacyToggleSetting(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY);
-  await migrateLegacyToggleSetting(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY);
+    await migrateLegacyToggleSetting(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY);
+    await migrateLegacyToggleSetting(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY);
 }
 
 export async function resetThemeSettingsToDefault(): Promise<void> {
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  const key = 'theme';
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    const key = "theme";
 
-  try {
-    await config.update(key, serializeThemeSettings(defaultThemeSettings), vscode.ConfigurationTarget.Global);
-  } catch {
-    // Fall back to clearing global values if writing default payload fails.
-    await clearThemeKeysForTarget(config, [key], vscode.ConfigurationTarget.Global);
-  }
+    try {
+        await config.update(key, serializeThemeSettings(defaultThemeSettings), vscode.ConfigurationTarget.Global);
+    } catch {
+        // Fall back to clearing global values if writing default payload fails.
+        await clearThemeKeysForTarget(config, [key], vscode.ConfigurationTarget.Global);
+    }
 }
 
 export async function syncEditorAssociations(useAsDefault: boolean): Promise<void> {
-  const config = vscode.workspace.getConfiguration('workbench');
-  const inspected = config.inspect<Record<string, string>>('editorAssociations');
-  const markdownAssociation = useAsDefault ? 'markdownEditorOptimized.editor' : 'default';
+    const config = vscode.workspace.getConfiguration("workbench");
+    const inspected = config.inspect<Record<string, string>>("editorAssociations");
+    const markdownAssociation = useAsDefault ? "markdownEditorOptimized.editor" : "default";
 
-  await syncEditorAssociationsForTarget(
-    config,
-    inspected?.globalValue,
-    vscode.ConfigurationTarget.Global,
-    markdownAssociation
-  );
+    await syncEditorAssociationsForTarget(config, inspected?.globalValue, vscode.ConfigurationTarget.Global, markdownAssociation);
 }
 
-function getToggleSettingValue(
-  context: vscode.ExtensionContext,
-  settingKey: string,
-  legacyStateKey: string,
-  legacySettingKeys: readonly string[] = [],
-  fallbackDefault = true
-): boolean {
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
-    return config.get<boolean>(settingKey, fallbackDefault);
-  }
-  for (const legacySettingKey of legacySettingKeys) {
-    if (hasExplicitConfigurationValue<boolean>(config, legacySettingKey)) {
-      return config.get<boolean>(legacySettingKey, fallbackDefault);
+function getToggleSettingValue(context: vscode.ExtensionContext, settingKey: string, legacyStateKey: string, legacySettingKeys: readonly string[] = [], fallbackDefault = true): boolean {
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
+        return config.get<boolean>(settingKey, fallbackDefault);
     }
-  }
-  return context.globalState.get<boolean>(legacyStateKey, fallbackDefault);
+    for (const legacySettingKey of legacySettingKeys) {
+        if (hasExplicitConfigurationValue<boolean>(config, legacySettingKey)) {
+            return config.get<boolean>(legacySettingKey, fallbackDefault);
+        }
+    }
+    return context.globalState.get<boolean>(legacyStateKey, fallbackDefault);
 }
 
 function normalizeRememberPositionLineCount(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 100;
-  }
-  return Math.max(0, Math.floor(value));
+    if (!Number.isFinite(value)) {
+        return 100;
+    }
+    return Math.max(0, Math.floor(value));
 }
 
-async function migrateLegacyToggleSetting(
-  context: vscode.ExtensionContext,
-  settingKey: string,
-  legacyStateKey: string
-): Promise<void> {
-  const legacyValue = context.globalState.get<boolean | undefined>(legacyStateKey);
-  if (typeof legacyValue !== 'boolean') {
-    return;
-  }
+async function migrateLegacyToggleSetting(context: vscode.ExtensionContext, settingKey: string, legacyStateKey: string): Promise<void> {
+    const legacyValue = context.globalState.get<boolean | undefined>(legacyStateKey);
+    if (typeof legacyValue !== "boolean") {
+        return;
+    }
 
-  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-  if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
-    return;
-  }
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
+        return;
+    }
 
-  if (legacyValue === true) {
-    return;
-  }
+    if (legacyValue === true) {
+        return;
+    }
 
-  try {
-    await config.update(settingKey, legacyValue, vscode.ConfigurationTarget.Global);
-  } catch {
-    // Ignore configuration write failures to avoid breaking editor startup.
-  }
+    try {
+        await config.update(settingKey, legacyValue, vscode.ConfigurationTarget.Global);
+    } catch {
+        // Ignore configuration write failures to avoid breaking editor startup.
+    }
 }
 
 function hasExplicitConfigurationValue<T>(config: vscode.WorkspaceConfiguration, key: string): boolean {
-  const inspected = config.inspect<T>(key);
-  if (!inspected) {
-    return false;
-  }
-
-  const languageScoped = inspected as typeof inspected & {
-    globalLanguageValue?: T;
-    workspaceLanguageValue?: T;
-    workspaceFolderLanguageValue?: T;
-  };
-
-  return (
-    inspected.globalValue !== undefined ||
-    inspected.workspaceValue !== undefined ||
-    inspected.workspaceFolderValue !== undefined ||
-    languageScoped.globalLanguageValue !== undefined ||
-    languageScoped.workspaceLanguageValue !== undefined ||
-    languageScoped.workspaceFolderLanguageValue !== undefined
-  );
-}
-
-async function clearThemeKeysForTarget(
-  config: vscode.WorkspaceConfiguration,
-  keys: string[],
-  target: vscode.ConfigurationTarget
-): Promise<void> {
-  for (const key of keys) {
-    try {
-      await config.update(key, undefined, target);
-    } catch {
-      // Ignore failures so editor startup is not blocked by unsupported target writes.
+    const inspected = config.inspect<T>(key);
+    if (!inspected) {
+        return false;
     }
-  }
+
+    const languageScoped = inspected as typeof inspected & {
+        globalLanguageValue?: T;
+        workspaceLanguageValue?: T;
+        workspaceFolderLanguageValue?: T;
+    };
+
+    return inspected.globalValue !== undefined || inspected.workspaceValue !== undefined || inspected.workspaceFolderValue !== undefined || languageScoped.globalLanguageValue !== undefined || languageScoped.workspaceLanguageValue !== undefined || languageScoped.workspaceFolderLanguageValue !== undefined;
 }
 
-async function syncEditorAssociationsForTarget(
-  config: vscode.WorkspaceConfiguration,
-  inspectedValue: Record<string, string> | undefined,
-  target: vscode.ConfigurationTarget,
-  markdownAssociation: string
-): Promise<void> {
-  const markdownAssociations = {
-    ...inspectedValue,
-    '*.md': markdownAssociation,
-    '*.markdown': markdownAssociation,
-    '*.mdx': markdownAssociation,
-    '*.mdc': markdownAssociation,
-    'git:/**/*.md': 'default',
-    'git:/**/*.markdown': 'default',
-    'git:/**/*.mdx': 'default',
-    'git:/**/*.mdc': 'default',
-    'git:**/*.md': 'default',
-    'git:**/*.markdown': 'default',
-    'git:**/*.mdx': 'default',
-    'git:**/*.mdc': 'default',
-    'chat-editing-text-model:/**/*.md': 'default',
-    'chat-editing-text-model:/**/*.markdown': 'default',
-    'chat-editing-text-model:/**/*.mdx': 'default',
-    'chat-editing-text-model:/**/*.mdc': 'default',
-    'chat-editing-text-model:**/*.md': 'default',
-    'chat-editing-text-model:**/*.markdown': 'default',
-    'chat-editing-text-model:**/*.mdx': 'default',
-    'chat-editing-text-model:**/*.mdc': 'default'
-  };
+async function clearThemeKeysForTarget(config: vscode.WorkspaceConfiguration, keys: string[], target: vscode.ConfigurationTarget): Promise<void> {
+    for (const key of keys) {
+        try {
+            await config.update(key, undefined, target);
+        } catch {
+            // Ignore failures so editor startup is not blocked by unsupported target writes.
+        }
+    }
+}
 
-  await config.update('editorAssociations', markdownAssociations, target);
+async function syncEditorAssociationsForTarget(config: vscode.WorkspaceConfiguration, inspectedValue: Record<string, string> | undefined, target: vscode.ConfigurationTarget, markdownAssociation: string): Promise<void> {
+    const markdownAssociations = {
+        ...inspectedValue,
+        "*.md": markdownAssociation,
+        "*.markdown": markdownAssociation,
+        "*.mdx": markdownAssociation,
+        "*.mdc": markdownAssociation,
+        "git:/**/*.md": "default",
+        "git:/**/*.markdown": "default",
+        "git:/**/*.mdx": "default",
+        "git:/**/*.mdc": "default",
+        "git:**/*.md": "default",
+        "git:**/*.markdown": "default",
+        "git:**/*.mdx": "default",
+        "git:**/*.mdc": "default",
+        "chat-editing-text-model:/**/*.md": "default",
+        "chat-editing-text-model:/**/*.markdown": "default",
+        "chat-editing-text-model:/**/*.mdx": "default",
+        "chat-editing-text-model:/**/*.mdc": "default",
+        "chat-editing-text-model:**/*.md": "default",
+        "chat-editing-text-model:**/*.markdown": "default",
+        "chat-editing-text-model:**/*.mdx": "default",
+        "chat-editing-text-model:**/*.mdc": "default",
+    };
+
+    await config.update("editorAssociations", markdownAssociations, target);
 }

--- a/src/shared/extensionConfig.ts
+++ b/src/shared/extensionConfig.ts
@@ -1,287 +1,360 @@
-import * as vscode from "vscode";
-import { defaultThemeSettings, resolveTheme, serializeThemeSettings, type ThemeSettings, validateThemePayload } from "./themeDefaults";
+import * as vscode from 'vscode';
+import {
+  defaultThemeSettings,
+  resolveTheme,
+  serializeThemeSettings,
+  type ThemeSettings,
+  validateThemePayload
+} from './themeDefaults';
 
-export const EXTENSION_CONFIG_SECTION = "markdownEditorOptimized";
-export const LINE_NUMBERS_SETTING_KEY = "lineNumbers.visible";
-export const GIT_CHANGES_GUTTER_SETTING_KEY = "gitChanges.visible";
-export const GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY = "gitChanges.lineHighlights";
-export const VIM_MODE_SETTING_KEY = "vimMode.enabled";
-export const REMEMBER_POSITION_LINES_SETTING_KEY = "rememberPosition.lines";
-export const LINE_NUMBERS_LEGACY_SETTING_KEY = "lineNumbers.enabled";
-export const LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY = "lineNumbers.visibility";
-export const GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY = "gitChanges.visibility";
-export const GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY = "gitChangesGutter.visibility";
-export const GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY = "gitChangesGutter.enabled";
-export const LINE_NUMBERS_KEY = "lineNumbersEnabled";
-export const GIT_CHANGES_GUTTER_KEY = "gitChangesGutterEnabled";
-export const VIM_MODE_KEY = "vimModeEnabled";
-export const OUTLINE_VISIBLE_KEY = "outlineVisible";
-export const MARKDOWN_FILE_EXTENSIONS = [".md", ".markdown", ".mdx", ".mdc"] as const;
+export const EXTENSION_CONFIG_SECTION = 'markdownEditorOptimized';
+export const LINE_NUMBERS_SETTING_KEY = 'lineNumbers.visible';
+export const GIT_CHANGES_GUTTER_SETTING_KEY = 'gitChanges.visible';
+export const GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY = 'gitChanges.lineHighlights';
+export const VIM_MODE_BEHAVIOR_SETTING_KEY = 'vimMode.behavior';
+export const VIM_MODE_SETTING_KEY = 'vimMode.enabled';
+export const REMEMBER_POSITION_LINES_SETTING_KEY = 'rememberPosition.lines';
+export const LINE_NUMBERS_LEGACY_SETTING_KEY = 'lineNumbers.enabled';
+export const LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY = 'lineNumbers.visibility';
+export const GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY = 'gitChanges.visibility';
+export const GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY = 'gitChangesGutter.visibility';
+export const GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY = 'gitChangesGutter.enabled';
+export const LINE_NUMBERS_KEY = 'lineNumbersEnabled';
+export const GIT_CHANGES_GUTTER_KEY = 'gitChangesGutterEnabled';
+export const VIM_MODE_KEY = 'vimModeEnabled';
+export const OUTLINE_VISIBLE_KEY = 'outlineVisible';
+export const MARKDOWN_FILE_EXTENSIONS = ['.md', '.markdown', '.mdx', '.mdc'] as const;
+const VSCODEVIM_EXTENSION_ID = 'vscodevim.vim';
+const VSCODE_NEOVIM_EXTENSION_ID = 'asvetliakov.vscode-neovim';
 
-export type OutlinePosition = "left" | "right";
-export type ExportHtmlImageMode = "embedded" | "linked";
+export type OutlinePosition = 'left' | 'right';
+export type ExportHtmlImageMode = 'embedded' | 'linked';
+export type VimModeBehavior = 'auto' | 'enabled' | 'disabled';
 
 export function getThemeSettings(): ThemeSettings {
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    const themeValue = config.get<unknown>("theme");
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  const themeValue = config.get<unknown>('theme');
 
-    if (!themeValue) {
-        return defaultThemeSettings;
-    }
+  if (!themeValue) {
+    return defaultThemeSettings;
+  }
 
-    const result = validateThemePayload(themeValue);
-    if (!result.success) {
-        return resolveTheme(themeValue as Partial<ThemeSettings>);
-    }
+  const result = validateThemePayload(themeValue);
+  if (!result.success) {
+    return resolveTheme(themeValue as Partial<ThemeSettings>);
+  }
 
-    return result.theme;
+  return result.theme;
 }
 
 export function getLineNumbersEnabled(context: vscode.ExtensionContext): boolean {
-    return getToggleSettingValue(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY, [LINE_NUMBERS_LEGACY_SETTING_KEY, LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY]);
+  return getToggleSettingValue(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY, [
+    LINE_NUMBERS_LEGACY_SETTING_KEY,
+    LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY
+  ]);
 }
 
 export function getGitChangesGutterEnabled(context: vscode.ExtensionContext): boolean {
-    return getToggleSettingValue(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY, [GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY, GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY]);
+  return getToggleSettingValue(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY, [
+    GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY,
+    GIT_CHANGES_GUTTER_LEGACY_VISIBILITY_SETTING_KEY,
+    GIT_CHANGES_GUTTER_LEGACY_SETTING_KEY
+  ]);
 }
 
 export function getGitDiffLineHighlightsEnabled(): boolean {
-    return vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>(GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY, true);
+  return vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>(GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY, true);
 }
 
 export function getVimModeEnabled(context: vscode.ExtensionContext): boolean {
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    if (hasExplicitConfigurationValue<boolean>(config, VIM_MODE_SETTING_KEY)) {
-        return config.get<boolean>(VIM_MODE_SETTING_KEY, false);
-    }
-    // Auto-detect: mirror VSCodeVim extension state when our setting is not explicitly set.
-    const vscodevim = vscode.extensions.getExtension("vscodevim.vim");
-    if (vscodevim) {
-        return vscode.workspace.getConfiguration("vim").get<boolean>("enable", true);
-    }
-    return context.globalState.get<boolean>(VIM_MODE_KEY, false);
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  const behavior = getVimModeBehavior(config);
+  if (behavior === 'enabled') {
+    return true;
+  }
+  if (behavior === 'disabled') {
+    return false;
+  }
+
+  // Backward compatibility for users who already set the old boolean setting.
+  if (hasExplicitConfigurationValue<boolean>(config, VIM_MODE_SETTING_KEY)) {
+    return config.get<boolean>(VIM_MODE_SETTING_KEY, false);
+  }
+
+  // Auto-detect: mirror VSCodeVim when present, or enable CodeMirror Vim emulation
+  // for VSCode Neovim users. Neovim mappings are not synced into the webview.
+  const vscodevim = vscode.extensions.getExtension(VSCODEVIM_EXTENSION_ID);
+  const vscodevimEnabled = vscodevim ? vscode.workspace.getConfiguration('vim').get<boolean>('enable', true) : false;
+  if (vscodevimEnabled || vscode.extensions.getExtension(VSCODE_NEOVIM_EXTENSION_ID)) {
+    return true;
+  }
+  return context.globalState.get<boolean>(VIM_MODE_KEY, false);
 }
 
 export type VimKeybinding = {
-    before: string;
-    after: string;
-    mode: "normal" | "insert" | "visual";
-    recursive: boolean;
+  before: string;
+  after: string;
+  mode: 'normal' | 'insert' | 'visual';
+  recursive: boolean;
 };
 
 export function getVimLeaderKey(): string {
-    return vscode.workspace.getConfiguration("vim").get<string>("leader", "\\") || "\\";
+  return vscode.workspace.getConfiguration('vim').get<string>('leader', '\\') || '\\';
 }
 
 export function getVimKeybindings(): VimKeybinding[] {
-    const config = vscode.workspace.getConfiguration("vim");
-    const modeMappings: Array<{ key: string; mode: "normal" | "insert" | "visual"; recursive: boolean }> = [
-        { key: "normalModeKeyBindings", mode: "normal", recursive: true },
-        { key: "normalModeKeyBindingsNonRecursive", mode: "normal", recursive: false },
-        { key: "insertModeKeyBindings", mode: "insert", recursive: true },
-        { key: "insertModeKeyBindingsNonRecursive", mode: "insert", recursive: false },
-        { key: "visualModeKeyBindings", mode: "visual", recursive: true },
-        { key: "visualModeKeyBindingsNonRecursive", mode: "visual", recursive: false },
-    ];
-    const result: VimKeybinding[] = [];
-    for (const { key, mode, recursive } of modeMappings) {
-        const bindings = config.get<Array<{ before?: unknown; after?: unknown }>>(key, []);
-        if (!Array.isArray(bindings)) {
-            continue;
-        }
-        for (const binding of bindings) {
-            if (!Array.isArray(binding.before) || !Array.isArray(binding.after)) {
-                continue;
-            }
-            const before = (binding.before as string[]).join("");
-            const after = (binding.after as string[]).join("");
-            if (!before || !after) {
-                continue;
-            }
-            result.push({ before, after, mode, recursive });
-        }
+  const config = vscode.workspace.getConfiguration('vim');
+  const modeMappings: Array<{ key: string; mode: 'normal' | 'insert' | 'visual'; recursive: boolean }> = [
+    { key: 'normalModeKeyBindings', mode: 'normal', recursive: true },
+    { key: 'normalModeKeyBindingsNonRecursive', mode: 'normal', recursive: false },
+    { key: 'insertModeKeyBindings', mode: 'insert', recursive: true },
+    { key: 'insertModeKeyBindingsNonRecursive', mode: 'insert', recursive: false },
+    { key: 'visualModeKeyBindings', mode: 'visual', recursive: true },
+    { key: 'visualModeKeyBindingsNonRecursive', mode: 'visual', recursive: false }
+  ];
+  const result: VimKeybinding[] = [];
+  for (const { key, mode, recursive } of modeMappings) {
+    const bindings = config.get<Array<{ before?: unknown; after?: unknown }>>(key, []);
+    if (!Array.isArray(bindings)) {
+      continue;
     }
-    return result;
+    for (const binding of bindings) {
+      if (!Array.isArray(binding.before) || !Array.isArray(binding.after)) {
+        continue;
+      }
+      const before = (binding.before as string[]).join('');
+      const after = (binding.after as string[]).join('');
+      if (!before || !after) {
+        continue;
+      }
+      result.push({ before, after, mode, recursive });
+    }
+  }
+  return result;
+}
+
+function getVimModeBehavior(config: vscode.WorkspaceConfiguration): VimModeBehavior {
+  if (!hasExplicitConfigurationValue<VimModeBehavior>(config, VIM_MODE_BEHAVIOR_SETTING_KEY)) {
+    return 'auto';
+  }
+  const behavior = config.get<string>(VIM_MODE_BEHAVIOR_SETTING_KEY, 'auto');
+  if (behavior === 'enabled' || behavior === 'disabled') {
+    return behavior;
+  }
+  return 'auto';
 }
 
 export function getRememberPositionLines(): number {
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    return normalizeRememberPositionLineCount(config.get<number>(REMEMBER_POSITION_LINES_SETTING_KEY, 100));
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  return normalizeRememberPositionLineCount(config.get<number>(REMEMBER_POSITION_LINES_SETTING_KEY, 100));
 }
 
 export function getOutlinePosition(): OutlinePosition {
-    const value = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<string>("outline.position", "right");
-    return value === "left" ? "left" : "right";
+  const value = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<string>('outline.position', 'right');
+  return value === 'left' ? 'left' : 'right';
 }
 
 export function getOutlineVisible(context: vscode.ExtensionContext): boolean {
-    return context.globalState.get<boolean>(OUTLINE_VISIBLE_KEY, false);
+  return context.globalState.get<boolean>(OUTLINE_VISIBLE_KEY, false);
 }
 
 export function getExportPdfBrowserPath(): string | undefined {
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    const settingKey = "export.browserPath";
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  const settingKey = 'export.browserPath';
 
-    if (hasExplicitConfigurationValue<string>(config, settingKey)) {
-        const configured = config.get<string>(settingKey, "");
-        const trimmed = `${configured ?? ""}`.trim();
-        return trimmed || undefined;
-    }
+  if (hasExplicitConfigurationValue<string>(config, settingKey)) {
+    const configured = config.get<string>(settingKey, '');
+    const trimmed = `${configured ?? ''}`.trim();
+    return trimmed || undefined;
+  }
 
-    const configured = config.get<string>(settingKey, "");
-    const trimmed = `${configured ?? ""}`.trim();
-    if (trimmed) {
-        return trimmed;
-    }
+  const configured = config.get<string>(settingKey, '');
+  const trimmed = `${configured ?? ''}`.trim();
+  if (trimmed) {
+    return trimmed;
+  }
 
-    const legacyConfigured = config.get<string>("export.pdf.browserPath", "");
-    const legacyTrimmed = `${legacyConfigured ?? ""}`.trim();
-    return legacyTrimmed || undefined;
+  const legacyConfigured = config.get<string>('export.pdf.browserPath', '');
+  const legacyTrimmed = `${legacyConfigured ?? ''}`.trim();
+  return legacyTrimmed || undefined;
 }
 
 export function getExportHtmlImageMode(): ExportHtmlImageMode {
-    const configured = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<string>("export.html.imageMode", "embedded");
-    const normalized = `${configured ?? ""}`.trim().toLowerCase();
-    return normalized === "linked" ? "linked" : "embedded";
+  const configured = vscode.workspace
+    .getConfiguration(EXTENSION_CONFIG_SECTION)
+    .get<string>('export.html.imageMode', 'embedded');
+  const normalized = `${configured ?? ''}`.trim().toLowerCase();
+  return normalized === 'linked' ? 'linked' : 'embedded';
 }
 
 export function getExportEditorFontEnvironment(): { editorFontFamily?: string; editorFontWeight?: string; editorFontSizePx?: number } {
-    const editorConfig = vscode.workspace.getConfiguration("editor");
-    const fontFamily = `${editorConfig.get<string>("fontFamily", "") ?? ""}`.trim() || undefined;
-    const editorFontWeight = `${editorConfig.get<string>("fontWeight", "normal") ?? "normal"}`.trim() || "normal";
-    const fontSize = editorConfig.get<number>("fontSize");
-    return {
-        editorFontFamily: fontFamily,
-        editorFontWeight: editorFontWeight,
-        editorFontSizePx: typeof fontSize === "number" && Number.isFinite(fontSize) ? fontSize : undefined,
-    };
+  const editorConfig = vscode.workspace.getConfiguration('editor');
+  const fontFamily = `${editorConfig.get<string>('fontFamily', '') ?? ''}`.trim() || undefined;
+  const editorFontWeight = `${editorConfig.get<string>('fontWeight', 'normal') ?? 'normal'}`.trim() || 'normal';
+  const fontSize = editorConfig.get<number>('fontSize');
+  return {
+    editorFontFamily: fontFamily,
+    editorFontWeight: editorFontWeight,
+    editorFontSizePx: typeof fontSize === 'number' && Number.isFinite(fontSize) ? fontSize : undefined
+  };
 }
 
 export function isMarkdownDocumentPath(filePath: string): boolean {
-    return MARKDOWN_FILE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
+  return MARKDOWN_FILE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
 }
 
 export function withMarkdownExtensions(basePath: string, preferExtensionlessFirst = false): string[] {
-    const extensionCandidates = MARKDOWN_FILE_EXTENSIONS.map((extension) => `${basePath}${extension}`);
-    return preferExtensionlessFirst ? [basePath, ...extensionCandidates] : [...extensionCandidates, basePath];
+  const extensionCandidates = MARKDOWN_FILE_EXTENSIONS.map((extension) => `${basePath}${extension}`);
+  return preferExtensionlessFirst ? [basePath, ...extensionCandidates] : [...extensionCandidates, basePath];
 }
 
 export async function migrateLegacyToggleSettings(context: vscode.ExtensionContext): Promise<void> {
-    await migrateLegacyToggleSetting(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY);
-    await migrateLegacyToggleSetting(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY);
+  await migrateLegacyToggleSetting(context, LINE_NUMBERS_SETTING_KEY, LINE_NUMBERS_KEY);
+  await migrateLegacyToggleSetting(context, GIT_CHANGES_GUTTER_SETTING_KEY, GIT_CHANGES_GUTTER_KEY);
 }
 
 export async function resetThemeSettingsToDefault(): Promise<void> {
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    const key = "theme";
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  const key = 'theme';
 
-    try {
-        await config.update(key, serializeThemeSettings(defaultThemeSettings), vscode.ConfigurationTarget.Global);
-    } catch {
-        // Fall back to clearing global values if writing default payload fails.
-        await clearThemeKeysForTarget(config, [key], vscode.ConfigurationTarget.Global);
-    }
+  try {
+    await config.update(key, serializeThemeSettings(defaultThemeSettings), vscode.ConfigurationTarget.Global);
+  } catch {
+    // Fall back to clearing global values if writing default payload fails.
+    await clearThemeKeysForTarget(config, [key], vscode.ConfigurationTarget.Global);
+  }
 }
 
 export async function syncEditorAssociations(useAsDefault: boolean): Promise<void> {
-    const config = vscode.workspace.getConfiguration("workbench");
-    const inspected = config.inspect<Record<string, string>>("editorAssociations");
-    const markdownAssociation = useAsDefault ? "markdownEditorOptimized.editor" : "default";
+  const config = vscode.workspace.getConfiguration('workbench');
+  const inspected = config.inspect<Record<string, string>>('editorAssociations');
+  const markdownAssociation = useAsDefault ? 'markdownEditorOptimized.editor' : 'default';
 
-    await syncEditorAssociationsForTarget(config, inspected?.globalValue, vscode.ConfigurationTarget.Global, markdownAssociation);
+  await syncEditorAssociationsForTarget(
+    config,
+    inspected?.globalValue,
+    vscode.ConfigurationTarget.Global,
+    markdownAssociation
+  );
 }
 
-function getToggleSettingValue(context: vscode.ExtensionContext, settingKey: string, legacyStateKey: string, legacySettingKeys: readonly string[] = [], fallbackDefault = true): boolean {
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
-        return config.get<boolean>(settingKey, fallbackDefault);
+function getToggleSettingValue(
+  context: vscode.ExtensionContext,
+  settingKey: string,
+  legacyStateKey: string,
+  legacySettingKeys: readonly string[] = [],
+  fallbackDefault = true
+): boolean {
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
+    return config.get<boolean>(settingKey, fallbackDefault);
+  }
+  for (const legacySettingKey of legacySettingKeys) {
+    if (hasExplicitConfigurationValue<boolean>(config, legacySettingKey)) {
+      return config.get<boolean>(legacySettingKey, fallbackDefault);
     }
-    for (const legacySettingKey of legacySettingKeys) {
-        if (hasExplicitConfigurationValue<boolean>(config, legacySettingKey)) {
-            return config.get<boolean>(legacySettingKey, fallbackDefault);
-        }
-    }
-    return context.globalState.get<boolean>(legacyStateKey, fallbackDefault);
+  }
+  return context.globalState.get<boolean>(legacyStateKey, fallbackDefault);
 }
 
 function normalizeRememberPositionLineCount(value: number): number {
-    if (!Number.isFinite(value)) {
-        return 100;
-    }
-    return Math.max(0, Math.floor(value));
+  if (!Number.isFinite(value)) {
+    return 100;
+  }
+  return Math.max(0, Math.floor(value));
 }
 
-async function migrateLegacyToggleSetting(context: vscode.ExtensionContext, settingKey: string, legacyStateKey: string): Promise<void> {
-    const legacyValue = context.globalState.get<boolean | undefined>(legacyStateKey);
-    if (typeof legacyValue !== "boolean") {
-        return;
-    }
+async function migrateLegacyToggleSetting(
+  context: vscode.ExtensionContext,
+  settingKey: string,
+  legacyStateKey: string
+): Promise<void> {
+  const legacyValue = context.globalState.get<boolean | undefined>(legacyStateKey);
+  if (typeof legacyValue !== 'boolean') {
+    return;
+  }
 
-    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
-    if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
-        return;
-    }
+  const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+  if (hasExplicitConfigurationValue<boolean>(config, settingKey)) {
+    return;
+  }
 
-    if (legacyValue === true) {
-        return;
-    }
+  if (legacyValue === true) {
+    return;
+  }
 
-    try {
-        await config.update(settingKey, legacyValue, vscode.ConfigurationTarget.Global);
-    } catch {
-        // Ignore configuration write failures to avoid breaking editor startup.
-    }
+  try {
+    await config.update(settingKey, legacyValue, vscode.ConfigurationTarget.Global);
+  } catch {
+    // Ignore configuration write failures to avoid breaking editor startup.
+  }
 }
 
 function hasExplicitConfigurationValue<T>(config: vscode.WorkspaceConfiguration, key: string): boolean {
-    const inspected = config.inspect<T>(key);
-    if (!inspected) {
-        return false;
-    }
+  const inspected = config.inspect<T>(key);
+  if (!inspected) {
+    return false;
+  }
 
-    const languageScoped = inspected as typeof inspected & {
-        globalLanguageValue?: T;
-        workspaceLanguageValue?: T;
-        workspaceFolderLanguageValue?: T;
-    };
+  const languageScoped = inspected as typeof inspected & {
+    globalLanguageValue?: T;
+    workspaceLanguageValue?: T;
+    workspaceFolderLanguageValue?: T;
+  };
 
-    return inspected.globalValue !== undefined || inspected.workspaceValue !== undefined || inspected.workspaceFolderValue !== undefined || languageScoped.globalLanguageValue !== undefined || languageScoped.workspaceLanguageValue !== undefined || languageScoped.workspaceFolderLanguageValue !== undefined;
+  return (
+    inspected.globalValue !== undefined ||
+    inspected.workspaceValue !== undefined ||
+    inspected.workspaceFolderValue !== undefined ||
+    languageScoped.globalLanguageValue !== undefined ||
+    languageScoped.workspaceLanguageValue !== undefined ||
+    languageScoped.workspaceFolderLanguageValue !== undefined
+  );
 }
 
-async function clearThemeKeysForTarget(config: vscode.WorkspaceConfiguration, keys: string[], target: vscode.ConfigurationTarget): Promise<void> {
-    for (const key of keys) {
-        try {
-            await config.update(key, undefined, target);
-        } catch {
-            // Ignore failures so editor startup is not blocked by unsupported target writes.
-        }
+async function clearThemeKeysForTarget(
+  config: vscode.WorkspaceConfiguration,
+  keys: string[],
+  target: vscode.ConfigurationTarget
+): Promise<void> {
+  for (const key of keys) {
+    try {
+      await config.update(key, undefined, target);
+    } catch {
+      // Ignore failures so editor startup is not blocked by unsupported target writes.
     }
+  }
 }
 
-async function syncEditorAssociationsForTarget(config: vscode.WorkspaceConfiguration, inspectedValue: Record<string, string> | undefined, target: vscode.ConfigurationTarget, markdownAssociation: string): Promise<void> {
-    const markdownAssociations = {
-        ...inspectedValue,
-        "*.md": markdownAssociation,
-        "*.markdown": markdownAssociation,
-        "*.mdx": markdownAssociation,
-        "*.mdc": markdownAssociation,
-        "git:/**/*.md": "default",
-        "git:/**/*.markdown": "default",
-        "git:/**/*.mdx": "default",
-        "git:/**/*.mdc": "default",
-        "git:**/*.md": "default",
-        "git:**/*.markdown": "default",
-        "git:**/*.mdx": "default",
-        "git:**/*.mdc": "default",
-        "chat-editing-text-model:/**/*.md": "default",
-        "chat-editing-text-model:/**/*.markdown": "default",
-        "chat-editing-text-model:/**/*.mdx": "default",
-        "chat-editing-text-model:/**/*.mdc": "default",
-        "chat-editing-text-model:**/*.md": "default",
-        "chat-editing-text-model:**/*.markdown": "default",
-        "chat-editing-text-model:**/*.mdx": "default",
-        "chat-editing-text-model:**/*.mdc": "default",
-    };
+async function syncEditorAssociationsForTarget(
+  config: vscode.WorkspaceConfiguration,
+  inspectedValue: Record<string, string> | undefined,
+  target: vscode.ConfigurationTarget,
+  markdownAssociation: string
+): Promise<void> {
+  const markdownAssociations = {
+    ...inspectedValue,
+    '*.md': markdownAssociation,
+    '*.markdown': markdownAssociation,
+    '*.mdx': markdownAssociation,
+    '*.mdc': markdownAssociation,
+    'git:/**/*.md': 'default',
+    'git:/**/*.markdown': 'default',
+    'git:/**/*.mdx': 'default',
+    'git:/**/*.mdc': 'default',
+    'git:**/*.md': 'default',
+    'git:**/*.markdown': 'default',
+    'git:**/*.mdx': 'default',
+    'git:**/*.mdc': 'default',
+    'chat-editing-text-model:/**/*.md': 'default',
+    'chat-editing-text-model:/**/*.markdown': 'default',
+    'chat-editing-text-model:/**/*.mdx': 'default',
+    'chat-editing-text-model:/**/*.mdc': 'default',
+    'chat-editing-text-model:**/*.md': 'default',
+    'chat-editing-text-model:**/*.markdown': 'default',
+    'chat-editing-text-model:**/*.mdx': 'default',
+    'chat-editing-text-model:**/*.mdc': 'default'
+  };
 
-    await config.update("editorAssociations", markdownAssociations, target);
+  await config.update('editorAssociations', markdownAssociations, target);
 }

--- a/webview/src/editor.ts
+++ b/webview/src/editor.ts
@@ -1,2331 +1,2233 @@
-import { EditorState, Compartment, Transaction, StateEffect, StateField, RangeSetBuilder, type ChangeSpec } from '@codemirror/state';
-import { EditorView, keymap, highlightActiveLine, lineNumbers, highlightActiveLineGutter, scrollPastEnd, Decoration, type ViewUpdate } from '@codemirror/view';
-import { defaultKeymap, history, historyKeymap, indentMore, indentLess, undo, redo } from '@codemirror/commands';
-import { markdown, markdownKeymap, markdownLanguage } from '@codemirror/lang-markdown';
-import { indentUnit, syntaxHighlighting, syntaxTree, forceParsing } from '@codemirror/language';
-import { vim } from '@replit/codemirror-vim';
-import { highlightStyle } from './theme';
-import { liveModeExtensions } from './liveMode';
-import { headingCollapseSharedExtensions, headingCollapseSourceSpacerExtensions } from './helpers/headingCollapse';
-import { resolveCodeLanguage, insertCodeBlock, sourceCodeBlockField } from './helpers/codeBlocks';
-import { sourceStrikeMarkerField } from './helpers/strikeMarkers';
-import { sourceWikiMarkerField } from './helpers/wikiLinks';
-import { sourceFileLinkField } from './helpers/sourceRawLinks';
-import { sourceUrlBoundaryField } from './helpers/sourceUrlBoundaries';
-import { sourceFootnoteMarkerField } from './helpers/sourceFootnotes';
-import { getLinkHrefAtPointer, isPrimaryModifierPointerClick } from './helpers/linkNavigation';
-import {
-  gitDiffGutterBaselineExtensions,
-  gitDiffGutterLiveRenderExtensions,
-  gitDiffGutterRenderExtensions,
-  setGitBaseline as applyGitBaseline
-} from './helpers/gitDiffGutter';
-import { gitDiffLineHighlightsField } from './helpers/gitDiffLineHighlights';
-import { createGitDiffOverviewRulerController } from './helpers/gitDiffOverviewRuler';
-import { createGitBlameHoverController } from './helpers/gitBlameHover';
-import { mergeConflictSourceExtensions } from './helpers/mergeConflicts';
-import { resolvedSyntaxTree, extractHeadings, extractHeadingSections } from './helpers/markdownSyntax';
-import {
-  sourceListBorderField,
-  sourceListMarkerField,
-  listMarkerData,
-  handleArrowLeftAtListContentStart,
-  handleArrowRightAtListLineStart,
-  handleBackspaceAtListContentStart,
-  handleEnterAtListContentStart,
-  handleEnterOnEmptyListItem,
-  handleEnterContinueList,
-  handleEnterBeforeNestedList,
-  collectOrderedListRenumberChanges,
-  indentListByTwoSpaces,
-  outdentListByTwoSpaces
-} from './helpers/listMarkers';
-import { insertTable, sourceTableHeaderLineField } from './helpers/tables';
-import { parseFrontmatter, sourceFrontmatterField } from './helpers/frontmatter';
-import { collectLatexMathRanges } from './helpers/math';
+import { EditorState, Compartment, Transaction, StateEffect, StateField, RangeSetBuilder, type ChangeSpec } from "@codemirror/state";
+import { EditorView, keymap, highlightActiveLine, lineNumbers, highlightActiveLineGutter, scrollPastEnd, Decoration, type ViewUpdate } from "@codemirror/view";
+import { defaultKeymap, history, historyKeymap, indentMore, indentLess, undo, redo } from "@codemirror/commands";
+import { markdown, markdownKeymap, markdownLanguage } from "@codemirror/lang-markdown";
+import { indentUnit, syntaxHighlighting, syntaxTree, forceParsing } from "@codemirror/language";
+import { vim, Vim } from "@replit/codemirror-vim";
+import { highlightStyle } from "./theme";
+import { liveModeExtensions } from "./liveMode";
+import { headingCollapseSharedExtensions, headingCollapseSourceSpacerExtensions } from "./helpers/headingCollapse";
+import { resolveCodeLanguage, insertCodeBlock, sourceCodeBlockField } from "./helpers/codeBlocks";
+import { sourceStrikeMarkerField } from "./helpers/strikeMarkers";
+import { sourceWikiMarkerField } from "./helpers/wikiLinks";
+import { sourceFileLinkField } from "./helpers/sourceRawLinks";
+import { sourceUrlBoundaryField } from "./helpers/sourceUrlBoundaries";
+import { sourceFootnoteMarkerField } from "./helpers/sourceFootnotes";
+import { getLinkHrefAtPointer, isPrimaryModifierPointerClick } from "./helpers/linkNavigation";
+import { gitDiffGutterBaselineExtensions, gitDiffGutterLiveRenderExtensions, gitDiffGutterRenderExtensions, setGitBaseline as applyGitBaseline } from "./helpers/gitDiffGutter";
+import { gitDiffLineHighlightsField } from "./helpers/gitDiffLineHighlights";
+import { createGitDiffOverviewRulerController } from "./helpers/gitDiffOverviewRuler";
+import { createGitBlameHoverController } from "./helpers/gitBlameHover";
+import { mergeConflictSourceExtensions } from "./helpers/mergeConflicts";
+import { resolvedSyntaxTree, extractHeadings, extractHeadingSections } from "./helpers/markdownSyntax";
+import { sourceListBorderField, sourceListMarkerField, listMarkerData, handleArrowLeftAtListContentStart, handleArrowRightAtListLineStart, handleBackspaceAtListContentStart, handleEnterAtListContentStart, handleEnterOnEmptyListItem, handleEnterContinueList, handleEnterBeforeNestedList, collectOrderedListRenumberChanges, indentListByTwoSpaces, outdentListByTwoSpaces } from "./helpers/listMarkers";
+import { insertTable, sourceTableHeaderLineField } from "./helpers/tables";
+import { parseFrontmatter, sourceFrontmatterField } from "./helpers/frontmatter";
+import { collectLatexMathRanges } from "./helpers/math";
 
-declare module '@codemirror/view' {
-  interface EditorView {
-    EDIT_CONTEXT?: boolean;
-  }
+declare module "@codemirror/view" {
+    interface EditorView {
+        EDIT_CONTEXT?: boolean;
+    }
 }
 
 type SearchOptions = {
-  wholeWord?: boolean;
-  caseSensitive?: boolean;
+    wholeWord?: boolean;
+    caseSensitive?: boolean;
 };
 
 type SearchQueryState = {
-  text: string;
-  wholeWord: boolean;
-  caseSensitive: boolean;
+    text: string;
+    wholeWord: boolean;
+    caseSensitive: boolean;
 };
 
 type SearchMatchRange = {
-  start: number;
-  end: number;
+    start: number;
+    end: number;
 };
 
 type InlineSelectionRange = {
-  from: number;
-  to: number;
-  anchor: number;
-  head: number;
-  empty: boolean;
+    from: number;
+    to: number;
+    anchor: number;
+    head: number;
+    empty: boolean;
 };
 
 type MarkerReplacementContext = {
-  contentStart: number;
-  oldMarkerLen: number;
-  isExistingTask: boolean;
+    contentStart: number;
+    oldMarkerLen: number;
+    isExistingTask: boolean;
 };
 
 const setSearchQueryEffect = StateEffect.define<SearchQueryState>();
 const refreshDecorationsEffect = StateEffect.define();
-const searchMatchMark = Decoration.mark({ class: 'meo-search-match' });
+const searchMatchMark = Decoration.mark({ class: "meo-search-match" });
 const existingListMarkerRegex = /^(\s*)([-+*]\s+\[[ xX~\-]\]|[-+*]|\d+[.)])\s+/;
 const existingHeadingMarkerRegex = /^(\s*)(#{1,6})\s+/;
 const existingTaskMarkerRegex = /^[-+*]\s+\[[ xX~\-]\]/;
 const blockquoteLinePrefixRegex = /^[ \t]{0,3}(?:>[ \t]?)+/;
-const quotedCodeBlockAncestorNames = new Set(['FencedCode', 'CodeBlock']);
+const quotedCodeBlockAncestorNames = new Set(["FencedCode", "CodeBlock"]);
 
 const buildSearchDecorations = (doc, searchQuery: SearchQueryState) => {
-  if (!searchQuery.text) {
-    return Decoration.none;
-  }
+    if (!searchQuery.text) {
+        return Decoration.none;
+    }
 
-  const builder = new RangeSetBuilder();
-  const textValue = doc.toString();
-  const matches = findSearchMatchRanges(textValue, searchQuery.text, searchQuery);
-  for (const match of matches) {
-    builder.add(match.start, match.end, searchMatchMark);
-  }
-  return builder.finish();
+    const builder = new RangeSetBuilder();
+    const textValue = doc.toString();
+    const matches = findSearchMatchRanges(textValue, searchQuery.text, searchQuery);
+    for (const match of matches) {
+        builder.add(match.start, match.end, searchMatchMark);
+    }
+    return builder.finish();
 };
 
 const searchQueryField = StateField.define({
-  create() {
-    return createSearchQueryState('');
-  },
-  update(value, tr) {
-    for (const effect of tr.effects) {
-      if (effect.is(setSearchQueryEffect)) {
-        return effect.value;
-      }
-    }
-    return value;
-  }
+    create() {
+        return createSearchQueryState("");
+    },
+    update(value, tr) {
+        for (const effect of tr.effects) {
+            if (effect.is(setSearchQueryEffect)) {
+                return effect.value;
+            }
+        }
+        return value;
+    },
 });
 
 const searchMatchField = StateField.define<any>({
-  create() {
-    return Decoration.none;
-  },
-  update(value: any, tr: Transaction) {
-    if (tr.docChanged) {
-      const searchQuery = tr.state.field(searchQueryField);
-      return buildSearchDecorations(tr.state.doc, searchQuery);
-    }
+    create() {
+        return Decoration.none;
+    },
+    update(value: any, tr: Transaction) {
+        if (tr.docChanged) {
+            const searchQuery = tr.state.field(searchQueryField);
+            return buildSearchDecorations(tr.state.doc, searchQuery);
+        }
 
-    for (const effect of tr.effects) {
-      if (effect.is(setSearchQueryEffect)) {
-        return buildSearchDecorations(tr.state.doc, effect.value);
-      }
-    }
+        for (const effect of tr.effects) {
+            if (effect.is(setSearchQueryEffect)) {
+                return buildSearchDecorations(tr.state.doc, effect.value);
+            }
+        }
 
-    return value;
-  },
-  provide(field: any) {
-    return EditorView.decorations.from(field);
-  }
+        return value;
+    },
+    provide(field: any) {
+        return EditorView.decorations.from(field);
+    },
 });
 
-export function createEditor({
-  parent,
-  text,
-  onApplyChanges,
-  onOpenLink,
-  onSelectionChange,
-  onViewportChange,
-  onRequestGitBlame,
-  onOpenGitRevisionForLine,
-  onOpenGitWorktreeForLine,
-  initialMode = 'source',
-  initialTopLine = null,
-  initialTopLineOffset = 0,
-  initialLineNumbers = true,
-  initialGitGutter = true,
-  initialVimMode = false
-}) {
-  // VS Code webviews can hit cross-origin window access issues in the EditContext path.
-  // Disable it explicitly for stability in embedded Chromium.
-  (EditorView as any).EDIT_CONTEXT = false;
-
-  const modeCompartment = new Compartment();
-  const gitGutterCompartment = new Compartment();
-  const vimCompartment = new Compartment();
-  const startMode = initialMode === 'live' ? 'live' : 'source';
-  let lineNumbersVisible = initialLineNumbers !== false;
-  let gitGutterVisible = initialGitGutter !== false;
-  let vimModeEnabled = initialVimMode === true;
-  let applyingExternal = false;
-  let capturedPointerId = null;
-  let inlineCodeClick = null;
-  let checkboxClick = null;
-  let frontmatterBoundaryClick = null;
-  let view = null;
-  let currentMode = startMode;
-  let applyingRenumber = false;
-  // External syncs may carry stale selections in their history entries.
-  // Preserve the user's current cursor once on the next undo of such a change.
-  let pendingExternalUndoSelectionPreserve = false;
-  let tableInteractionActive = false;
-  let onTableInteraction = null;
-  let onTableOpenLink = null;
-  let onTableSelectionChange = null;
-  let onScroll = null;
-  let gitBlameHover = null;
-  let gitDiffOverviewRuler = null;
-  let sourceLinkHoverPointerActive = false;
-  const normalizeTopLineOffset = (value) => {
-    if (!Number.isFinite(value)) {
-      return 0;
-    }
-    return Math.max(0, Number(value));
-  };
-  const vimExtensionsForState = () => (vimModeEnabled && currentMode === 'source' ? vim() : []);
-  const getLineStartOffset = (docText, targetLineNumber) => {
-    const targetLine = Math.max(1, Math.floor(targetLineNumber));
-    if (targetLine === 1) {
-      return 0;
-    }
-    let line = 1;
-    for (let index = 0; index < docText.length; index += 1) {
-      if (docText.charCodeAt(index) !== 10) {
-        continue;
-      }
-      line += 1;
-      if (line === targetLine) {
-        return index + 1;
-      }
-    }
-    return docText.length;
-  };
-  const initialCursorPos = (() => {
-    if (typeof initialTopLine === 'number' && Number.isFinite(initialTopLine)) {
-      return getLineStartOffset(text ?? '', initialTopLine);
-    }
-    if (!text) {
-      return 0;
-    }
-    const firstLineEnd = text.indexOf('\n');
-    return firstLineEnd === -1 ? text.length : firstLineEnd;
-  })();
-  const targetElementFrom = (target) => (
-    target instanceof Element ? target : target instanceof Node ? target.parentElement : null
-  );
-  const openLinkIfModifierClick = (event, editorView) => {
-    if (!isPrimaryModifierPointerClick(event)) {
-      return false;
-    }
-    const href = getLinkHrefAtPointer(event, editorView);
-    if (!href) {
-      return false;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-    onOpenLink?.(href);
-    return true;
-  };
-  const setSourceLinkHoverCursor = (editorView, active) => {
-    if (sourceLinkHoverPointerActive === active) {
-      return;
-    }
-    sourceLinkHoverPointerActive = active;
-    const cursor = active ? 'pointer' : '';
-    editorView.dom.style.cursor = cursor;
-    editorView.contentDOM.style.cursor = cursor;
-  };
-  const updateSourceLinkHoverCursor = (event, editorView) => {
-    if (currentMode !== 'source') {
-      setSourceLinkHoverCursor(editorView, false);
-      return;
-    }
-    const target = event.target;
-    if (!(target instanceof Node) || !editorView.contentDOM.contains(target)) {
-      setSourceLinkHoverCursor(editorView, false);
-      return;
-    }
-    const href = getLinkHrefAtPointer(event, editorView, { exactTextHit: true });
-    setSourceLinkHoverCursor(editorView, Boolean(href));
-  };
-  const isLiveMode = (editorView) => editorView.dom.classList.contains('meo-mode-live');
-  const isPlainPrimaryPointerEvent = (event) => (
-    event.button === 0 && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey
-  );
-  const frontmatterBoundaryCursorEnd = (state, pos) => {
-    const frontmatter = parseFrontmatter(state);
-    if (!frontmatter) {
-      return null;
-    }
-    const line = state.doc.lineAt(pos);
-    const openingLineNo = state.doc.lineAt(frontmatter.openingFrom).number;
-    const closingLineNo = state.doc.lineAt(frontmatter.closingFrom).number;
-    if (line.number !== openingLineNo && line.number !== closingLineNo) {
-      return null;
-    }
-    const lineText = state.doc.sliceString(line.from, line.to);
-    const markerStart = lineText.indexOf('---');
-    return markerStart >= 0 ? line.from + markerStart + 3 : null;
-  };
-  const emptyBlockquoteLineCursorEnd = (state, pos) => {
-    const line = state.doc.lineAt(pos);
-    const lineText = state.doc.sliceString(line.from, line.to);
-    const quoteMatch = /^[ \t]{0,3}(?:>[ \t]?)+$/.exec(lineText);
-    if (!quoteMatch) {
-      return null;
-    }
-
-    const probePos = Math.min(line.to, line.from + 1);
-    let node = resolvedSyntaxTree(state).resolveInner(probePos, 1);
-    while (node) {
-      if (node.name === 'Blockquote') {
-        return line.from + quoteMatch[0].length;
-      }
-      node = node.parent;
-    }
-
-    return null;
-  };
-  const trackFrontmatterBoundaryClick = (event, editorView) => {
-    frontmatterBoundaryClick = null;
-    if (!isLiveMode(editorView) || !isPlainPrimaryPointerEvent(event)) {
-      return;
-    }
-    const clickedPos = editorView.posAtCoords({ x: event.clientX, y: event.clientY });
-    if (clickedPos === null) {
-      return;
-    }
-    const cursorEnd = frontmatterBoundaryCursorEnd(editorView.state, clickedPos);
-    if (cursorEnd === null) {
-      return;
-    }
-    frontmatterBoundaryClick = {
-      pointerId: event.pointerId,
-      cursorEnd
-    };
-  };
-
-  const setTableInteractionActive = (active) => {
-    if (!view || tableInteractionActive === active) {
-      return;
-    }
-    tableInteractionActive = active;
-    view.dom.classList.toggle('meo-table-interaction-active', active);
-  };
-  const tableEntryCellSelector = 'th[data-table-row][data-table-col], td[data-table-row][data-table-col]';
-  const tableEntryProbeOffsetsY = [1, 4, 8, 12, 18];
-  const focusTableEntryInput = (input) => {
-    if (!(input instanceof HTMLTextAreaElement)) {
-      return false;
-    }
-    input.focus({ preventScroll: true });
-    const caret = input.value.length;
-    input.setSelectionRange(caret, caret);
-    input.closest(tableEntryCellSelector)?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
-    return true;
-  };
-  const findTableEntryInput = (wrap, hit, direction) => {
-    const cell = hit.closest(tableEntryCellSelector);
-    if (cell instanceof HTMLElement && wrap.contains(cell)) {
-      const cellInput = cell.querySelector('textarea');
-      if (cellInput instanceof HTMLTextAreaElement) {
-        return cellInput;
-      }
-    }
-
-    if (direction === 'down') {
-      const first = wrap.querySelector('textarea');
-      return first instanceof HTMLTextAreaElement ? first : null;
-    }
-
-    const inputs = wrap.querySelectorAll('textarea');
-    const last = inputs.length ? inputs[inputs.length - 1] : null;
-    return last instanceof HTMLTextAreaElement ? last : null;
-  };
-
-  const tryEnterAdjacentTable = (editorView, direction) => {
-    if ((direction !== 'down' && direction !== 'up') || currentMode !== 'live' || tableInteractionActive) {
-      return false;
-    }
-
-    const selection = editorView.state.selection.main;
-    if (!selection.empty) {
-      return false;
-    }
-
-    const caretRect = editorView.coordsAtPos(selection.head);
-    if (!caretRect) {
-      return false;
-    }
-
-    const contentRect = editorView.contentDOM.getBoundingClientRect();
-    if (!contentRect || contentRect.width <= 0 || contentRect.height <= 0) {
-      return false;
-    }
-
-    const clampX = (x) => Math.min(Math.max(x, contentRect.left + 1), contentRect.right - 1);
-    const probeXs = [
-      clampX(caretRect.left + 1),
-      clampX(contentRect.left + Math.min(24, Math.max(8, contentRect.width * 0.05)))
-    ];
-
-    for (const offsetY of tableEntryProbeOffsetsY) {
-      const y = direction === 'down'
-        ? caretRect.bottom + offsetY
-        : caretRect.top - offsetY;
-      if (y < 0 || y >= window.innerHeight) {
-        if (direction === 'down' && y >= window.innerHeight) break;
-        continue;
-      }
-      for (const x of probeXs) {
-        const hit = document.elementFromPoint(x, y);
-        if (!(hit instanceof Element)) {
-          continue;
-        }
-        const wrap = hit.closest('.meo-md-html-table-wrap');
-        if (!(wrap instanceof HTMLElement) || !editorView.dom.contains(wrap)) {
-          continue;
-        }
-        const input = findTableEntryInput(wrap, hit, direction);
-        if (!focusTableEntryInput(input)) {
-          continue;
-        }
-        return true;
-      }
-    }
-
-    return false;
-  };
-
-  const syncModeClasses = () => {
-    if (!view) {
-      return;
-    }
-    const isLiveModeActive = currentMode === 'live';
-    view.dom.classList.toggle('meo-mode-live', currentMode === 'live');
-    view.dom.classList.toggle('meo-mode-source', currentMode !== 'live');
-    // Keep active typography vars explicitly synced to mode so source/live
-    // font sizing and line-height don't depend on selector cascade.
-    view.dom.style.setProperty('--meo-active-editor-font', isLiveModeActive ? 'var(--meo-font-live)' : 'var(--meo-font-source)');
-    view.dom.style.setProperty('--meo-active-editor-font-weight', isLiveModeActive ? 'var(--meo-font-live-weight)' : 'var(--meo-font-source-weight)');
-    view.dom.style.setProperty('--meo-active-editor-font-size', isLiveModeActive ? 'var(--meo-font-live-size)' : 'var(--meo-font-source-size)');
-    view.dom.style.setProperty('--meo-active-editor-line-height', isLiveModeActive ? 'var(--meo-line-height-live)' : 'var(--meo-line-height-source)');
-    if (currentMode !== 'source') {
-      setSourceLinkHoverCursor(view, false);
-    }
-  };
-
-  const syncLineNumbersVisibility = () => {
-    if (!view) {
-      return;
-    }
-    view.dom.classList.toggle('meo-line-numbers-hidden', !lineNumbersVisible);
-  };
-
-  const syncGitGutterVisibility = () => {
-    if (!view) {
-      return;
-    }
-    const shouldShowGitGutter = gitGutterVisible;
-    view.dom.classList.toggle('meo-git-gutter-hidden', !shouldShowGitGutter);
-    if (!shouldShowGitGutter) {
-      gitBlameHover?.hide();
-    }
-    gitDiffOverviewRuler?.refresh();
-  };
-
-  const releasePointerCaptureIfHeld = (pointerId) => {
-    if (!view || pointerId === null) {
-      return;
-    }
-    if (view.dom.releasePointerCapture && view.dom.hasPointerCapture(pointerId)) {
-      view.dom.releasePointerCapture(pointerId);
-    }
-  };
-
-  const syncSelectionClass = () => {
-    if (!view) {
-      return;
-    }
-    const hasSelection = view.state.selection.ranges.some((range) => !range.empty);
-    view.dom.classList.toggle('has-selection', hasSelection);
-  };
-
-  const getActiveTableInput = () => {
-    if (!view) {
-      return null;
-    }
-    const active = document.activeElement;
-    if (!(active instanceof HTMLTextAreaElement)) {
-      return null;
-    }
-    if (!view.dom.contains(active)) {
-      return null;
-    }
-    return active.closest('.meo-md-html-table-wrap') ? active : null;
-  };
-
-  const measureTextareaSelectionStart = (input, index) => {
-    const doc = input.ownerDocument;
-    const mirror = doc.createElement('div');
-    const marker = doc.createElement('span');
-    const computed = window.getComputedStyle(input);
-
-    mirror.style.position = 'fixed';
-    mirror.style.left = '0';
-    mirror.style.top = '0';
-    mirror.style.visibility = 'hidden';
-    mirror.style.pointerEvents = 'none';
-    mirror.style.whiteSpace = 'pre-wrap';
-    mirror.style.overflowWrap = 'break-word';
-    mirror.style.wordBreak = 'break-word';
-    mirror.style.boxSizing = computed.boxSizing;
-    mirror.style.width = `${input.getBoundingClientRect().width}px`;
-    mirror.style.minHeight = computed.height;
-    mirror.style.padding = computed.padding;
-    mirror.style.border = computed.border;
-    mirror.style.font = computed.font;
-    mirror.style.fontFamily = computed.fontFamily;
-    mirror.style.fontSize = computed.fontSize;
-    mirror.style.fontWeight = computed.fontWeight;
-    mirror.style.fontStyle = computed.fontStyle;
-    mirror.style.letterSpacing = computed.letterSpacing;
-    mirror.style.lineHeight = computed.lineHeight;
-    mirror.style.textTransform = computed.textTransform;
-    mirror.style.textIndent = computed.textIndent;
-    mirror.style.tabSize = computed.tabSize;
-
-    mirror.textContent = input.value.slice(0, index);
-    marker.textContent = '\u200b';
-    mirror.appendChild(marker);
-    doc.body.appendChild(mirror);
-
-    const markerRect = marker.getBoundingClientRect();
-    const mirrorRect = mirror.getBoundingClientRect();
-    const inputRect = input.getBoundingClientRect();
-    const coords = {
-      left: inputRect.left + (markerRect.left - mirrorRect.left),
-      top: inputRect.top + (markerRect.top - mirrorRect.top)
-    };
-
-    mirror.remove();
-    return coords;
-  };
-
-  const getActiveTableSelectionState = (input) => {
-    const rawStart = input.selectionStart ?? 0;
-    const rawEnd = input.selectionEnd ?? rawStart;
-    if (rawStart === rawEnd) {
-      return null;
-    }
-    const selectionStart = Math.min(rawStart, rawEnd);
-    const coords = measureTextareaSelectionStart(input, selectionStart);
-    return {
-      visible: true,
-      anchorX: coords.left,
-      anchorY: coords.top
-    };
-  };
-
-  const updateActiveTableInput = (input, nextValue, anchor, head = anchor) => {
-    input.value = nextValue;
-    input.focus({ preventScroll: true });
-    input.setSelectionRange(
-      Math.min(anchor, head),
-      Math.max(anchor, head),
-      anchor <= head ? 'forward' : 'backward'
-    );
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    emitSelectionChange();
-    return true;
-  };
-
-  const editActiveTableInputWithSelection = (input, transform) => {
-    const rawStart = input.selectionStart ?? 0;
-    const rawEnd = input.selectionEnd ?? rawStart;
-    const start = Math.min(rawStart, rawEnd);
-    const end = Math.max(rawStart, rawEnd);
-    return transform(input.value, start, end);
-  };
-
-  const trimTrailingNewlines = (value, start, end) => {
-    let nextEnd = end;
-    while (nextEnd > start && value.slice(nextEnd - 1, nextEnd) === '\n') {
-      nextEnd -= 1;
-    }
-    return nextEnd;
-  };
-
-  const wrapActiveTableInputSelection = (
-    input,
-    openMarker,
-    closeMarker = openMarker,
-    { toggle = true, selectWrapped = true } = {}
-  ) => {
-    return editActiveTableInputWithSelection(input, (value, start, end) => {
-      if (start === end) {
-        const insert = `${openMarker}${closeMarker}`;
-        const nextValue = value.slice(0, start) + insert + value.slice(end);
-        return updateActiveTableInput(input, nextValue, start + openMarker.length);
-      }
-
-      const trimmedEnd = trimTrailingNewlines(value, start, end);
-      if (toggle) {
-        const hasOpenMarker =
-          start >= openMarker.length && value.slice(start - openMarker.length, start) === openMarker;
-        const hasCloseMarker = value.slice(trimmedEnd, trimmedEnd + closeMarker.length) === closeMarker;
-        if (hasOpenMarker && hasCloseMarker) {
-          const nextValue =
-            value.slice(0, start - openMarker.length) +
-            value.slice(start, trimmedEnd) +
-            value.slice(trimmedEnd + closeMarker.length);
-          return updateActiveTableInput(
-            input,
-            nextValue,
-            start - openMarker.length,
-            trimmedEnd - openMarker.length
-          );
-        }
-      }
-
-      const nextValue =
-        value.slice(0, start) +
-        openMarker +
-        value.slice(start, trimmedEnd) +
-        closeMarker +
-        value.slice(trimmedEnd);
-      if (!selectWrapped) {
-        const cursor = start + openMarker.length + (trimmedEnd - start) + closeMarker.length;
-        return updateActiveTableInput(input, nextValue, cursor);
-      }
-      return updateActiveTableInput(input, nextValue, start + openMarker.length, trimmedEnd + openMarker.length);
-    });
-  };
-
-  const insertFormatInActiveTableInput = (input, action) => {
-    switch (action) {
-      case 'inlineCode':
-        return wrapActiveTableInputSelection(input, '`', '`', { toggle: false, selectWrapped: false });
-      case 'kbd':
-        return wrapActiveTableInputSelection(input, '<kbd>', '</kbd>');
-      case 'bold':
-        return wrapActiveTableInputSelection(input, '**');
-      case 'italic':
-        return wrapActiveTableInputSelection(input, '*');
-      case 'lineover':
-      case 'strike':
-        return wrapActiveTableInputSelection(input, '~~');
-      case 'link':
-        return editActiveTableInputWithSelection(input, (value, start, end) => {
-          if (start !== end) {
-            const trimmedEnd = trimTrailingNewlines(value, start, end);
-            const selectedText = value.slice(start, trimmedEnd);
-            const insert = `[${selectedText}]()`;
-            const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
-            return updateActiveTableInput(input, nextValue, start + insert.length - 1);
-          }
-
-          const insert = '[]()';
-          const nextValue = value.slice(0, start) + insert + value.slice(end);
-          return updateActiveTableInput(input, nextValue, start + 3);
-        });
-      case 'wikiLink':
-        return editActiveTableInputWithSelection(input, (value, start, end) => {
-          if (start !== end) {
-            const trimmedEnd = trimTrailingNewlines(value, start, end);
-            const selectedText = value.slice(start, trimmedEnd);
-            const insert = `[[${selectedText}]]`;
-            const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
-            return updateActiveTableInput(input, nextValue, start + insert.length);
-          }
-
-          const insert = '[[]]';
-          const nextValue = value.slice(0, start) + insert + value.slice(end);
-          return updateActiveTableInput(input, nextValue, start + 2);
-        });
-      default:
-        return false;
-    }
-  };
-
-  const forEachSelectedLine = (
-    state: EditorState,
-    callback: (line: { from: number; to: number; number: number }) => void
-  ): void => {
-    const seen = new Set<number>();
-    for (const range of state.selection.ranges) {
-      const fromLine = state.doc.lineAt(range.from).number;
-      const toPos = Math.max(range.from, range.to - (range.empty ? 0 : 1));
-      const toLine = state.doc.lineAt(toPos).number;
-      for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
-        if (seen.has(lineNumber)) {
-          continue;
-        }
-        seen.add(lineNumber);
-        callback(state.doc.line(lineNumber));
-      }
-    }
-  };
-
-  const lineMarkerReplacementContext = (
-    state: EditorState,
-    line: { from: number; to: number }
-  ): MarkerReplacementContext => {
-    const lineText = state.doc.sliceString(line.from, line.to);
-    const existingMarker = existingListMarkerRegex.exec(lineText);
-    const existingHeading = existingHeadingMarkerRegex.exec(lineText);
-    const leadingWhitespace = existingMarker?.[1] ?? existingHeading?.[1] ?? /^(\s*)/.exec(lineText)[1];
-
-    const contentStart = line.from + leadingWhitespace.length;
-    let oldMarkerLen = 0;
-    if (existingMarker) {
-      oldMarkerLen = existingMarker[0].length - leadingWhitespace.length;
-    } else if (existingHeading) {
-      oldMarkerLen = existingHeading[0].length - leadingWhitespace.length;
-    }
-
-    const isExistingTask = Boolean(existingMarker && existingTaskMarkerRegex.test(existingMarker[0]));
-    return { contentStart, oldMarkerLen, isExistingTask };
-  };
-
-  const buildListFormatChangesForSelection = (state: EditorState, insert: string): ChangeSpec[] => {
-    const changes: ChangeSpec[] = [];
-    forEachSelectedLine(state, (line) => {
-      const { contentStart, oldMarkerLen } = lineMarkerReplacementContext(state, line);
-      changes.push({ from: contentStart, to: contentStart + oldMarkerLen, insert });
-    });
-    return changes;
-  };
-
-  const dispatchSelectedListFormatChanges = (
-    state: EditorState,
-    changes: ChangeSpec[],
-    shouldRenumberOrdered: boolean
-  ): void => {
-    if (!changes.length) {
-      return;
-    }
-
-    if (!shouldRenumberOrdered) {
-      view.dispatch({ changes });
-      return;
-    }
-
-    const withMarkers = state.update({ changes });
-    const renumberChanges = collectOrderedListRenumberChanges(withMarkers.state);
-    if (!renumberChanges.length) {
-      view.dispatch(withMarkers);
-      return;
-    }
-
-    view.dispatch(
-      state.update(
-        { changes },
-        { changes: renumberChanges, sequential: true }
-      )
-    );
-  };
-
-  const isSearchMatchSelection = (from, to) => {
-    if (!view || from >= to) {
-      return false;
-    }
-
-    const searchQuery = view.state.field(searchQueryField);
-    if (!searchQuery.text || to - from !== searchQuery.text.length) {
-      return false;
-    }
-
-    let isMatchSelection = false;
-    view.state.field(searchMatchField).between(from, to, (matchFrom, matchTo) => {
-      if (matchFrom === from && matchTo === to) {
-        isMatchSelection = true;
-      }
-    });
-    return isMatchSelection;
-  };
-
-  const resolveNativeSelectionAnchor = (): { anchorX: number; anchorY: number } | null => {
-    if (!view) {
-      return null;
-    }
-
-    const nativeSelection = window.getSelection();
-    if (!nativeSelection || nativeSelection.isCollapsed || nativeSelection.rangeCount === 0) {
-      return null;
-    }
-
-    let topRect: DOMRect | null = null;
-    for (let rangeIndex = 0; rangeIndex < nativeSelection.rangeCount; rangeIndex += 1) {
-      const range = nativeSelection.getRangeAt(rangeIndex);
-      const ancestor = range.commonAncestorContainer;
-      if (!view.dom.contains(ancestor)) {
-        continue;
-      }
-
-      const rects = range.getClientRects();
-      for (let rectIndex = 0; rectIndex < rects.length; rectIndex += 1) {
-        const rect = rects.item(rectIndex);
-        if (!rect || (rect.width <= 0 && rect.height <= 0)) {
-          continue;
-        }
-        if (!topRect || rect.top < topRect.top || (rect.top === topRect.top && rect.left < topRect.left)) {
-          topRect = rect;
-        }
-      }
-    }
-
-    if (!topRect) {
-      return null;
-    }
-
-    return {
-      anchorX: topRect.left,
-      anchorY: topRect.top
-    };
-  };
-
-  const emitSelectionChange = () => {
-    if (!view || typeof onSelectionChange !== 'function') {
-      return;
-    }
-
-    const activeTableInput = getActiveTableInput();
-    if (activeTableInput) {
-      onSelectionChange(getActiveTableSelectionState(activeTableInput) ?? { visible: false });
-      return;
-    }
-
-    const selection = view.state.selection.main;
-    if (selection.empty) {
-      onSelectionChange({ visible: false });
-      return;
-    }
-
-    const from = Math.min(selection.from, selection.to);
-    const to = Math.max(selection.from, selection.to);
-    if (isSearchMatchSelection(from, to)) {
-      onSelectionChange({ visible: false });
-      return;
-    }
-
-    if (!isRegularInlineSelection(view.state, from, to)) {
-      onSelectionChange({ visible: false });
-      return;
-    }
-
-    const nativeAnchor = resolveNativeSelectionAnchor();
-    if (nativeAnchor) {
-      onSelectionChange({
-        visible: true,
-        from,
-        to,
-        anchorX: nativeAnchor.anchorX,
-        anchorY: nativeAnchor.anchorY
-      });
-      return;
-    }
-
-    const fromCoords = view.coordsAtPos(from);
-    const toCoords = view.coordsAtPos(to);
-    if (!fromCoords || !toCoords) {
-      onSelectionChange({ visible: false });
-      return;
-    }
-
-    const fromCharCoords = view.coordsForChar(from);
-    const anchorX = fromCharCoords?.left ?? fromCoords.left;
-    const anchorY = fromCharCoords ? Math.min(fromCoords.top, fromCharCoords.top) : fromCoords.top;
-
-    onSelectionChange({
-      visible: true,
-      from,
-      to,
-      anchorX,
-      anchorY
-    });
-  };
-
-  const isHistoryReplayUpdate = (update: ViewUpdate): boolean => {
-    return update.transactions.some((transaction) => {
-      const userEvent = transaction.annotation(Transaction.userEvent);
-      return (
-        typeof userEvent === 'string' &&
-        (userEvent === 'undo' || userEvent === 'redo' || userEvent.startsWith('undo.') || userEvent.startsWith('redo.'))
-      );
-    });
-  };
-
-  const inlineCodeCaretPosition = (state, position) => {
-    let node = syntaxTree(state).resolveInner(position, -1);
-    while (node && node.name !== 'InlineCode' && node.name !== 'CodeText') {
-      node = node.parent;
-    }
-    if (!node) {
-      return null;
-    }
-
-    const text = state.doc.sliceString(node.from, node.to);
-    const openTicks = (/^`+/.exec(text) ?? [''])[0].length;
-    const closeTicks = (/`+$/.exec(text) ?? [''])[0].length;
-    if (!openTicks || !closeTicks) {
-      return null;
-    }
-
-    const min = node.from + openTicks;
-    const max = node.to - closeTicks;
-    if (min > max) {
-      return null;
-    }
-    if (position < min) {
-      return min;
-    }
-    if (position > max) {
-      return max;
-    }
-    return null;
-  };
-
-  const selectSearchMatch = (from, to, { focusEditor = true } = {}) => {
-    view.dispatch({
-      selection: { anchor: from, head: to },
-      effects: EditorView.scrollIntoView(from, { y: 'center' })
-    });
-    if (focusEditor) {
-      view.focus();
-    }
-  };
-
-  const applyRevealSelection = (anchor, head = anchor, { focusEditor = true, align = 'center' } = {}) => {
-    const max = view.state.doc.length;
-    const nextAnchor = Math.max(0, Math.min(anchor, max));
-    const nextHead = Math.max(0, Math.min(head, max));
-    const y = align === 'top' ? 'start' : 'center';
-    const selection = view.state.selection.main;
-
-    if (selection.anchor === nextAnchor && selection.head === nextHead) {
-      view.dispatch({
-        effects: EditorView.scrollIntoView(nextAnchor, { y })
-      });
-      if (focusEditor) {
-        view.focus();
-      }
-      return;
-    }
-
-    view.dispatch({
-      selection: { anchor: nextAnchor, head: nextHead },
-      effects: EditorView.scrollIntoView(nextAnchor, { y })
-    });
-    if (focusEditor) {
-      view.focus();
-    }
-  };
-
-  const TOP_LINE_VISIBILITY_EPSILON = 0.5;
-  const SCROLL_RESTORE_EPSILON = 0.5;
-  const SCROLL_RESTORE_MAX_ATTEMPTS = 3;
-
-  const getTopLineMetrics = (scrollTopValue = view.scrollDOM.scrollTop) => {
-    const scrollTop = Math.max(0, scrollTopValue);
-    const lineBlock = view.lineBlockAtHeight(scrollTop);
-    const line = view.state.doc.lineAt(lineBlock.from);
-    return {
-      line,
-      lineBlock,
-      hiddenTopPixels: scrollTop - lineBlock.top
-    };
-  };
-
-  const topVisibleLineAtCurrentScroll = () => {
-    const { line, hiddenTopPixels } = getTopLineMetrics();
-    if (hiddenTopPixels <= TOP_LINE_VISIBILITY_EPSILON) {
-      return line;
-    }
-
-    const nextLineNumber = Math.min(view.state.doc.lines, line.number + 1);
-    return view.state.doc.line(nextLineNumber);
-  };
-
-  const syncCursorToTopVisibleLine = () => {
-    const line = topVisibleLineAtCurrentScroll();
-    const anchor = line.from;
-    const selection = view.state.selection.main;
-    if (selection.anchor === anchor && selection.head === anchor) {
-      return;
-    }
-    view.dispatch({
-      selection: { anchor },
-      annotations: Transaction.addToHistory.of(false)
-    });
-  };
-
-  const computeTopVisiblePosition = () => {
-    const { line, hiddenTopPixels } = getTopLineMetrics();
-    return {
-      lineNumber: line.number,
-      lineOffset: normalizeTopLineOffset(hiddenTopPixels)
-    };
-  };
-
-  const restoreTopVisibleLine = (lineNumber, lineOffset = 0, { syncCursor = true } = {}) => {
-    const targetLineNumber = Math.min(Math.max(1, Math.floor(lineNumber || 1)), view.state.doc.lines);
-    const targetOffset = normalizeTopLineOffset(lineOffset);
-    let attempts = 0;
-    const restoreScroll = () => {
-      if (!view || ++attempts > SCROLL_RESTORE_MAX_ATTEMPTS) {
-        if (syncCursor && view) {
-          syncCursorToTopVisibleLine();
-        }
-        return;
-      }
-      const targetLine = view.state.doc.line(targetLineNumber);
-      const targetTop = Math.max(0, view.lineBlockAt(targetLine.from).top + targetOffset);
-      const currentTop = view.scrollDOM.scrollTop;
-      view.scrollDOM.scrollTop = targetTop;
-      if (Math.abs(currentTop - targetTop) <= SCROLL_RESTORE_EPSILON) {
-        if (syncCursor) {
-          syncCursorToTopVisibleLine();
-        }
-        return;
-      }
-      requestAnimationFrame(restoreScroll);
-    };
-    restoreScroll();
-  };
-
-  const findMatch = (
-    query,
-    backward = false,
-    { focusEditor = true, ...searchOptions }: SearchOptions & { focusEditor?: boolean } = {}
-  ) => {
-    if (!query) {
-      return { found: false, current: 0, total: 0 };
-    }
-
-    const text = view.state.doc.toString();
-    const selection = view.state.selection.main;
-    const from = Math.min(selection.from, selection.to);
-    const to = Math.max(selection.from, selection.to);
-    const matches = findSearchMatchRanges(text, query, searchOptions);
-    const total = matches.length;
-
-    if (!total) {
-      return { found: false, current: 0, total };
-    }
-
-    let matchIndex = -1;
-    if (backward) {
-      for (let index = matches.length - 1; index >= 0; index -= 1) {
-        if (matches[index].start < from) {
-          matchIndex = index;
-          break;
-        }
-      }
-      if (matchIndex < 0) {
-        matchIndex = matches.length - 1;
-      }
-    } else {
-      for (let index = 0; index < matches.length; index += 1) {
-        if (matches[index].start >= to) {
-          matchIndex = index;
-          break;
-        }
-      }
-      if (matchIndex < 0) {
-        matchIndex = 0;
-      }
-    }
-
-    const match = matches[matchIndex];
-    selectSearchMatch(match.start, match.end, { focusEditor });
-    return {
-      found: true,
-      current: matchIndex + 1,
-      total
-    };
-  };
-
-  const replaceCurrentMatch = (query, replacement, options: SearchOptions = {}) => {
-    if (!query) {
-      return { replaced: false, found: false, current: 0, total: 0 };
-    }
-
-    const text = view.state.doc.toString();
-    const selection = view.state.selection.main;
-    const from = Math.min(selection.from, selection.to);
-    const to = Math.max(selection.from, selection.to);
-    const matches = findSearchMatchRanges(text, query, options);
-    const matchIndex = findSelectedSearchMatchIndex(matches, from, to);
-    if (matchIndex < 0) {
-      return { replaced: false, ...findMatch(query, false, options) };
-    }
-
-    view.dispatch({
-      changes: { from, to, insert: replacement },
-      selection: { anchor: from, head: from + replacement.length }
-    });
-    const nextMatch = findMatch(query, false, options);
-    if (nextMatch.found) {
-      return { replaced: true, ...nextMatch };
-    }
-
-    const remaining = countMatches(view.state.doc.toString(), query, options);
-    return { replaced: true, found: false, current: 0, total: remaining };
-  };
-
-  const state = EditorState.create({
-    doc: text,
-    selection: { anchor: initialCursorPos },
-    extensions: [
-      EditorState.tabSize.of(4),
-      indentUnit.of('  '),
-      vimCompartment.of(vimExtensionsForState()),
-      keymap.of([
-        { key: 'Tab', run: (view) => indentListByTwoSpaces(view) || indentMore(view) },
-        { key: 'Shift-Tab', run: (view) => outdentListByTwoSpaces(view) || indentLess(view) },
-        { key: 'Backspace', run: deleteBackwardSmart },
-        { key: 'ArrowLeft', run: (view) => isLiveMode(view) && handleArrowLeftAtListContentStart(view) },
-        { key: 'ArrowRight', run: (view) => isLiveMode(view) && handleArrowRightAtListLineStart(view) },
-        {
-          key: 'Enter',
-          run: (view) =>
-            handleEnterContinueQuotedCodeBlock(view) ||
-            handleEnterOnEmptyListItem(view) ||
-            handleEnterAtListContentStart(view) ||
-            handleEnterContinueList(view) ||
-            handleEnterBeforeNestedList(view)
-        },
-        { key: 'Shift-Enter', run: insertTableCellLineBreak },
-        { key: 'ArrowUp', run: (view) => tryEnterAdjacentTable(view, 'up') },
-        { key: 'ArrowDown', run: (view) => tryEnterAdjacentTable(view, 'down') },
-        ...markdownKeymap,
-        ...defaultKeymap,
-        ...historyKeymap
-      ]),
-      history(),
-      lineNumbers(),
-      ...gitDiffGutterBaselineExtensions(),
-      gitGutterCompartment.of(startMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()),
-      highlightActiveLineGutter(),
-      highlightActiveLine(),
-      EditorView.lineWrapping,
-      scrollPastEnd(),
-      EditorView.domEventHandlers({
-        pointerdown(event, view) {
-          if (event.button !== 0) {
-            frontmatterBoundaryClick = null;
-            return false;
-          }
-          if (openLinkIfModifierClick(event, view)) {
-            frontmatterBoundaryClick = null;
-            return true;
-          }
-
-          const target = event.target;
-          const targetElement = targetElementFrom(target);
-          if (!(target instanceof Node) || !view.contentDOM.contains(target)) {
-            return false;
-          }
-
-          trackFrontmatterBoundaryClick(event, view);
-
-          if (targetElement && targetElement.closest('.meo-mermaid-zoom-controls')) {
-            event.preventDefault();
-            event.stopPropagation();
-            return true;
-          }
-
-          if (targetElement && targetElement.closest('.meo-task-checkbox')) {
-            checkboxClick = { pointerId: event.pointerId };
-            return false;
-          }
-
-          // Let interactive HTML table widget controls handle focus/click natively.
-          if (targetElement && targetElement.closest('.meo-md-html-table-wrap')) {
-            inlineCodeClick = null;
-            checkboxClick = null;
-            return false;
-          }
-
-          inlineCodeClick = {
-            pointerId: event.pointerId,
-            inInlineCode:
-              currentMode === 'live' &&
-              targetElement &&
-              targetElement.closest('.meo-md-inline-code') !== null
-          };
-
-          if (view.dom.setPointerCapture) {
-            view.dom.setPointerCapture(event.pointerId);
-            capturedPointerId = event.pointerId;
-          }
-          return false;
-        },
-        pointerup(event, view) {
-          if (checkboxClick?.pointerId === event.pointerId) {
-            frontmatterBoundaryClick = null;
-            checkboxClick = null;
-            return false;
-          }
-
-          if (capturedPointerId !== event.pointerId) {
-            if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
-              frontmatterBoundaryClick = null;
+export function createEditor({ parent, text, onApplyChanges, onOpenLink, onSelectionChange, onViewportChange, onRequestGitBlame, onOpenGitRevisionForLine, onOpenGitWorktreeForLine, initialMode = "source", initialTopLine = null, initialTopLineOffset = 0, initialLineNumbers = true, initialGitGutter = true, initialVimMode = false, initialVimKeybindings = [], initialVimLeader = "\\" }) {
+    // VS Code webviews can hit cross-origin window access issues in the EditContext path.
+    // Disable it explicitly for stability in embedded Chromium.
+    (EditorView as any).EDIT_CONTEXT = false;
+
+    const modeCompartment = new Compartment();
+    const gitGutterCompartment = new Compartment();
+    const vimCompartment = new Compartment();
+    const startMode = initialMode === "live" ? "live" : "source";
+    let lineNumbersVisible = initialLineNumbers !== false;
+    let gitGutterVisible = initialGitGutter !== false;
+    let vimModeEnabled = initialVimMode === true;
+    let appliedVimKeybindings: Array<{ before: string; mode: string }> = [];
+
+    const applyVimKeybindings = (bindings: Array<{ before: string; after: string; mode: string; recursive: boolean }>, leaderKey: string) => {
+        for (const { before, mode } of appliedVimKeybindings) {
+            try {
+                Vim.unmap(before, mode);
+            } catch {
+                /* ignore unmapping errors */
             }
-            return false;
-          }
-
-          releasePointerCaptureIfHeld(event.pointerId);
-          capturedPointerId = null;
-
-          if (
-            inlineCodeClick?.pointerId === event.pointerId &&
-            inlineCodeClick.inInlineCode &&
-            isLiveMode(view)
-          ) {
-            const { head, empty } = view.state.selection.main;
-            if (empty) {
-              const clamped = inlineCodeCaretPosition(view.state, head);
-              if (clamped !== null && clamped !== head) {
-                view.dispatch({ selection: { anchor: clamped } });
-              }
-            }
-          }
-
-          if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
-            if (isLiveMode(view)) {
-              const selection = view.state.selection.main;
-              if (selection.empty && selection.head !== frontmatterBoundaryClick.cursorEnd) {
-                view.dispatch({ selection: { anchor: frontmatterBoundaryClick.cursorEnd } });
-              }
-            }
-            frontmatterBoundaryClick = null;
-          }
-
-          if (isLiveMode(view)) {
-            const { head, empty } = view.state.selection.main;
-            if (empty) {
-              const emptyQuoteCursorEnd = emptyBlockquoteLineCursorEnd(view.state, head);
-              if (emptyQuoteCursorEnd !== null && head < emptyQuoteCursorEnd) {
-                view.dispatch({ selection: { anchor: emptyQuoteCursorEnd } });
-                return false;
-              }
-
-              const node = resolvedSyntaxTree(view.state).resolveInner(head, -1);
-              if (node.name === 'HorizontalRule') {
-                const line = view.state.doc.lineAt(head);
-                const lineText = view.state.doc.sliceString(line.from, line.to);
-                const hrMatch = /^[ \t]*(-{3,}|\*{3,}|_{3,})/.exec(lineText);
-                if (hrMatch) {
-                  const cursorEnd = line.from + hrMatch[0].length;
-                  if (head !== cursorEnd) {
-                    view.dispatch({ selection: { anchor: cursorEnd } });
-                  }
+        }
+        appliedVimKeybindings = [];
+        try {
+            Vim.setOption("leader", leaderKey);
+        } catch {
+            /* ignore */
+        }
+        for (const { before, after, mode, recursive } of bindings) {
+            try {
+                if (recursive) {
+                    Vim.map(before, after, mode);
+                } else {
+                    Vim.noremap(before, after, mode);
                 }
-              }
+                appliedVimKeybindings.push({ before, mode });
+            } catch {
+                /* ignore individual mapping errors */
             }
-          }
+        }
+    };
 
-          inlineCodeClick = null;
-          return false;
-        },
-        pointercancel(event, _view) {
-          if (capturedPointerId !== event.pointerId) {
-            if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
-              frontmatterBoundaryClick = null;
+    if (initialVimMode === true) {
+        applyVimKeybindings(initialVimKeybindings, initialVimLeader);
+    }
+    let applyingExternal = false;
+    let capturedPointerId = null;
+    let inlineCodeClick = null;
+    let checkboxClick = null;
+    let frontmatterBoundaryClick = null;
+    let view = null;
+    let currentMode = startMode;
+    let applyingRenumber = false;
+    // External syncs may carry stale selections in their history entries.
+    // Preserve the user's current cursor once on the next undo of such a change.
+    let pendingExternalUndoSelectionPreserve = false;
+    let tableInteractionActive = false;
+    let onTableInteraction = null;
+    let onTableOpenLink = null;
+    let onTableSelectionChange = null;
+    let onScroll = null;
+    let gitBlameHover = null;
+    let gitDiffOverviewRuler = null;
+    let sourceLinkHoverPointerActive = false;
+    const normalizeTopLineOffset = (value) => {
+        if (!Number.isFinite(value)) {
+            return 0;
+        }
+        return Math.max(0, Number(value));
+    };
+    const vimExtensionsForState = () => (vimModeEnabled ? vim() : []);
+    const getLineStartOffset = (docText, targetLineNumber) => {
+        const targetLine = Math.max(1, Math.floor(targetLineNumber));
+        if (targetLine === 1) {
+            return 0;
+        }
+        let line = 1;
+        for (let index = 0; index < docText.length; index += 1) {
+            if (docText.charCodeAt(index) !== 10) {
+                continue;
             }
+            line += 1;
+            if (line === targetLine) {
+                return index + 1;
+            }
+        }
+        return docText.length;
+    };
+    const initialCursorPos = (() => {
+        if (typeof initialTopLine === "number" && Number.isFinite(initialTopLine)) {
+            return getLineStartOffset(text ?? "", initialTopLine);
+        }
+        if (!text) {
+            return 0;
+        }
+        const firstLineEnd = text.indexOf("\n");
+        return firstLineEnd === -1 ? text.length : firstLineEnd;
+    })();
+    const targetElementFrom = (target) => (target instanceof Element ? target : target instanceof Node ? target.parentElement : null);
+    const openLinkIfModifierClick = (event, editorView) => {
+        if (!isPrimaryModifierPointerClick(event)) {
             return false;
-          }
-
-          releasePointerCaptureIfHeld(event.pointerId);
-          capturedPointerId = null;
-          frontmatterBoundaryClick = null;
-          inlineCodeClick = null;
-          checkboxClick = null;
-          return false;
-        },
-        pointermove(event, view) {
-          updateSourceLinkHoverCursor(event, view);
-          return false;
-        },
-        pointerleave(_event, view) {
-          setSourceLinkHoverCursor(view, false);
-          return false;
         }
-      }),
-      ...headingCollapseSharedExtensions(),
-      modeCompartment.of(startMode === 'live' ? liveModeExtensions() : sourceMode()),
-      searchQueryField,
-      searchMatchField,
-      EditorView.updateListener.of((update) => {
-        syncModeClasses();
-        syncLineNumbersVisibility();
-        syncGitGutterVisibility();
-
-        if (update.selectionSet) {
-          syncSelectionClass();
-          emitSelectionChange();
-        } else if (update.viewportChanged) {
-          emitSelectionChange();
-          onViewportChange?.();
+        const href = getLinkHrefAtPointer(event, editorView);
+        if (!href) {
+            return false;
         }
-
-        if (!update.docChanged || applyingExternal || applyingRenumber) {
-          return;
+        event.preventDefault();
+        event.stopPropagation();
+        onOpenLink?.(href);
+        return true;
+    };
+    const setSourceLinkHoverCursor = (editorView, active) => {
+        if (sourceLinkHoverPointerActive === active) {
+            return;
         }
-
-        gitBlameHover?.hide();
-
-        pendingExternalUndoSelectionPreserve = false;
-
-        if (isHistoryReplayUpdate(update)) {
-          onApplyChanges(update.state.doc.toString());
-          return;
+        sourceLinkHoverPointerActive = active;
+        const cursor = active ? "pointer" : "";
+        editorView.dom.style.cursor = cursor;
+        editorView.contentDOM.style.cursor = cursor;
+    };
+    const updateSourceLinkHoverCursor = (event, editorView) => {
+        if (currentMode !== "source") {
+            setSourceLinkHoverCursor(editorView, false);
+            return;
         }
-
-        const renumberChanges = collectOrderedListRenumberChanges(update.state);
-        if (renumberChanges.length) {
-          applyingRenumber = true;
-          view.dispatch({
-            changes: renumberChanges,
-            annotations: Transaction.addToHistory.of(false)
-          });
-          applyingRenumber = false;
-          onApplyChanges(view.state.doc.toString());
-          return;
+        const target = event.target;
+        if (!(target instanceof Node) || !editorView.contentDOM.contains(target)) {
+            setSourceLinkHoverCursor(editorView, false);
+            return;
+        }
+        const href = getLinkHrefAtPointer(event, editorView, { exactTextHit: true });
+        setSourceLinkHoverCursor(editorView, Boolean(href));
+    };
+    const isLiveMode = (editorView) => editorView.dom.classList.contains("meo-mode-live");
+    const isPlainPrimaryPointerEvent = (event) => event.button === 0 && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey;
+    const frontmatterBoundaryCursorEnd = (state, pos) => {
+        const frontmatter = parseFrontmatter(state);
+        if (!frontmatter) {
+            return null;
+        }
+        const line = state.doc.lineAt(pos);
+        const openingLineNo = state.doc.lineAt(frontmatter.openingFrom).number;
+        const closingLineNo = state.doc.lineAt(frontmatter.closingFrom).number;
+        if (line.number !== openingLineNo && line.number !== closingLineNo) {
+            return null;
+        }
+        const lineText = state.doc.sliceString(line.from, line.to);
+        const markerStart = lineText.indexOf("---");
+        return markerStart >= 0 ? line.from + markerStart + 3 : null;
+    };
+    const emptyBlockquoteLineCursorEnd = (state, pos) => {
+        const line = state.doc.lineAt(pos);
+        const lineText = state.doc.sliceString(line.from, line.to);
+        const quoteMatch = /^[ \t]{0,3}(?:>[ \t]?)+$/.exec(lineText);
+        if (!quoteMatch) {
+            return null;
         }
 
-        onApplyChanges(update.state.doc.toString());
-      })
-    ]
-  });
-
-  const initialScrollTo = (() => {
-    if (typeof initialTopLine !== 'number' || !Number.isFinite(initialTopLine)) {
-      return undefined;
-    }
-    const lineNumber = Math.min(Math.max(1, Math.floor(initialTopLine)), state.doc.lines);
-    const line = state.doc.line(lineNumber);
-    return EditorView.scrollIntoView(line.from, { y: 'start' });
-  })();
-
-  view = new EditorView({
-    state,
-    parent,
-    scrollTo: initialScrollTo
-  });
-  if (typeof initialTopLine === 'number' && Number.isFinite(initialTopLine)) {
-    restoreTopVisibleLine(initialTopLine, initialTopLineOffset, { syncCursor: true });
-  }
-  onTableInteraction = (event) => {
-    const active = Boolean(event?.detail?.active);
-    setTableInteractionActive(active);
-  };
-  view.dom.addEventListener('meo-table-interaction', onTableInteraction);
-  onTableOpenLink = (event) => {
-    const href = event?.detail?.href;
-    if (typeof href !== 'string' || !href) {
-      return;
-    }
-    onOpenLink?.(href);
-  };
-  view.dom.addEventListener('meo-open-link', onTableOpenLink);
-  onTableSelectionChange = () => {
-    emitSelectionChange();
-  };
-  view.dom.addEventListener('meo-table-selection-change', onTableSelectionChange);
-  onScroll = () => {
-    emitSelectionChange();
-    gitBlameHover?.hide();
-    onViewportChange?.();
-  };
-  view.scrollDOM.addEventListener('scroll', onScroll, { passive: true });
-  if (typeof onRequestGitBlame === 'function') {
-    gitBlameHover = createGitBlameHoverController({
-      view,
-      getMode: () => currentMode,
-      requestBlame: onRequestGitBlame,
-      openRevisionForLine: onOpenGitRevisionForLine,
-      openWorktreeForLine: onOpenGitWorktreeForLine
-    });
-  }
-  gitDiffOverviewRuler = createGitDiffOverviewRulerController({
-    view,
-    getMode: () => currentMode,
-    isGitChangesVisible: () => gitGutterVisible
-  });
-  syncModeClasses();
-  syncLineNumbersVisibility();
-  syncGitGutterVisibility();
-  syncSelectionClass();
-  emitSelectionChange();
-
-  return {
-    view,
-    state: view.state,
-    getText() {
-      return view.state.doc.toString();
-    },
-    selectAll() {
-      view.dispatch({
-        selection: {
-          anchor: 0,
-          head: view.state.doc.length
+        const probePos = Math.min(line.to, line.from + 1);
+        let node = resolvedSyntaxTree(state).resolveInner(probePos, 1);
+        while (node) {
+            if (node.name === "Blockquote") {
+                return line.from + quoteMatch[0].length;
+            }
+            node = node.parent;
         }
-      });
-      return true;
-    },
-    undo() {
-      const shouldPreserveSelection = pendingExternalUndoSelectionPreserve;
-      const { anchor, head } = view.state.selection.main;
-      const applied = undo(view);
-      if (!applied) {
+
+        return null;
+    };
+    const trackFrontmatterBoundaryClick = (event, editorView) => {
+        frontmatterBoundaryClick = null;
+        if (!isLiveMode(editorView) || !isPlainPrimaryPointerEvent(event)) {
+            return;
+        }
+        const clickedPos = editorView.posAtCoords({ x: event.clientX, y: event.clientY });
+        if (clickedPos === null) {
+            return;
+        }
+        const cursorEnd = frontmatterBoundaryCursorEnd(editorView.state, clickedPos);
+        if (cursorEnd === null) {
+            return;
+        }
+        frontmatterBoundaryClick = {
+            pointerId: event.pointerId,
+            cursorEnd,
+        };
+    };
+
+    const setTableInteractionActive = (active) => {
+        if (!view || tableInteractionActive === active) {
+            return;
+        }
+        tableInteractionActive = active;
+        view.dom.classList.toggle("meo-table-interaction-active", active);
+    };
+    const tableEntryCellSelector = "th[data-table-row][data-table-col], td[data-table-row][data-table-col]";
+    const tableEntryProbeOffsetsY = [1, 4, 8, 12, 18];
+    const focusTableEntryInput = (input) => {
+        if (!(input instanceof HTMLTextAreaElement)) {
+            return false;
+        }
+        input.focus({ preventScroll: true });
+        const caret = input.value.length;
+        input.setSelectionRange(caret, caret);
+        input.closest(tableEntryCellSelector)?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+        return true;
+    };
+    const findTableEntryInput = (wrap, hit, direction) => {
+        const cell = hit.closest(tableEntryCellSelector);
+        if (cell instanceof HTMLElement && wrap.contains(cell)) {
+            const cellInput = cell.querySelector("textarea");
+            if (cellInput instanceof HTMLTextAreaElement) {
+                return cellInput;
+            }
+        }
+
+        if (direction === "down") {
+            const first = wrap.querySelector("textarea");
+            return first instanceof HTMLTextAreaElement ? first : null;
+        }
+
+        const inputs = wrap.querySelectorAll("textarea");
+        const last = inputs.length ? inputs[inputs.length - 1] : null;
+        return last instanceof HTMLTextAreaElement ? last : null;
+    };
+
+    const tryEnterAdjacentTable = (editorView, direction) => {
+        if ((direction !== "down" && direction !== "up") || currentMode !== "live" || tableInteractionActive) {
+            return false;
+        }
+
+        const selection = editorView.state.selection.main;
+        if (!selection.empty) {
+            return false;
+        }
+
+        const caretRect = editorView.coordsAtPos(selection.head);
+        if (!caretRect) {
+            return false;
+        }
+
+        const contentRect = editorView.contentDOM.getBoundingClientRect();
+        if (!contentRect || contentRect.width <= 0 || contentRect.height <= 0) {
+            return false;
+        }
+
+        const clampX = (x) => Math.min(Math.max(x, contentRect.left + 1), contentRect.right - 1);
+        const probeXs = [clampX(caretRect.left + 1), clampX(contentRect.left + Math.min(24, Math.max(8, contentRect.width * 0.05)))];
+
+        for (const offsetY of tableEntryProbeOffsetsY) {
+            const y = direction === "down" ? caretRect.bottom + offsetY : caretRect.top - offsetY;
+            if (y < 0 || y >= window.innerHeight) {
+                if (direction === "down" && y >= window.innerHeight) break;
+                continue;
+            }
+            for (const x of probeXs) {
+                const hit = document.elementFromPoint(x, y);
+                if (!(hit instanceof Element)) {
+                    continue;
+                }
+                const wrap = hit.closest(".meo-md-html-table-wrap");
+                if (!(wrap instanceof HTMLElement) || !editorView.dom.contains(wrap)) {
+                    continue;
+                }
+                const input = findTableEntryInput(wrap, hit, direction);
+                if (!focusTableEntryInput(input)) {
+                    continue;
+                }
+                return true;
+            }
+        }
+
         return false;
-      }
-      if (!shouldPreserveSelection) {
+    };
+
+    const syncModeClasses = () => {
+        if (!view) {
+            return;
+        }
+        const isLiveModeActive = currentMode === "live";
+        view.dom.classList.toggle("meo-mode-live", currentMode === "live");
+        view.dom.classList.toggle("meo-mode-source", currentMode !== "live");
+        // Keep active typography vars explicitly synced to mode so source/live
+        // font sizing and line-height don't depend on selector cascade.
+        view.dom.style.setProperty("--meo-active-editor-font", isLiveModeActive ? "var(--meo-font-live)" : "var(--meo-font-source)");
+        view.dom.style.setProperty("--meo-active-editor-font-weight", isLiveModeActive ? "var(--meo-font-live-weight)" : "var(--meo-font-source-weight)");
+        view.dom.style.setProperty("--meo-active-editor-font-size", isLiveModeActive ? "var(--meo-font-live-size)" : "var(--meo-font-source-size)");
+        view.dom.style.setProperty("--meo-active-editor-line-height", isLiveModeActive ? "var(--meo-line-height-live)" : "var(--meo-line-height-source)");
+        if (currentMode !== "source") {
+            setSourceLinkHoverCursor(view, false);
+        }
+    };
+
+    const syncLineNumbersVisibility = () => {
+        if (!view) {
+            return;
+        }
+        view.dom.classList.toggle("meo-line-numbers-hidden", !lineNumbersVisible);
+    };
+
+    const syncGitGutterVisibility = () => {
+        if (!view) {
+            return;
+        }
+        const shouldShowGitGutter = gitGutterVisible;
+        view.dom.classList.toggle("meo-git-gutter-hidden", !shouldShowGitGutter);
+        if (!shouldShowGitGutter) {
+            gitBlameHover?.hide();
+        }
+        gitDiffOverviewRuler?.refresh();
+    };
+
+    const releasePointerCaptureIfHeld = (pointerId) => {
+        if (!view || pointerId === null) {
+            return;
+        }
+        if (view.dom.releasePointerCapture && view.dom.hasPointerCapture(pointerId)) {
+            view.dom.releasePointerCapture(pointerId);
+        }
+    };
+
+    const syncSelectionClass = () => {
+        if (!view) {
+            return;
+        }
+        const hasSelection = view.state.selection.ranges.some((range) => !range.empty);
+        view.dom.classList.toggle("has-selection", hasSelection);
+    };
+
+    const getActiveTableInput = () => {
+        if (!view) {
+            return null;
+        }
+        const active = document.activeElement;
+        if (!(active instanceof HTMLTextAreaElement)) {
+            return null;
+        }
+        if (!view.dom.contains(active)) {
+            return null;
+        }
+        return active.closest(".meo-md-html-table-wrap") ? active : null;
+    };
+
+    const measureTextareaSelectionStart = (input, index) => {
+        const doc = input.ownerDocument;
+        const mirror = doc.createElement("div");
+        const marker = doc.createElement("span");
+        const computed = window.getComputedStyle(input);
+
+        mirror.style.position = "fixed";
+        mirror.style.left = "0";
+        mirror.style.top = "0";
+        mirror.style.visibility = "hidden";
+        mirror.style.pointerEvents = "none";
+        mirror.style.whiteSpace = "pre-wrap";
+        mirror.style.overflowWrap = "break-word";
+        mirror.style.wordBreak = "break-word";
+        mirror.style.boxSizing = computed.boxSizing;
+        mirror.style.width = `${input.getBoundingClientRect().width}px`;
+        mirror.style.minHeight = computed.height;
+        mirror.style.padding = computed.padding;
+        mirror.style.border = computed.border;
+        mirror.style.font = computed.font;
+        mirror.style.fontFamily = computed.fontFamily;
+        mirror.style.fontSize = computed.fontSize;
+        mirror.style.fontWeight = computed.fontWeight;
+        mirror.style.fontStyle = computed.fontStyle;
+        mirror.style.letterSpacing = computed.letterSpacing;
+        mirror.style.lineHeight = computed.lineHeight;
+        mirror.style.textTransform = computed.textTransform;
+        mirror.style.textIndent = computed.textIndent;
+        mirror.style.tabSize = computed.tabSize;
+
+        mirror.textContent = input.value.slice(0, index);
+        marker.textContent = "\u200b";
+        mirror.appendChild(marker);
+        doc.body.appendChild(mirror);
+
+        const markerRect = marker.getBoundingClientRect();
+        const mirrorRect = mirror.getBoundingClientRect();
+        const inputRect = input.getBoundingClientRect();
+        const coords = {
+            left: inputRect.left + (markerRect.left - mirrorRect.left),
+            top: inputRect.top + (markerRect.top - mirrorRect.top),
+        };
+
+        mirror.remove();
+        return coords;
+    };
+
+    const getActiveTableSelectionState = (input) => {
+        const rawStart = input.selectionStart ?? 0;
+        const rawEnd = input.selectionEnd ?? rawStart;
+        if (rawStart === rawEnd) {
+            return null;
+        }
+        const selectionStart = Math.min(rawStart, rawEnd);
+        const coords = measureTextareaSelectionStart(input, selectionStart);
+        return {
+            visible: true,
+            anchorX: coords.left,
+            anchorY: coords.top,
+        };
+    };
+
+    const updateActiveTableInput = (input, nextValue, anchor, head = anchor) => {
+        input.value = nextValue;
+        input.focus({ preventScroll: true });
+        input.setSelectionRange(Math.min(anchor, head), Math.max(anchor, head), anchor <= head ? "forward" : "backward");
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        emitSelectionChange();
         return true;
-      }
+    };
 
-      pendingExternalUndoSelectionPreserve = false;
-      const nextAnchor = Math.min(anchor, view.state.doc.length);
-      const nextHead = Math.min(head, view.state.doc.length);
-      const selection = view.state.selection.main;
-      if (selection.anchor === nextAnchor && selection.head === nextHead) {
-        return true;
-      }
+    const editActiveTableInputWithSelection = (input, transform) => {
+        const rawStart = input.selectionStart ?? 0;
+        const rawEnd = input.selectionEnd ?? rawStart;
+        const start = Math.min(rawStart, rawEnd);
+        const end = Math.max(rawStart, rawEnd);
+        return transform(input.value, start, end);
+    };
 
-      view.dispatch({
-        selection: { anchor: nextAnchor, head: nextHead },
-        annotations: Transaction.addToHistory.of(false)
-      });
-      return true;
-    },
-    redo() {
-      return redo(view);
-    },
-    findNext(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
-      return findMatch(query, false, options);
-    },
-    findPrevious(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
-      return findMatch(query, true, options);
-    },
-    replaceCurrent(query, replacement, options: SearchOptions = {}) {
-      return replaceCurrentMatch(query, replacement, options);
-    },
-    replaceAll(query, replacement, options: SearchOptions = {}) {
-      if (!query) {
-        return { replaced: 0, total: 0 };
-      }
+    const trimTrailingNewlines = (value, start, end) => {
+        let nextEnd = end;
+        while (nextEnd > start && value.slice(nextEnd - 1, nextEnd) === "\n") {
+            nextEnd -= 1;
+        }
+        return nextEnd;
+    };
 
-      const text = view.state.doc.toString();
-      const matches = findSearchMatchRanges(text, query, options);
-      const replaced = matches.length;
-      if (!replaced) {
-        return { replaced: 0, total: 0 };
-      }
+    const wrapActiveTableInputSelection = (input, openMarker, closeMarker = openMarker, { toggle = true, selectWrapped = true } = {}) => {
+        return editActiveTableInputWithSelection(input, (value, start, end) => {
+            if (start === end) {
+                const insert = `${openMarker}${closeMarker}`;
+                const nextValue = value.slice(0, start) + insert + value.slice(end);
+                return updateActiveTableInput(input, nextValue, start + openMarker.length);
+            }
 
-      const nextText = replaceMatchRanges(text, matches, replacement);
-      view.dispatch({
-        changes: { from: 0, to: text.length, insert: nextText },
-        selection: { anchor: 0 }
-      });
-      return { replaced, total: countMatches(nextText, query, options) };
-    },
-    countMatches(query, options: SearchOptions = {}) {
-      if (!query) {
-        return 0;
-      }
-      return countMatches(view.state.doc.toString(), query, options);
-    },
-    setSearchQuery(query, options: SearchOptions = {}) {
-      const nextQuery = createSearchQueryState(query, options);
-      const currentQuery = view.state.field(searchQueryField);
-      if (
-        currentQuery.text === nextQuery.text &&
-        currentQuery.wholeWord === nextQuery.wholeWord &&
-        currentQuery.caseSensitive === nextQuery.caseSensitive
-      ) {
-        return;
-      }
-      view.dispatch({
-        effects: setSearchQueryEffect.of(nextQuery)
-      });
-    },
-    hasFocus() {
-      return view.hasFocus;
-    },
-    focus() {
-      const activeTableInput = getActiveTableInput();
-      if (activeTableInput) {
-        activeTableInput.focus({ preventScroll: true });
-        return;
-      }
-      view.focus();
-    },
-    destroy() {
-      gitBlameHover?.destroy();
-      gitBlameHover = null;
-      gitDiffOverviewRuler?.destroy();
-      gitDiffOverviewRuler = null;
-      if (onScroll) {
-        view.scrollDOM.removeEventListener('scroll', onScroll);
-        onScroll = null;
-      }
-      if (onTableInteraction) {
-        view.dom.removeEventListener('meo-table-interaction', onTableInteraction);
-        onTableInteraction = null;
-      }
-      if (onTableOpenLink) {
-        view.dom.removeEventListener('meo-open-link', onTableOpenLink);
-        onTableOpenLink = null;
-      }
-      if (onTableSelectionChange) {
-        view.dom.removeEventListener('meo-table-selection-change', onTableSelectionChange);
-        onTableSelectionChange = null;
-      }
-      if (capturedPointerId !== null) {
-        releasePointerCaptureIfHeld(capturedPointerId);
-        capturedPointerId = null;
-      }
-      setSourceLinkHoverCursor(view, false);
-      view.destroy();
-    },
-    setText(textValue) {
-      gitBlameHover?.hide();
-      const currentText = view.state.doc.toString();
-      const syncChange = findSyncChange(currentText, textValue);
-      if (!syncChange) {
-        return;
-      }
+            const trimmedEnd = trimTrailingNewlines(value, start, end);
+            if (toggle) {
+                const hasOpenMarker = start >= openMarker.length && value.slice(start - openMarker.length, start) === openMarker;
+                const hasCloseMarker = value.slice(trimmedEnd, trimmedEnd + closeMarker.length) === closeMarker;
+                if (hasOpenMarker && hasCloseMarker) {
+                    const nextValue = value.slice(0, start - openMarker.length) + value.slice(start, trimmedEnd) + value.slice(trimmedEnd + closeMarker.length);
+                    return updateActiveTableInput(input, nextValue, start - openMarker.length, trimmedEnd - openMarker.length);
+                }
+            }
 
-      const { anchor, head } = view.state.selection.main;
-      const newLength = textValue.length;
-      const mappedAnchor = Math.min(mapPositionThroughChange(anchor, syncChange), newLength);
-      const mappedHead = Math.min(mapPositionThroughChange(head, syncChange), newLength);
-      applyingExternal = true;
-      view.dispatch({
-        changes: syncChange,
-        selection: { anchor: mappedAnchor, head: mappedHead }
-      });
-      applyingExternal = false;
-      pendingExternalUndoSelectionPreserve = true;
-      syncSelectionClass();
-      emitSelectionChange();
-    },
-    setMode(mode) {
-      gitBlameHover?.hide();
-      const nextMode = mode === 'live' ? 'live' : 'source';
-      if (nextMode === currentMode) {
-        return;
-      }
-
-      const topPosition = computeTopVisiblePosition();
-
-      const previousMode = currentMode;
-      currentMode = nextMode;
-      try {
-        view.dispatch({
-          effects: [
-            modeCompartment.reconfigure(nextMode === 'live' ? liveModeExtensions() : sourceMode()),
-            gitGutterCompartment.reconfigure(
-              nextMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()
-            ),
-            vimCompartment.reconfigure(vimExtensionsForState())
-          ]
+            const nextValue = value.slice(0, start) + openMarker + value.slice(start, trimmedEnd) + closeMarker + value.slice(trimmedEnd);
+            if (!selectWrapped) {
+                const cursor = start + openMarker.length + (trimmedEnd - start) + closeMarker.length;
+                return updateActiveTableInput(input, nextValue, cursor);
+            }
+            return updateActiveTableInput(input, nextValue, start + openMarker.length, trimmedEnd + openMarker.length);
         });
-        forceParsing(view, view.state.doc.length, 500);
-      } catch (error) {
-        currentMode = previousMode;
-        syncModeClasses();
-        throw error;
-      }
-      syncModeClasses();
-      syncGitGutterVisibility();
+    };
 
-      restoreTopVisibleLine(topPosition.lineNumber, topPosition.lineOffset, { syncCursor: false });
-    },
-    setLineNumbers(visible) {
-      const nextVisible = visible !== false;
-      if (nextVisible === lineNumbersVisible) {
-        return;
-      }
-      lineNumbersVisible = nextVisible;
-      syncLineNumbersVisibility();
-    },
-    setGitGutterVisible(visible) {
-      const nextVisible = visible !== false;
-      if (nextVisible === gitGutterVisible) {
-        return;
-      }
-      gitGutterVisible = nextVisible;
-      syncGitGutterVisibility();
-    },
-    setVimMode(enabled) {
-      const nextEnabled = enabled === true;
-      if (nextEnabled === vimModeEnabled) {
-        return;
-      }
-      vimModeEnabled = nextEnabled;
-      view.dispatch({
-        effects: vimCompartment.reconfigure(vimExtensionsForState())
-      });
-    },
-    insertFormat(action, level) {
-      const activeTableInput = getActiveTableInput();
-      if (activeTableInput) {
-        return insertFormatInActiveTableInput(activeTableInput, action);
-      }
+    const insertFormatInActiveTableInput = (input, action) => {
+        switch (action) {
+            case "inlineCode":
+                return wrapActiveTableInputSelection(input, "`", "`", { toggle: false, selectWrapped: false });
+            case "kbd":
+                return wrapActiveTableInputSelection(input, "<kbd>", "</kbd>");
+            case "bold":
+                return wrapActiveTableInputSelection(input, "**");
+            case "italic":
+                return wrapActiveTableInputSelection(input, "*");
+            case "lineover":
+            case "strike":
+                return wrapActiveTableInputSelection(input, "~~");
+            case "link":
+                return editActiveTableInputWithSelection(input, (value, start, end) => {
+                    if (start !== end) {
+                        const trimmedEnd = trimTrailingNewlines(value, start, end);
+                        const selectedText = value.slice(start, trimmedEnd);
+                        const insert = `[${selectedText}]()`;
+                        const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
+                        return updateActiveTableInput(input, nextValue, start + insert.length - 1);
+                    }
 
-      const { state } = view;
-      const selection = state.selection.main;
-      let cachedInlineSelection: InlineSelectionRange | null = null;
-      const inlineSelection = (): InlineSelectionRange => {
-        if (cachedInlineSelection) {
-          return cachedInlineSelection;
+                    const insert = "[]()";
+                    const nextValue = value.slice(0, start) + insert + value.slice(end);
+                    return updateActiveTableInput(input, nextValue, start + 3);
+                });
+            case "wikiLink":
+                return editActiveTableInputWithSelection(input, (value, start, end) => {
+                    if (start !== end) {
+                        const trimmedEnd = trimTrailingNewlines(value, start, end);
+                        const selectedText = value.slice(start, trimmedEnd);
+                        const insert = `[[${selectedText}]]`;
+                        const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
+                        return updateActiveTableInput(input, nextValue, start + insert.length);
+                    }
+
+                    const insert = "[[]]";
+                    const nextValue = value.slice(0, start) + insert + value.slice(end);
+                    return updateActiveTableInput(input, nextValue, start + 2);
+                });
+            default:
+                return false;
         }
-        cachedInlineSelection = currentMode === 'live'
-          ? normalizeLiveInlineSelectionForListContent(state, selection)
-          : selection;
-        return cachedInlineSelection;
-      };
+    };
 
-      let insert = '';
-      switch (action) {
-        case 'heading':
-          insert = `${'#'.repeat(level ?? 1)} `;
-          break;
-        case 'bulletList':
-          insert = '- ';
-          break;
-        case 'numberedList':
-          insert = '1. ';
-          break;
-        case 'task':
-          insert = '- [ ] ';
-          break;
-        case 'codeBlock':
-          return insertCodeBlock(view, selection);
-        case 'inlineCode':
-          return insertInlineCode(view, inlineSelection());
-        case 'kbd':
-          return insertKbd(view, inlineSelection());
-        case 'bold':
-          return insertInlineFence(view, inlineSelection(), '**');
-        case 'italic':
-          return insertInlineFence(view, inlineSelection(), '*');
-        case 'lineover':
-        case 'strike':
-          return insertInlineFence(view, inlineSelection(), '~~');
-        case 'quote':
-          return insertQuote(view, selection);
-        case 'hr':
-          return insertHr(view, selection);
-        case 'table':
-          return insertTable(view, selection, level?.cols, level?.rows);
-        case 'link':
-          return insertLink(view, inlineSelection());
-        case 'wikiLink':
-          return insertWikiLink(view, inlineSelection());
-        case 'image':
-          return insertImage(view, inlineSelection());
-      }
+    const forEachSelectedLine = (state: EditorState, callback: (line: { from: number; to: number; number: number }) => void): void => {
+        const seen = new Set<number>();
+        for (const range of state.selection.ranges) {
+            const fromLine = state.doc.lineAt(range.from).number;
+            const toPos = Math.max(range.from, range.to - (range.empty ? 0 : 1));
+            const toLine = state.doc.lineAt(toPos).number;
+            for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
+                if (seen.has(lineNumber)) {
+                    continue;
+                }
+                seen.add(lineNumber);
+                callback(state.doc.line(lineNumber));
+            }
+        }
+    };
 
-      if (!selection.empty && (action === 'bulletList' || action === 'numberedList')) {
-        const changes = buildListFormatChangesForSelection(state, insert);
-        dispatchSelectedListFormatChanges(state, changes, action === 'numberedList');
-        return;
-      }
+    const lineMarkerReplacementContext = (state: EditorState, line: { from: number; to: number }): MarkerReplacementContext => {
+        const lineText = state.doc.sliceString(line.from, line.to);
+        const existingMarker = existingListMarkerRegex.exec(lineText);
+        const existingHeading = existingHeadingMarkerRegex.exec(lineText);
+        const leadingWhitespace = existingMarker?.[1] ?? existingHeading?.[1] ?? /^(\s*)/.exec(lineText)[1];
 
-      const line = state.doc.lineAt(selection.from);
-      const { contentStart, oldMarkerLen, isExistingTask } = lineMarkerReplacementContext(state, line);
-      if (action === 'task' && isExistingTask) {
-        return;
-      }
+        const contentStart = line.from + leadingWhitespace.length;
+        let oldMarkerLen = 0;
+        if (existingMarker) {
+            oldMarkerLen = existingMarker[0].length - leadingWhitespace.length;
+        } else if (existingHeading) {
+            oldMarkerLen = existingHeading[0].length - leadingWhitespace.length;
+        }
 
-      const newMarkerLen = insert.length;
-      const cursorOffset = selection.from - (contentStart + oldMarkerLen);
-      const newCursorPos = contentStart + newMarkerLen + Math.max(0, cursorOffset);
+        const isExistingTask = Boolean(existingMarker && existingTaskMarkerRegex.test(existingMarker[0]));
+        return { contentStart, oldMarkerLen, isExistingTask };
+    };
 
-      view.dispatch({
-        changes: { from: contentStart, to: contentStart + oldMarkerLen, insert },
-        selection: { anchor: newCursorPos }
-      });
-    },
-    getHeadings() {
-      return extractHeadings(view.state);
-    },
-    moveHeadingSection(sourceHeadingFrom, targetHeadingFrom, placement) {
-      if (placement !== 'before' && placement !== 'after') {
-        return false;
-      }
+    const buildListFormatChangesForSelection = (state: EditorState, insert: string): ChangeSpec[] => {
+        const changes: ChangeSpec[] = [];
+        forEachSelectedLine(state, (line) => {
+            const { contentStart, oldMarkerLen } = lineMarkerReplacementContext(state, line);
+            changes.push({ from: contentStart, to: contentStart + oldMarkerLen, insert });
+        });
+        return changes;
+    };
 
-      const sections = extractHeadingSections(view.state);
-      const source = sections.find((heading) => heading.from === sourceHeadingFrom);
-      const target = sections.find((heading) => heading.from === targetHeadingFrom);
-      if (!source || !target) {
-        return false;
-      }
+    const dispatchSelectedListFormatChanges = (state: EditorState, changes: ChangeSpec[], shouldRenumberOrdered: boolean): void => {
+        if (!changes.length) {
+            return;
+        }
 
-      const insertionPoint = placement === 'before' ? target.sectionFrom : target.sectionTo;
-      if (insertionPoint > source.sectionFrom && insertionPoint < source.sectionTo) {
-        return false;
-      }
+        if (!shouldRenumberOrdered) {
+            view.dispatch({ changes });
+            return;
+        }
 
-      const currentText = view.state.doc.toString();
-      const movedText = currentText.slice(source.sectionFrom, source.sectionTo);
-      if (!movedText) {
-        return false;
-      }
+        const withMarkers = state.update({ changes });
+        const renumberChanges = collectOrderedListRenumberChanges(withMarkers.state);
+        if (!renumberChanges.length) {
+            view.dispatch(withMarkers);
+            return;
+        }
 
-      const textWithoutSource = currentText.slice(0, source.sectionFrom) + currentText.slice(source.sectionTo);
-      const sourceLength = source.sectionTo - source.sectionFrom;
-      const adjustedInsertionPoint = insertionPoint >= source.sectionTo ? insertionPoint - sourceLength : insertionPoint;
-      const nextText =
-        textWithoutSource.slice(0, adjustedInsertionPoint) +
-        movedText +
-        textWithoutSource.slice(adjustedInsertionPoint);
+        view.dispatch(state.update({ changes }, { changes: renumberChanges, sequential: true }));
+    };
 
-      if (nextText === currentText) {
-        return false;
-      }
+    const isSearchMatchSelection = (from, to) => {
+        if (!view || from >= to) {
+            return false;
+        }
 
-      const nextAnchor = Math.min(adjustedInsertionPoint, nextText.length);
-      view.dispatch({
-        changes: { from: 0, to: currentText.length, insert: nextText },
-        selection: { anchor: nextAnchor },
-        effects: EditorView.scrollIntoView(nextAnchor, { y: 'start' })
-      });
-      return true;
-    },
-    scrollToLine(lineNumber, align = 'center') {
-      const line = view.state.doc.line(Math.min(lineNumber, view.state.doc.lines));
-      applyRevealSelection(line.from, line.from, { focusEditor: true, align });
-    },
-    restoreTopLine(lineNumber, lineOffset) {
-      restoreTopVisibleLine(lineNumber, lineOffset, { syncCursor: true });
-    },
-    getTopVisiblePosition() {
-      const position = computeTopVisiblePosition();
-      return {
-        line: position.lineNumber,
-        lineOffset: position.lineOffset
-      };
-    },
-    getTopVisibleLine() {
-      return computeTopVisiblePosition().lineNumber;
-    },
-    revealSelection(anchor, head, options) {
-      applyRevealSelection(anchor, head, options);
-    },
-    refreshSelectionOverlay() {
-      emitSelectionChange();
-    },
-    refreshDecorations() {
-      view.dispatch({ effects: refreshDecorationsEffect.of(null) });
-    },
-    refreshLayout() {
-      view.requestMeasure();
-      if (currentMode === 'live') {
-        forceParsing(view, view.state.doc.length, 500);
-      }
-      emitSelectionChange();
-    },
-    setGitBaseline(snapshot) {
-      applyGitBaseline(view, snapshot);
-      gitBlameHover?.hide();
-      gitDiffOverviewRuler?.refresh();
-    },
-    clearGitUiTransientState() {
-      gitBlameHover?.hide();
+        const searchQuery = view.state.field(searchQueryField);
+        if (!searchQuery.text || to - from !== searchQuery.text.length) {
+            return false;
+        }
+
+        let isMatchSelection = false;
+        view.state.field(searchMatchField).between(from, to, (matchFrom, matchTo) => {
+            if (matchFrom === from && matchTo === to) {
+                isMatchSelection = true;
+            }
+        });
+        return isMatchSelection;
+    };
+
+    const resolveNativeSelectionAnchor = (): { anchorX: number; anchorY: number } | null => {
+        if (!view) {
+            return null;
+        }
+
+        const nativeSelection = window.getSelection();
+        if (!nativeSelection || nativeSelection.isCollapsed || nativeSelection.rangeCount === 0) {
+            return null;
+        }
+
+        let topRect: DOMRect | null = null;
+        for (let rangeIndex = 0; rangeIndex < nativeSelection.rangeCount; rangeIndex += 1) {
+            const range = nativeSelection.getRangeAt(rangeIndex);
+            const ancestor = range.commonAncestorContainer;
+            if (!view.dom.contains(ancestor)) {
+                continue;
+            }
+
+            const rects = range.getClientRects();
+            for (let rectIndex = 0; rectIndex < rects.length; rectIndex += 1) {
+                const rect = rects.item(rectIndex);
+                if (!rect || (rect.width <= 0 && rect.height <= 0)) {
+                    continue;
+                }
+                if (!topRect || rect.top < topRect.top || (rect.top === topRect.top && rect.left < topRect.left)) {
+                    topRect = rect;
+                }
+            }
+        }
+
+        if (!topRect) {
+            return null;
+        }
+
+        return {
+            anchorX: topRect.left,
+            anchorY: topRect.top,
+        };
+    };
+
+    const emitSelectionChange = () => {
+        if (!view || typeof onSelectionChange !== "function") {
+            return;
+        }
+
+        const activeTableInput = getActiveTableInput();
+        if (activeTableInput) {
+            onSelectionChange(getActiveTableSelectionState(activeTableInput) ?? { visible: false });
+            return;
+        }
+
+        const selection = view.state.selection.main;
+        if (selection.empty) {
+            onSelectionChange({ visible: false });
+            return;
+        }
+
+        const from = Math.min(selection.from, selection.to);
+        const to = Math.max(selection.from, selection.to);
+        if (isSearchMatchSelection(from, to)) {
+            onSelectionChange({ visible: false });
+            return;
+        }
+
+        if (!isRegularInlineSelection(view.state, from, to)) {
+            onSelectionChange({ visible: false });
+            return;
+        }
+
+        const nativeAnchor = resolveNativeSelectionAnchor();
+        if (nativeAnchor) {
+            onSelectionChange({
+                visible: true,
+                from,
+                to,
+                anchorX: nativeAnchor.anchorX,
+                anchorY: nativeAnchor.anchorY,
+            });
+            return;
+        }
+
+        const fromCoords = view.coordsAtPos(from);
+        const toCoords = view.coordsAtPos(to);
+        if (!fromCoords || !toCoords) {
+            onSelectionChange({ visible: false });
+            return;
+        }
+
+        const fromCharCoords = view.coordsForChar(from);
+        const anchorX = fromCharCoords?.left ?? fromCoords.left;
+        const anchorY = fromCharCoords ? Math.min(fromCoords.top, fromCharCoords.top) : fromCoords.top;
+
+        onSelectionChange({
+            visible: true,
+            from,
+            to,
+            anchorX,
+            anchorY,
+        });
+    };
+
+    const isHistoryReplayUpdate = (update: ViewUpdate): boolean => {
+        return update.transactions.some((transaction) => {
+            const userEvent = transaction.annotation(Transaction.userEvent);
+            return typeof userEvent === "string" && (userEvent === "undo" || userEvent === "redo" || userEvent.startsWith("undo.") || userEvent.startsWith("redo."));
+        });
+    };
+
+    const inlineCodeCaretPosition = (state, position) => {
+        let node = syntaxTree(state).resolveInner(position, -1);
+        while (node && node.name !== "InlineCode" && node.name !== "CodeText") {
+            node = node.parent;
+        }
+        if (!node) {
+            return null;
+        }
+
+        const text = state.doc.sliceString(node.from, node.to);
+        const openTicks = (/^`+/.exec(text) ?? [""])[0].length;
+        const closeTicks = (/`+$/.exec(text) ?? [""])[0].length;
+        if (!openTicks || !closeTicks) {
+            return null;
+        }
+
+        const min = node.from + openTicks;
+        const max = node.to - closeTicks;
+        if (min > max) {
+            return null;
+        }
+        if (position < min) {
+            return min;
+        }
+        if (position > max) {
+            return max;
+        }
+        return null;
+    };
+
+    const selectSearchMatch = (from, to, { focusEditor = true } = {}) => {
+        view.dispatch({
+            selection: { anchor: from, head: to },
+            effects: EditorView.scrollIntoView(from, { y: "center" }),
+        });
+        if (focusEditor) {
+            view.focus();
+        }
+    };
+
+    const applyRevealSelection = (anchor, head = anchor, { focusEditor = true, align = "center" } = {}) => {
+        const max = view.state.doc.length;
+        const nextAnchor = Math.max(0, Math.min(anchor, max));
+        const nextHead = Math.max(0, Math.min(head, max));
+        const y = align === "top" ? "start" : "center";
+        const selection = view.state.selection.main;
+
+        if (selection.anchor === nextAnchor && selection.head === nextHead) {
+            view.dispatch({
+                effects: EditorView.scrollIntoView(nextAnchor, { y }),
+            });
+            if (focusEditor) {
+                view.focus();
+            }
+            return;
+        }
+
+        view.dispatch({
+            selection: { anchor: nextAnchor, head: nextHead },
+            effects: EditorView.scrollIntoView(nextAnchor, { y }),
+        });
+        if (focusEditor) {
+            view.focus();
+        }
+    };
+
+    const TOP_LINE_VISIBILITY_EPSILON = 0.5;
+    const SCROLL_RESTORE_EPSILON = 0.5;
+    const SCROLL_RESTORE_MAX_ATTEMPTS = 3;
+
+    const getTopLineMetrics = (scrollTopValue = view.scrollDOM.scrollTop) => {
+        const scrollTop = Math.max(0, scrollTopValue);
+        const lineBlock = view.lineBlockAtHeight(scrollTop);
+        const line = view.state.doc.lineAt(lineBlock.from);
+        return {
+            line,
+            lineBlock,
+            hiddenTopPixels: scrollTop - lineBlock.top,
+        };
+    };
+
+    const topVisibleLineAtCurrentScroll = () => {
+        const { line, hiddenTopPixels } = getTopLineMetrics();
+        if (hiddenTopPixels <= TOP_LINE_VISIBILITY_EPSILON) {
+            return line;
+        }
+
+        const nextLineNumber = Math.min(view.state.doc.lines, line.number + 1);
+        return view.state.doc.line(nextLineNumber);
+    };
+
+    const syncCursorToTopVisibleLine = () => {
+        const line = topVisibleLineAtCurrentScroll();
+        const anchor = line.from;
+        const selection = view.state.selection.main;
+        if (selection.anchor === anchor && selection.head === anchor) {
+            return;
+        }
+        view.dispatch({
+            selection: { anchor },
+            annotations: Transaction.addToHistory.of(false),
+        });
+    };
+
+    const computeTopVisiblePosition = () => {
+        const { line, hiddenTopPixels } = getTopLineMetrics();
+        return {
+            lineNumber: line.number,
+            lineOffset: normalizeTopLineOffset(hiddenTopPixels),
+        };
+    };
+
+    const restoreTopVisibleLine = (lineNumber, lineOffset = 0, { syncCursor = true } = {}) => {
+        const targetLineNumber = Math.min(Math.max(1, Math.floor(lineNumber || 1)), view.state.doc.lines);
+        const targetOffset = normalizeTopLineOffset(lineOffset);
+        let attempts = 0;
+        const restoreScroll = () => {
+            if (!view || ++attempts > SCROLL_RESTORE_MAX_ATTEMPTS) {
+                if (syncCursor && view) {
+                    syncCursorToTopVisibleLine();
+                }
+                return;
+            }
+            const targetLine = view.state.doc.line(targetLineNumber);
+            const targetTop = Math.max(0, view.lineBlockAt(targetLine.from).top + targetOffset);
+            const currentTop = view.scrollDOM.scrollTop;
+            view.scrollDOM.scrollTop = targetTop;
+            if (Math.abs(currentTop - targetTop) <= SCROLL_RESTORE_EPSILON) {
+                if (syncCursor) {
+                    syncCursorToTopVisibleLine();
+                }
+                return;
+            }
+            requestAnimationFrame(restoreScroll);
+        };
+        restoreScroll();
+    };
+
+    const findMatch = (query, backward = false, { focusEditor = true, ...searchOptions }: SearchOptions & { focusEditor?: boolean } = {}) => {
+        if (!query) {
+            return { found: false, current: 0, total: 0 };
+        }
+
+        const text = view.state.doc.toString();
+        const selection = view.state.selection.main;
+        const from = Math.min(selection.from, selection.to);
+        const to = Math.max(selection.from, selection.to);
+        const matches = findSearchMatchRanges(text, query, searchOptions);
+        const total = matches.length;
+
+        if (!total) {
+            return { found: false, current: 0, total };
+        }
+
+        let matchIndex = -1;
+        if (backward) {
+            for (let index = matches.length - 1; index >= 0; index -= 1) {
+                if (matches[index].start < from) {
+                    matchIndex = index;
+                    break;
+                }
+            }
+            if (matchIndex < 0) {
+                matchIndex = matches.length - 1;
+            }
+        } else {
+            for (let index = 0; index < matches.length; index += 1) {
+                if (matches[index].start >= to) {
+                    matchIndex = index;
+                    break;
+                }
+            }
+            if (matchIndex < 0) {
+                matchIndex = 0;
+            }
+        }
+
+        const match = matches[matchIndex];
+        selectSearchMatch(match.start, match.end, { focusEditor });
+        return {
+            found: true,
+            current: matchIndex + 1,
+            total,
+        };
+    };
+
+    const replaceCurrentMatch = (query, replacement, options: SearchOptions = {}) => {
+        if (!query) {
+            return { replaced: false, found: false, current: 0, total: 0 };
+        }
+
+        const text = view.state.doc.toString();
+        const selection = view.state.selection.main;
+        const from = Math.min(selection.from, selection.to);
+        const to = Math.max(selection.from, selection.to);
+        const matches = findSearchMatchRanges(text, query, options);
+        const matchIndex = findSelectedSearchMatchIndex(matches, from, to);
+        if (matchIndex < 0) {
+            return { replaced: false, ...findMatch(query, false, options) };
+        }
+
+        view.dispatch({
+            changes: { from, to, insert: replacement },
+            selection: { anchor: from, head: from + replacement.length },
+        });
+        const nextMatch = findMatch(query, false, options);
+        if (nextMatch.found) {
+            return { replaced: true, ...nextMatch };
+        }
+
+        const remaining = countMatches(view.state.doc.toString(), query, options);
+        return { replaced: true, found: false, current: 0, total: remaining };
+    };
+
+    const state = EditorState.create({
+        doc: text,
+        selection: { anchor: initialCursorPos },
+        extensions: [
+            EditorState.tabSize.of(4),
+            indentUnit.of("  "),
+            vimCompartment.of(vimExtensionsForState()),
+            keymap.of([
+                { key: "Tab", run: (view) => indentListByTwoSpaces(view) || indentMore(view) },
+                { key: "Shift-Tab", run: (view) => outdentListByTwoSpaces(view) || indentLess(view) },
+                { key: "Backspace", run: deleteBackwardSmart },
+                { key: "ArrowLeft", run: (view) => isLiveMode(view) && handleArrowLeftAtListContentStart(view) },
+                { key: "ArrowRight", run: (view) => isLiveMode(view) && handleArrowRightAtListLineStart(view) },
+                {
+                    key: "Enter",
+                    run: (view) => handleEnterContinueQuotedCodeBlock(view) || handleEnterOnEmptyListItem(view) || handleEnterAtListContentStart(view) || handleEnterContinueList(view) || handleEnterBeforeNestedList(view),
+                },
+                { key: "Shift-Enter", run: insertTableCellLineBreak },
+                { key: "ArrowUp", run: (view) => tryEnterAdjacentTable(view, "up") },
+                { key: "ArrowDown", run: (view) => tryEnterAdjacentTable(view, "down") },
+                ...markdownKeymap,
+                ...defaultKeymap,
+                ...historyKeymap,
+            ]),
+            history(),
+            lineNumbers(),
+            ...gitDiffGutterBaselineExtensions(),
+            gitGutterCompartment.of(startMode === "live" ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()),
+            highlightActiveLineGutter(),
+            highlightActiveLine(),
+            EditorView.lineWrapping,
+            scrollPastEnd(),
+            EditorView.domEventHandlers({
+                pointerdown(event, view) {
+                    if (event.button !== 0) {
+                        frontmatterBoundaryClick = null;
+                        return false;
+                    }
+                    if (openLinkIfModifierClick(event, view)) {
+                        frontmatterBoundaryClick = null;
+                        return true;
+                    }
+
+                    const target = event.target;
+                    const targetElement = targetElementFrom(target);
+                    if (!(target instanceof Node) || !view.contentDOM.contains(target)) {
+                        return false;
+                    }
+
+                    trackFrontmatterBoundaryClick(event, view);
+
+                    if (targetElement && targetElement.closest(".meo-mermaid-zoom-controls")) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        return true;
+                    }
+
+                    if (targetElement && targetElement.closest(".meo-task-checkbox")) {
+                        checkboxClick = { pointerId: event.pointerId };
+                        return false;
+                    }
+
+                    // Let interactive HTML table widget controls handle focus/click natively.
+                    if (targetElement && targetElement.closest(".meo-md-html-table-wrap")) {
+                        inlineCodeClick = null;
+                        checkboxClick = null;
+                        return false;
+                    }
+
+                    inlineCodeClick = {
+                        pointerId: event.pointerId,
+                        inInlineCode: currentMode === "live" && targetElement && targetElement.closest(".meo-md-inline-code") !== null,
+                    };
+
+                    if (view.dom.setPointerCapture) {
+                        view.dom.setPointerCapture(event.pointerId);
+                        capturedPointerId = event.pointerId;
+                    }
+                    return false;
+                },
+                pointerup(event, view) {
+                    if (checkboxClick?.pointerId === event.pointerId) {
+                        frontmatterBoundaryClick = null;
+                        checkboxClick = null;
+                        return false;
+                    }
+
+                    if (capturedPointerId !== event.pointerId) {
+                        if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
+                            frontmatterBoundaryClick = null;
+                        }
+                        return false;
+                    }
+
+                    releasePointerCaptureIfHeld(event.pointerId);
+                    capturedPointerId = null;
+
+                    if (inlineCodeClick?.pointerId === event.pointerId && inlineCodeClick.inInlineCode && isLiveMode(view)) {
+                        const { head, empty } = view.state.selection.main;
+                        if (empty) {
+                            const clamped = inlineCodeCaretPosition(view.state, head);
+                            if (clamped !== null && clamped !== head) {
+                                view.dispatch({ selection: { anchor: clamped } });
+                            }
+                        }
+                    }
+
+                    if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
+                        if (isLiveMode(view)) {
+                            const selection = view.state.selection.main;
+                            if (selection.empty && selection.head !== frontmatterBoundaryClick.cursorEnd) {
+                                view.dispatch({ selection: { anchor: frontmatterBoundaryClick.cursorEnd } });
+                            }
+                        }
+                        frontmatterBoundaryClick = null;
+                    }
+
+                    if (isLiveMode(view)) {
+                        const { head, empty } = view.state.selection.main;
+                        if (empty) {
+                            const emptyQuoteCursorEnd = emptyBlockquoteLineCursorEnd(view.state, head);
+                            if (emptyQuoteCursorEnd !== null && head < emptyQuoteCursorEnd) {
+                                view.dispatch({ selection: { anchor: emptyQuoteCursorEnd } });
+                                return false;
+                            }
+
+                            const node = resolvedSyntaxTree(view.state).resolveInner(head, -1);
+                            if (node.name === "HorizontalRule") {
+                                const line = view.state.doc.lineAt(head);
+                                const lineText = view.state.doc.sliceString(line.from, line.to);
+                                const hrMatch = /^[ \t]*(-{3,}|\*{3,}|_{3,})/.exec(lineText);
+                                if (hrMatch) {
+                                    const cursorEnd = line.from + hrMatch[0].length;
+                                    if (head !== cursorEnd) {
+                                        view.dispatch({ selection: { anchor: cursorEnd } });
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    inlineCodeClick = null;
+                    return false;
+                },
+                pointercancel(event, _view) {
+                    if (capturedPointerId !== event.pointerId) {
+                        if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
+                            frontmatterBoundaryClick = null;
+                        }
+                        return false;
+                    }
+
+                    releasePointerCaptureIfHeld(event.pointerId);
+                    capturedPointerId = null;
+                    frontmatterBoundaryClick = null;
+                    inlineCodeClick = null;
+                    checkboxClick = null;
+                    return false;
+                },
+                pointermove(event, view) {
+                    updateSourceLinkHoverCursor(event, view);
+                    return false;
+                },
+                pointerleave(_event, view) {
+                    setSourceLinkHoverCursor(view, false);
+                    return false;
+                },
+            }),
+            ...headingCollapseSharedExtensions(),
+            modeCompartment.of(startMode === "live" ? liveModeExtensions() : sourceMode()),
+            searchQueryField,
+            searchMatchField,
+            EditorView.updateListener.of((update) => {
+                syncModeClasses();
+                syncLineNumbersVisibility();
+                syncGitGutterVisibility();
+
+                if (update.selectionSet) {
+                    syncSelectionClass();
+                    emitSelectionChange();
+                } else if (update.viewportChanged) {
+                    emitSelectionChange();
+                    onViewportChange?.();
+                }
+
+                if (!update.docChanged || applyingExternal || applyingRenumber) {
+                    return;
+                }
+
+                gitBlameHover?.hide();
+
+                pendingExternalUndoSelectionPreserve = false;
+
+                if (isHistoryReplayUpdate(update)) {
+                    onApplyChanges(update.state.doc.toString());
+                    return;
+                }
+
+                const renumberChanges = collectOrderedListRenumberChanges(update.state);
+                if (renumberChanges.length) {
+                    applyingRenumber = true;
+                    view.dispatch({
+                        changes: renumberChanges,
+                        annotations: Transaction.addToHistory.of(false),
+                    });
+                    applyingRenumber = false;
+                    onApplyChanges(view.state.doc.toString());
+                    return;
+                }
+
+                onApplyChanges(update.state.doc.toString());
+            }),
+        ],
+    });
+
+    const initialScrollTo = (() => {
+        if (typeof initialTopLine !== "number" || !Number.isFinite(initialTopLine)) {
+            return undefined;
+        }
+        const lineNumber = Math.min(Math.max(1, Math.floor(initialTopLine)), state.doc.lines);
+        const line = state.doc.line(lineNumber);
+        return EditorView.scrollIntoView(line.from, { y: "start" });
+    })();
+
+    view = new EditorView({
+        state,
+        parent,
+        scrollTo: initialScrollTo,
+    });
+    if (typeof initialTopLine === "number" && Number.isFinite(initialTopLine)) {
+        restoreTopVisibleLine(initialTopLine, initialTopLineOffset, { syncCursor: true });
     }
-  };
+    onTableInteraction = (event) => {
+        const active = Boolean(event?.detail?.active);
+        setTableInteractionActive(active);
+    };
+    view.dom.addEventListener("meo-table-interaction", onTableInteraction);
+    onTableOpenLink = (event) => {
+        const href = event?.detail?.href;
+        if (typeof href !== "string" || !href) {
+            return;
+        }
+        onOpenLink?.(href);
+    };
+    view.dom.addEventListener("meo-open-link", onTableOpenLink);
+    onTableSelectionChange = () => {
+        emitSelectionChange();
+    };
+    view.dom.addEventListener("meo-table-selection-change", onTableSelectionChange);
+    onScroll = () => {
+        emitSelectionChange();
+        gitBlameHover?.hide();
+        onViewportChange?.();
+    };
+    view.scrollDOM.addEventListener("scroll", onScroll, { passive: true });
+    if (typeof onRequestGitBlame === "function") {
+        gitBlameHover = createGitBlameHoverController({
+            view,
+            getMode: () => currentMode,
+            requestBlame: onRequestGitBlame,
+            openRevisionForLine: onOpenGitRevisionForLine,
+            openWorktreeForLine: onOpenGitWorktreeForLine,
+        });
+    }
+    gitDiffOverviewRuler = createGitDiffOverviewRulerController({
+        view,
+        getMode: () => currentMode,
+        isGitChangesVisible: () => gitGutterVisible,
+    });
+    syncModeClasses();
+    syncLineNumbersVisibility();
+    syncGitGutterVisibility();
+    syncSelectionClass();
+    emitSelectionChange();
+
+    return {
+        view,
+        state: view.state,
+        getText() {
+            return view.state.doc.toString();
+        },
+        selectAll() {
+            view.dispatch({
+                selection: {
+                    anchor: 0,
+                    head: view.state.doc.length,
+                },
+            });
+            return true;
+        },
+        undo() {
+            const shouldPreserveSelection = pendingExternalUndoSelectionPreserve;
+            const { anchor, head } = view.state.selection.main;
+            const applied = undo(view);
+            if (!applied) {
+                return false;
+            }
+            if (!shouldPreserveSelection) {
+                return true;
+            }
+
+            pendingExternalUndoSelectionPreserve = false;
+            const nextAnchor = Math.min(anchor, view.state.doc.length);
+            const nextHead = Math.min(head, view.state.doc.length);
+            const selection = view.state.selection.main;
+            if (selection.anchor === nextAnchor && selection.head === nextHead) {
+                return true;
+            }
+
+            view.dispatch({
+                selection: { anchor: nextAnchor, head: nextHead },
+                annotations: Transaction.addToHistory.of(false),
+            });
+            return true;
+        },
+        redo() {
+            return redo(view);
+        },
+        findNext(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
+            return findMatch(query, false, options);
+        },
+        findPrevious(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
+            return findMatch(query, true, options);
+        },
+        replaceCurrent(query, replacement, options: SearchOptions = {}) {
+            return replaceCurrentMatch(query, replacement, options);
+        },
+        replaceAll(query, replacement, options: SearchOptions = {}) {
+            if (!query) {
+                return { replaced: 0, total: 0 };
+            }
+
+            const text = view.state.doc.toString();
+            const matches = findSearchMatchRanges(text, query, options);
+            const replaced = matches.length;
+            if (!replaced) {
+                return { replaced: 0, total: 0 };
+            }
+
+            const nextText = replaceMatchRanges(text, matches, replacement);
+            view.dispatch({
+                changes: { from: 0, to: text.length, insert: nextText },
+                selection: { anchor: 0 },
+            });
+            return { replaced, total: countMatches(nextText, query, options) };
+        },
+        countMatches(query, options: SearchOptions = {}) {
+            if (!query) {
+                return 0;
+            }
+            return countMatches(view.state.doc.toString(), query, options);
+        },
+        setSearchQuery(query, options: SearchOptions = {}) {
+            const nextQuery = createSearchQueryState(query, options);
+            const currentQuery = view.state.field(searchQueryField);
+            if (currentQuery.text === nextQuery.text && currentQuery.wholeWord === nextQuery.wholeWord && currentQuery.caseSensitive === nextQuery.caseSensitive) {
+                return;
+            }
+            view.dispatch({
+                effects: setSearchQueryEffect.of(nextQuery),
+            });
+        },
+        hasFocus() {
+            return view.hasFocus;
+        },
+        focus() {
+            const activeTableInput = getActiveTableInput();
+            if (activeTableInput) {
+                activeTableInput.focus({ preventScroll: true });
+                return;
+            }
+            view.focus();
+        },
+        destroy() {
+            gitBlameHover?.destroy();
+            gitBlameHover = null;
+            gitDiffOverviewRuler?.destroy();
+            gitDiffOverviewRuler = null;
+            if (onScroll) {
+                view.scrollDOM.removeEventListener("scroll", onScroll);
+                onScroll = null;
+            }
+            if (onTableInteraction) {
+                view.dom.removeEventListener("meo-table-interaction", onTableInteraction);
+                onTableInteraction = null;
+            }
+            if (onTableOpenLink) {
+                view.dom.removeEventListener("meo-open-link", onTableOpenLink);
+                onTableOpenLink = null;
+            }
+            if (onTableSelectionChange) {
+                view.dom.removeEventListener("meo-table-selection-change", onTableSelectionChange);
+                onTableSelectionChange = null;
+            }
+            if (capturedPointerId !== null) {
+                releasePointerCaptureIfHeld(capturedPointerId);
+                capturedPointerId = null;
+            }
+            setSourceLinkHoverCursor(view, false);
+            view.destroy();
+        },
+        setText(textValue) {
+            gitBlameHover?.hide();
+            const currentText = view.state.doc.toString();
+            const syncChange = findSyncChange(currentText, textValue);
+            if (!syncChange) {
+                return;
+            }
+
+            const { anchor, head } = view.state.selection.main;
+            const newLength = textValue.length;
+            const mappedAnchor = Math.min(mapPositionThroughChange(anchor, syncChange), newLength);
+            const mappedHead = Math.min(mapPositionThroughChange(head, syncChange), newLength);
+            applyingExternal = true;
+            view.dispatch({
+                changes: syncChange,
+                selection: { anchor: mappedAnchor, head: mappedHead },
+            });
+            applyingExternal = false;
+            pendingExternalUndoSelectionPreserve = true;
+            syncSelectionClass();
+            emitSelectionChange();
+        },
+        setMode(mode) {
+            gitBlameHover?.hide();
+            const nextMode = mode === "live" ? "live" : "source";
+            if (nextMode === currentMode) {
+                return;
+            }
+
+            const topPosition = computeTopVisiblePosition();
+
+            const previousMode = currentMode;
+            currentMode = nextMode;
+            try {
+                view.dispatch({
+                    effects: [modeCompartment.reconfigure(nextMode === "live" ? liveModeExtensions() : sourceMode()), gitGutterCompartment.reconfigure(nextMode === "live" ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()), vimCompartment.reconfigure(vimExtensionsForState())],
+                });
+                forceParsing(view, view.state.doc.length, 500);
+            } catch (error) {
+                currentMode = previousMode;
+                syncModeClasses();
+                throw error;
+            }
+            syncModeClasses();
+            syncGitGutterVisibility();
+
+            restoreTopVisibleLine(topPosition.lineNumber, topPosition.lineOffset, { syncCursor: false });
+        },
+        setLineNumbers(visible) {
+            const nextVisible = visible !== false;
+            if (nextVisible === lineNumbersVisible) {
+                return;
+            }
+            lineNumbersVisible = nextVisible;
+            syncLineNumbersVisibility();
+        },
+        setGitGutterVisible(visible) {
+            const nextVisible = visible !== false;
+            if (nextVisible === gitGutterVisible) {
+                return;
+            }
+            gitGutterVisible = nextVisible;
+            syncGitGutterVisibility();
+        },
+        setVimMode(enabled) {
+            const nextEnabled = enabled === true;
+            if (nextEnabled === vimModeEnabled) {
+                return;
+            }
+            vimModeEnabled = nextEnabled;
+            view.dispatch({
+                effects: vimCompartment.reconfigure(vimExtensionsForState()),
+            });
+        },
+        setVimKeybindings(bindings: Array<{ before: string; after: string; mode: string; recursive: boolean }>, leaderKey: string) {
+            applyVimKeybindings(bindings, leaderKey);
+        },
+        insertFormat(action, level) {
+            const activeTableInput = getActiveTableInput();
+            if (activeTableInput) {
+                return insertFormatInActiveTableInput(activeTableInput, action);
+            }
+
+            const { state } = view;
+            const selection = state.selection.main;
+            let cachedInlineSelection: InlineSelectionRange | null = null;
+            const inlineSelection = (): InlineSelectionRange => {
+                if (cachedInlineSelection) {
+                    return cachedInlineSelection;
+                }
+                cachedInlineSelection = currentMode === "live" ? normalizeLiveInlineSelectionForListContent(state, selection) : selection;
+                return cachedInlineSelection;
+            };
+
+            let insert = "";
+            switch (action) {
+                case "heading":
+                    insert = `${"#".repeat(level ?? 1)} `;
+                    break;
+                case "bulletList":
+                    insert = "- ";
+                    break;
+                case "numberedList":
+                    insert = "1. ";
+                    break;
+                case "task":
+                    insert = "- [ ] ";
+                    break;
+                case "codeBlock":
+                    return insertCodeBlock(view, selection);
+                case "inlineCode":
+                    return insertInlineCode(view, inlineSelection());
+                case "kbd":
+                    return insertKbd(view, inlineSelection());
+                case "bold":
+                    return insertInlineFence(view, inlineSelection(), "**");
+                case "italic":
+                    return insertInlineFence(view, inlineSelection(), "*");
+                case "lineover":
+                case "strike":
+                    return insertInlineFence(view, inlineSelection(), "~~");
+                case "quote":
+                    return insertQuote(view, selection);
+                case "hr":
+                    return insertHr(view, selection);
+                case "table":
+                    return insertTable(view, selection, level?.cols, level?.rows);
+                case "link":
+                    return insertLink(view, inlineSelection());
+                case "wikiLink":
+                    return insertWikiLink(view, inlineSelection());
+                case "image":
+                    return insertImage(view, inlineSelection());
+            }
+
+            if (!selection.empty && (action === "bulletList" || action === "numberedList")) {
+                const changes = buildListFormatChangesForSelection(state, insert);
+                dispatchSelectedListFormatChanges(state, changes, action === "numberedList");
+                return;
+            }
+
+            const line = state.doc.lineAt(selection.from);
+            const { contentStart, oldMarkerLen, isExistingTask } = lineMarkerReplacementContext(state, line);
+            if (action === "task" && isExistingTask) {
+                return;
+            }
+
+            const newMarkerLen = insert.length;
+            const cursorOffset = selection.from - (contentStart + oldMarkerLen);
+            const newCursorPos = contentStart + newMarkerLen + Math.max(0, cursorOffset);
+
+            view.dispatch({
+                changes: { from: contentStart, to: contentStart + oldMarkerLen, insert },
+                selection: { anchor: newCursorPos },
+            });
+        },
+        getHeadings() {
+            return extractHeadings(view.state);
+        },
+        moveHeadingSection(sourceHeadingFrom, targetHeadingFrom, placement) {
+            if (placement !== "before" && placement !== "after") {
+                return false;
+            }
+
+            const sections = extractHeadingSections(view.state);
+            const source = sections.find((heading) => heading.from === sourceHeadingFrom);
+            const target = sections.find((heading) => heading.from === targetHeadingFrom);
+            if (!source || !target) {
+                return false;
+            }
+
+            const insertionPoint = placement === "before" ? target.sectionFrom : target.sectionTo;
+            if (insertionPoint > source.sectionFrom && insertionPoint < source.sectionTo) {
+                return false;
+            }
+
+            const currentText = view.state.doc.toString();
+            const movedText = currentText.slice(source.sectionFrom, source.sectionTo);
+            if (!movedText) {
+                return false;
+            }
+
+            const textWithoutSource = currentText.slice(0, source.sectionFrom) + currentText.slice(source.sectionTo);
+            const sourceLength = source.sectionTo - source.sectionFrom;
+            const adjustedInsertionPoint = insertionPoint >= source.sectionTo ? insertionPoint - sourceLength : insertionPoint;
+            const nextText = textWithoutSource.slice(0, adjustedInsertionPoint) + movedText + textWithoutSource.slice(adjustedInsertionPoint);
+
+            if (nextText === currentText) {
+                return false;
+            }
+
+            const nextAnchor = Math.min(adjustedInsertionPoint, nextText.length);
+            view.dispatch({
+                changes: { from: 0, to: currentText.length, insert: nextText },
+                selection: { anchor: nextAnchor },
+                effects: EditorView.scrollIntoView(nextAnchor, { y: "start" }),
+            });
+            return true;
+        },
+        scrollToLine(lineNumber, align = "center") {
+            const line = view.state.doc.line(Math.min(lineNumber, view.state.doc.lines));
+            applyRevealSelection(line.from, line.from, { focusEditor: true, align });
+        },
+        restoreTopLine(lineNumber, lineOffset) {
+            restoreTopVisibleLine(lineNumber, lineOffset, { syncCursor: true });
+        },
+        getTopVisiblePosition() {
+            const position = computeTopVisiblePosition();
+            return {
+                line: position.lineNumber,
+                lineOffset: position.lineOffset,
+            };
+        },
+        getTopVisibleLine() {
+            return computeTopVisiblePosition().lineNumber;
+        },
+        revealSelection(anchor, head, options) {
+            applyRevealSelection(anchor, head, options);
+        },
+        refreshSelectionOverlay() {
+            emitSelectionChange();
+        },
+        refreshDecorations() {
+            view.dispatch({ effects: refreshDecorationsEffect.of(null) });
+        },
+        refreshLayout() {
+            view.requestMeasure();
+            if (currentMode === "live") {
+                forceParsing(view, view.state.doc.length, 500);
+            }
+            emitSelectionChange();
+        },
+        setGitBaseline(snapshot) {
+            applyGitBaseline(view, snapshot);
+            gitBlameHover?.hide();
+            gitDiffOverviewRuler?.refresh();
+        },
+        clearGitUiTransientState() {
+            gitBlameHover?.hide();
+        },
+    };
 }
 
 function insertTableCellLineBreak(view) {
-  const { state } = view;
-  const selection = state.selection.main;
-  if (!isInsideTableCell(state, selection.from) || !isInsideTableCell(state, selection.to)) {
-    return false;
-  }
+    const { state } = view;
+    const selection = state.selection.main;
+    if (!isInsideTableCell(state, selection.from) || !isInsideTableCell(state, selection.to)) {
+        return false;
+    }
 
-  const insert = '<br>';
-  view.dispatch({
-    changes: { from: selection.from, to: selection.to, insert },
-    selection: { anchor: selection.from + insert.length }
-  });
-  return true;
+    const insert = "<br>";
+    view.dispatch({
+        changes: { from: selection.from, to: selection.to, insert },
+        selection: { anchor: selection.from + insert.length },
+    });
+    return true;
 }
 
 function handleEnterContinueQuotedCodeBlock(view) {
-  const { state } = view;
-  const selection = state.selection.main;
-  if (!selection.empty) {
-    return false;
-  }
+    const { state } = view;
+    const selection = state.selection.main;
+    if (!selection.empty) {
+        return false;
+    }
 
-  const quotePrefix = getQuotedCodeBlockLinePrefix(state, selection.from);
-  if (!quotePrefix) {
-    return false;
-  }
+    const quotePrefix = getQuotedCodeBlockLinePrefix(state, selection.from);
+    if (!quotePrefix) {
+        return false;
+    }
 
-  const insert = `\n${quotePrefix}`;
-  const nextPos = selection.from + insert.length;
-  view.dispatch({
-    changes: { from: selection.from, to: selection.from, insert },
-    selection: { anchor: nextPos }
-  });
-  return true;
+    const insert = `\n${quotePrefix}`;
+    const nextPos = selection.from + insert.length;
+    view.dispatch({
+        changes: { from: selection.from, to: selection.from, insert },
+        selection: { anchor: nextPos },
+    });
+    return true;
 }
 
 function getQuotedCodeBlockLinePrefix(state, position) {
-  const line = state.doc.lineAt(position);
-  const lineText = state.doc.sliceString(line.from, line.to);
-  const match = blockquoteLinePrefixRegex.exec(lineText);
-  if (!match) {
-    return null;
-  }
+    const line = state.doc.lineAt(position);
+    const lineText = state.doc.sliceString(line.from, line.to);
+    const match = blockquoteLinePrefixRegex.exec(lineText);
+    if (!match) {
+        return null;
+    }
 
-  return isInsideQuotedCodeBlock(state, position) ? match[0] : null;
+    return isInsideQuotedCodeBlock(state, position) ? match[0] : null;
 }
 
 function isInsideQuotedCodeBlock(state, position) {
-  let node = syntaxTree(state).resolveInner(position, -1);
-  let insideCodeBlock = false;
-  let insideBlockquote = false;
+    let node = syntaxTree(state).resolveInner(position, -1);
+    let insideCodeBlock = false;
+    let insideBlockquote = false;
 
-  while (node) {
-    if (quotedCodeBlockAncestorNames.has(node.name)) {
-      insideCodeBlock = true;
-    } else if (node.name === 'Blockquote') {
-      insideBlockquote = true;
+    while (node) {
+        if (quotedCodeBlockAncestorNames.has(node.name)) {
+            insideCodeBlock = true;
+        } else if (node.name === "Blockquote") {
+            insideBlockquote = true;
+        }
+        if (insideCodeBlock && insideBlockquote) {
+            return true;
+        }
+        node = node.parent;
     }
-    if (insideCodeBlock && insideBlockquote) {
-      return true;
-    }
-    node = node.parent;
-  }
 
-  return false;
+    return false;
 }
 
 function deleteTableCellLineBreakBackward(view) {
-  const { state } = view;
-  const selection = state.selection.main;
-  if (!selection.empty) {
-    return false;
-  }
+    const { state } = view;
+    const selection = state.selection.main;
+    if (!selection.empty) {
+        return false;
+    }
 
-  const pos = selection.from;
-  if (!isInsideTableCell(state, pos)) {
-    return false;
-  }
+    const pos = selection.from;
+    if (!isInsideTableCell(state, pos)) {
+        return false;
+    }
 
-  const from = Math.max(0, pos - 8);
-  const before = state.doc.sliceString(from, pos);
-  const match = /<br\s*\/?>$/i.exec(before);
-  if (!match) {
-    return false;
-  }
+    const from = Math.max(0, pos - 8);
+    const before = state.doc.sliceString(from, pos);
+    const match = /<br\s*\/?>$/i.exec(before);
+    if (!match) {
+        return false;
+    }
 
-  const start = pos - match[0].length;
-  view.dispatch({
-    changes: { from: start, to: pos },
-    selection: { anchor: start }
-  });
-  return true;
+    const start = pos - match[0].length;
+    view.dispatch({
+        changes: { from: start, to: pos },
+        selection: { anchor: start },
+    });
+    return true;
 }
 
 function deleteBackwardSmart(view) {
-  return handleBackspaceAtListContentStart(view) || deleteTableCellLineBreakBackward(view);
+    return handleBackspaceAtListContentStart(view) || deleteTableCellLineBreakBackward(view);
 }
 
 function isInsideTableCell(state, position) {
-  let node = syntaxTree(state).resolveInner(position, -1);
-  while (node) {
-    if (node.name === 'TableCell') {
-      return true;
+    let node = syntaxTree(state).resolveInner(position, -1);
+    while (node) {
+        if (node.name === "TableCell") {
+            return true;
+        }
+        if (node.name === "TableDelimiter" || node.name === "Table") {
+            return false;
+        }
+        node = node.parent;
     }
-    if (node.name === 'TableDelimiter' || node.name === 'Table') {
-      return false;
-    }
-    node = node.parent;
-  }
-  return false;
+    return false;
 }
 
 function findSyncChange(previousText, nextText) {
-  if (previousText === nextText) {
-    return null;
-  }
+    if (previousText === nextText) {
+        return null;
+    }
 
-  let from = 0;
-  const maxStart = Math.min(previousText.length, nextText.length);
-  while (from < maxStart && previousText.charCodeAt(from) === nextText.charCodeAt(from)) {
-    from += 1;
-  }
+    let from = 0;
+    const maxStart = Math.min(previousText.length, nextText.length);
+    while (from < maxStart && previousText.charCodeAt(from) === nextText.charCodeAt(from)) {
+        from += 1;
+    }
 
-  let previousTo = previousText.length;
-  let nextTo = nextText.length;
-  while (
-    previousTo > from &&
-    nextTo > from &&
-    previousText.charCodeAt(previousTo - 1) === nextText.charCodeAt(nextTo - 1)
-  ) {
-    previousTo -= 1;
-    nextTo -= 1;
-  }
+    let previousTo = previousText.length;
+    let nextTo = nextText.length;
+    while (previousTo > from && nextTo > from && previousText.charCodeAt(previousTo - 1) === nextText.charCodeAt(nextTo - 1)) {
+        previousTo -= 1;
+        nextTo -= 1;
+    }
 
-  return {
-    from,
-    to: previousTo,
-    insert: nextText.slice(from, nextTo)
-  };
+    return {
+        from,
+        to: previousTo,
+        insert: nextText.slice(from, nextTo),
+    };
 }
 
 // Map a position through a single replace change so external syncs keep the cursor nearby.
 function mapPositionThroughChange(position, change) {
-  const insertLength = change.insert.length;
-  const deletedLength = change.to - change.from;
-  const delta = insertLength - deletedLength;
+    const insertLength = change.insert.length;
+    const deletedLength = change.to - change.from;
+    const delta = insertLength - deletedLength;
 
-  if (position <= change.from) {
-    return position;
-  }
+    if (position <= change.from) {
+        return position;
+    }
 
-  if (position >= change.to) {
-    return position + delta;
-  }
+    if (position >= change.to) {
+        return position + delta;
+    }
 
-  return change.from + insertLength;
+    return change.from + insertLength;
 }
 
 function createSearchQueryState(query: string | null | undefined, options: SearchOptions = {}): SearchQueryState {
-  return {
-    text: query ?? '',
-    wholeWord: options.wholeWord === true,
-    caseSensitive: options.caseSensitive === true
-  };
+    return {
+        text: query ?? "",
+        wholeWord: options.wholeWord === true,
+        caseSensitive: options.caseSensitive === true,
+    };
 }
 
 function isWordBoundaryCharacter(value: string): boolean {
-  return /[0-9A-Za-z_]/.test(value);
+    return /[0-9A-Za-z_]/.test(value);
 }
 
 function isWholeWordRange(text: string, start: number, end: number): boolean {
-  const previous = start > 0 ? text.slice(start - 1, start) : '';
-  const next = end < text.length ? text.slice(end, end + 1) : '';
-  return !isWordBoundaryCharacter(previous) && !isWordBoundaryCharacter(next);
+    const previous = start > 0 ? text.slice(start - 1, start) : "";
+    const next = end < text.length ? text.slice(end, end + 1) : "";
+    return !isWordBoundaryCharacter(previous) && !isWordBoundaryCharacter(next);
 }
 
 function findSearchMatchRanges(text: string, query: string, options: SearchOptions = {}): SearchMatchRange[] {
-  if (!query) {
-    return [];
-  }
-
-  const haystack = options.caseSensitive ? text : text.toLocaleLowerCase();
-  const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
-  const matches: SearchMatchRange[] = [];
-  let offset = 0;
-  while (offset <= text.length) {
-    const index = haystack.indexOf(needle, offset);
-    if (index < 0) {
-      break;
+    if (!query) {
+        return [];
     }
 
-    const end = index + query.length;
-    if (!options.wholeWord || isWholeWordRange(text, index, end)) {
-      matches.push({ start: index, end });
+    const haystack = options.caseSensitive ? text : text.toLocaleLowerCase();
+    const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
+    const matches: SearchMatchRange[] = [];
+    let offset = 0;
+    while (offset <= text.length) {
+        const index = haystack.indexOf(needle, offset);
+        if (index < 0) {
+            break;
+        }
+
+        const end = index + query.length;
+        if (!options.wholeWord || isWholeWordRange(text, index, end)) {
+            matches.push({ start: index, end });
+        }
+        offset = end;
     }
-    offset = end;
-  }
-  return matches;
+    return matches;
 }
 
 function countMatches(text, query, options: SearchOptions = {}) {
-  if (!query) {
-    return 0;
-  }
+    if (!query) {
+        return 0;
+    }
 
-  return findSearchMatchRanges(text, query, options).length;
+    return findSearchMatchRanges(text, query, options).length;
 }
 
 function findSelectedSearchMatchIndex(matches: SearchMatchRange[], from: number, to: number): number {
-  for (let index = 0; index < matches.length; index += 1) {
-    if (matches[index].start === from && matches[index].end === to) {
-      return index;
+    for (let index = 0; index < matches.length; index += 1) {
+        if (matches[index].start === from && matches[index].end === to) {
+            return index;
+        }
     }
-  }
-  return -1;
+    return -1;
 }
 
 function replaceMatchRanges(text: string, matches: SearchMatchRange[], replacement: string): string {
-  if (!matches.length) {
-    return text;
-  }
+    if (!matches.length) {
+        return text;
+    }
 
-  let nextText = '';
-  let offset = 0;
-  for (const match of matches) {
-    nextText += text.slice(offset, match.start);
-    nextText += replacement;
-    offset = match.end;
-  }
-  nextText += text.slice(offset);
-  return nextText;
+    let nextText = "";
+    let offset = 0;
+    for (const match of matches) {
+        nextText += text.slice(offset, match.start);
+        nextText += replacement;
+        offset = match.end;
+    }
+    nextText += text.slice(offset);
+    return nextText;
 }
 
-function normalizeLiveInlineSelectionForListContent(
-  state: EditorState,
-  selection: InlineSelectionRange
-): InlineSelectionRange {
-  if (selection.empty) {
-    return selection;
-  }
+function normalizeLiveInlineSelectionForListContent(state: EditorState, selection: InlineSelectionRange): InlineSelectionRange {
+    if (selection.empty) {
+        return selection;
+    }
 
-  let from = Math.min(selection.from, selection.to);
-  const to = Math.max(selection.from, selection.to);
-  if (to <= from) {
-    return selection;
-  }
+    let from = Math.min(selection.from, selection.to);
+    const to = Math.max(selection.from, selection.to);
+    if (to <= from) {
+        return selection;
+    }
 
-  const startLine = state.doc.lineAt(from);
-  const endLine = state.doc.lineAt(to - 1);
-  if (startLine.number !== endLine.number) {
-    return selection;
-  }
+    const startLine = state.doc.lineAt(from);
+    const endLine = state.doc.lineAt(to - 1);
+    if (startLine.number !== endLine.number) {
+        return selection;
+    }
 
-  const lineText = state.doc.sliceString(startLine.from, startLine.to);
-  const marker = listMarkerData(lineText);
-  if (!marker) {
-    return selection;
-  }
+    const lineText = state.doc.sliceString(startLine.from, startLine.to);
+    const marker = listMarkerData(lineText);
+    if (!marker) {
+        return selection;
+    }
 
-  const contentFrom = startLine.from + marker.toOffset;
-  if (from >= contentFrom || to <= contentFrom) {
-    return selection;
-  }
+    const contentFrom = startLine.from + marker.toOffset;
+    if (from >= contentFrom || to <= contentFrom) {
+        return selection;
+    }
 
-  from = contentFrom;
-  if (from >= to) {
-    return selection;
-  }
+    from = contentFrom;
+    if (from >= to) {
+        return selection;
+    }
 
-  if (selection.anchor <= selection.head) {
-    return { from, to, anchor: from, head: to, empty: false };
-  }
-  return { from, to, anchor: to, head: from, empty: false };
+    if (selection.anchor <= selection.head) {
+        return { from, to, anchor: from, head: to, empty: false };
+    }
+    return { from, to, anchor: to, head: from, empty: false };
 }
 
 function insertInlineCode(view, selection) {
-  const { state } = view;
+    const { state } = view;
 
-  if (!selection.empty) {
-    let from = Math.min(selection.from, selection.to);
-    let to = Math.max(selection.from, selection.to);
-    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
-      to -= 1;
+    if (!selection.empty) {
+        let from = Math.min(selection.from, selection.to);
+        let to = Math.max(selection.from, selection.to);
+        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
+            to -= 1;
+        }
+        const selectedText = state.doc.sliceString(from, to);
+        const insert = `\`${selectedText}\``;
+        view.dispatch({
+            changes: { from, to, insert },
+            selection: { anchor: from + insert.length },
+        });
+        return;
     }
-    const selectedText = state.doc.sliceString(from, to);
-    const insert = `\`${selectedText}\``;
-    view.dispatch({
-      changes: { from, to, insert },
-      selection: { anchor: from + insert.length }
-    });
-    return;
-  }
 
-  const insert = '``';
-  view.dispatch({
-    changes: { from: selection.from, insert },
-    selection: { anchor: selection.from + 1 }
-  });
+    const insert = "``";
+    view.dispatch({
+        changes: { from: selection.from, insert },
+        selection: { anchor: selection.from + 1 },
+    });
 }
 
 function toggleInlineWrapper(view, selection, openMarker, closeMarker = openMarker) {
-  const { state } = view;
+    const { state } = view;
 
-  if (selection.empty) {
-    const insert = `${openMarker}${closeMarker}`;
-    view.dispatch({
-      changes: { from: selection.from, insert },
-      selection: { anchor: selection.from + openMarker.length }
-    });
-    return;
-  }
-
-  const from = Math.min(selection.from, selection.to);
-  let to = Math.max(selection.from, selection.to);
-  while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
-    to -= 1;
-  }
-
-  const hasOpenMarker =
-    from >= openMarker.length && state.doc.sliceString(from - openMarker.length, from) === openMarker;
-  const hasCloseMarker = state.doc.sliceString(to, to + closeMarker.length) === closeMarker;
-
-  if (hasOpenMarker && hasCloseMarker) {
-    view.dispatch({
-      changes: [
-        { from: to, to: to + closeMarker.length, insert: '' },
-        { from: from - openMarker.length, to: from, insert: '' }
-      ],
-      selection: {
-        anchor: from - openMarker.length,
-        head: to - openMarker.length
-      }
-    });
-    return;
-  }
-
-  view.dispatch({
-    changes: [
-      { from: to, insert: closeMarker },
-      { from, insert: openMarker }
-    ],
-    selection: {
-      anchor: from + openMarker.length,
-      head: to + openMarker.length
+    if (selection.empty) {
+        const insert = `${openMarker}${closeMarker}`;
+        view.dispatch({
+            changes: { from: selection.from, insert },
+            selection: { anchor: selection.from + openMarker.length },
+        });
+        return;
     }
-  });
+
+    const from = Math.min(selection.from, selection.to);
+    let to = Math.max(selection.from, selection.to);
+    while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
+        to -= 1;
+    }
+
+    const hasOpenMarker = from >= openMarker.length && state.doc.sliceString(from - openMarker.length, from) === openMarker;
+    const hasCloseMarker = state.doc.sliceString(to, to + closeMarker.length) === closeMarker;
+
+    if (hasOpenMarker && hasCloseMarker) {
+        view.dispatch({
+            changes: [
+                { from: to, to: to + closeMarker.length, insert: "" },
+                { from: from - openMarker.length, to: from, insert: "" },
+            ],
+            selection: {
+                anchor: from - openMarker.length,
+                head: to - openMarker.length,
+            },
+        });
+        return;
+    }
+
+    view.dispatch({
+        changes: [
+            { from: to, insert: closeMarker },
+            { from, insert: openMarker },
+        ],
+        selection: {
+            anchor: from + openMarker.length,
+            head: to + openMarker.length,
+        },
+    });
 }
 
 function insertKbd(view, selection) {
-  return toggleInlineWrapper(view, selection, '<kbd>', '</kbd>');
+    return toggleInlineWrapper(view, selection, "<kbd>", "</kbd>");
 }
 
 function insertInlineFence(view, selection, marker) {
-  return toggleInlineWrapper(view, selection, marker);
+    return toggleInlineWrapper(view, selection, marker);
 }
 
 function insertQuote(view, selection) {
-  const { state } = view;
-  const line = state.doc.lineAt(selection.from);
-  const lineText = state.doc.sliceString(line.from, line.to);
+    const { state } = view;
+    const line = state.doc.lineAt(selection.from);
+    const lineText = state.doc.sliceString(line.from, line.to);
 
-  const existingQuote = /^(\s*)(>\s*)/.exec(lineText);
-  if (existingQuote) {
-    return;
-  }
+    const existingQuote = /^(\s*)(>\s*)/.exec(lineText);
+    if (existingQuote) {
+        return;
+    }
 
-  const leadingWhitespace = /^(\s*)/.exec(lineText)[1];
-  const insert = '> ';
-  const contentStart = line.from + leadingWhitespace.length;
-  const cursorOffset = selection.from - contentStart;
+    const leadingWhitespace = /^(\s*)/.exec(lineText)[1];
+    const insert = "> ";
+    const contentStart = line.from + leadingWhitespace.length;
+    const cursorOffset = selection.from - contentStart;
 
-  view.dispatch({
-    changes: { from: contentStart, insert },
-    selection: { anchor: contentStart + insert.length + cursorOffset }
-  });
+    view.dispatch({
+        changes: { from: contentStart, insert },
+        selection: { anchor: contentStart + insert.length + cursorOffset },
+    });
 }
 
 function insertHr(view, selection) {
-  const { state } = view;
-  const line = state.doc.lineAt(selection.from);
-  const lineText = state.doc.sliceString(line.from, line.to);
-  const trimmed = lineText.trim();
+    const { state } = view;
+    const line = state.doc.lineAt(selection.from);
+    const lineText = state.doc.sliceString(line.from, line.to);
+    const trimmed = lineText.trim();
 
-  if (!trimmed) {
-    const insert = '---';
-    const cursorPos = line.from + insert.length;
-    view.dispatch({
-      changes: { from: line.from, to: line.to, insert },
-      selection: { anchor: cursorPos }
-    });
-  } else {
-    const insert = '\n---';
-    const cursorPos = line.to + insert.length;
-    view.dispatch({
-      changes: { from: line.to, insert },
-      selection: { anchor: cursorPos }
-    });
-  }
+    if (!trimmed) {
+        const insert = "---";
+        const cursorPos = line.from + insert.length;
+        view.dispatch({
+            changes: { from: line.from, to: line.to, insert },
+            selection: { anchor: cursorPos },
+        });
+    } else {
+        const insert = "\n---";
+        const cursorPos = line.to + insert.length;
+        view.dispatch({
+            changes: { from: line.to, insert },
+            selection: { anchor: cursorPos },
+        });
+    }
 }
 
 function insertLink(view, selection) {
-  const { state } = view;
+    const { state } = view;
 
-  if (!selection.empty) {
-    let from = Math.min(selection.from, selection.to);
-    let to = Math.max(selection.from, selection.to);
-    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
-      to -= 1;
+    if (!selection.empty) {
+        let from = Math.min(selection.from, selection.to);
+        let to = Math.max(selection.from, selection.to);
+        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
+            to -= 1;
+        }
+        const selectedText = state.doc.sliceString(from, to);
+        const insert = `[${selectedText}]()`;
+        view.dispatch({
+            changes: { from, to, insert },
+            selection: { anchor: from + insert.length - 1 },
+        });
+        return;
     }
-    const selectedText = state.doc.sliceString(from, to);
-    const insert = `[${selectedText}]()`;
-    view.dispatch({
-      changes: { from, to, insert },
-      selection: { anchor: from + insert.length - 1 }
-    });
-    return;
-  }
 
-  const insert = '[]()';
-  view.dispatch({
-    changes: { from: selection.from, insert },
-    selection: { anchor: selection.from + 3 }
-  });
+    const insert = "[]()";
+    view.dispatch({
+        changes: { from: selection.from, insert },
+        selection: { anchor: selection.from + 3 },
+    });
 }
 
 function insertImage(view, selection) {
-  const { state } = view;
+    const { state } = view;
 
-  if (!selection.empty) {
-    let from = Math.min(selection.from, selection.to);
-    let to = Math.max(selection.from, selection.to);
-    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
-      to -= 1;
+    if (!selection.empty) {
+        let from = Math.min(selection.from, selection.to);
+        let to = Math.max(selection.from, selection.to);
+        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
+            to -= 1;
+        }
+        const selectedText = state.doc.sliceString(from, to);
+        const insert = `![${selectedText}]()`;
+        view.dispatch({
+            changes: { from, to, insert },
+            selection: { anchor: from + insert.length - 1 },
+        });
+        return;
     }
-    const selectedText = state.doc.sliceString(from, to);
-    const insert = `![${selectedText}]()`;
-    view.dispatch({
-      changes: { from, to, insert },
-      selection: { anchor: from + insert.length - 1 }
-    });
-    return;
-  }
 
-  const insert = '![]()';
-  view.dispatch({
-    changes: { from: selection.from, insert },
-    selection: { anchor: selection.from + 4 }
-  });
+    const insert = "![]()";
+    view.dispatch({
+        changes: { from: selection.from, insert },
+        selection: { anchor: selection.from + 4 },
+    });
 }
 
 function insertWikiLink(view, selection) {
-  const { state } = view;
+    const { state } = view;
 
-  if (!selection.empty) {
-    let from = Math.min(selection.from, selection.to);
-    let to = Math.max(selection.from, selection.to);
-    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
-      to -= 1;
+    if (!selection.empty) {
+        let from = Math.min(selection.from, selection.to);
+        let to = Math.max(selection.from, selection.to);
+        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
+            to -= 1;
+        }
+        const selectedText = state.doc.sliceString(from, to);
+        const insert = `[[${selectedText}]]`;
+        view.dispatch({
+            changes: { from, to, insert },
+            selection: { anchor: from + insert.length },
+        });
+        return;
     }
-    const selectedText = state.doc.sliceString(from, to);
-    const insert = `[[${selectedText}]]`;
-    view.dispatch({
-      changes: { from, to, insert },
-      selection: { anchor: from + insert.length }
-    });
-    return;
-  }
 
-  const insert = '[[]]';
-  view.dispatch({
-    changes: { from: selection.from, insert },
-    selection: { anchor: selection.from + 2 }
-  });
+    const insert = "[[]]";
+    view.dispatch({
+        changes: { from: selection.from, insert },
+        selection: { anchor: selection.from + 2 },
+    });
 }
 
 function sourceMode() {
-  return [
-    markdown({
-      base: markdownLanguage,
-      addKeymap: false,
-      codeLanguages: resolveCodeLanguage,
-      extensions: [{ remove: ['SetextHeading'] }]
-    }),
-    syntaxHighlighting(highlightStyle),
-    sourceCodeBlockField,
-    sourceListBorderField,
-    sourceListMarkerField,
-    sourceStrikeMarkerField,
-    sourceWikiMarkerField,
-    sourceFileLinkField,
-    sourceUrlBoundaryField,
-    sourceFootnoteMarkerField,
-    sourceTableHeaderLineField,
-    sourceFrontmatterField,
-    gitDiffLineHighlightsField,
-    ...headingCollapseSourceSpacerExtensions(),
-    ...mergeConflictSourceExtensions()
-  ];
+    return [
+        markdown({
+            base: markdownLanguage,
+            addKeymap: false,
+            codeLanguages: resolveCodeLanguage,
+            extensions: [{ remove: ["SetextHeading"] }],
+        }),
+        syntaxHighlighting(highlightStyle),
+        sourceCodeBlockField,
+        sourceListBorderField,
+        sourceListMarkerField,
+        sourceStrikeMarkerField,
+        sourceWikiMarkerField,
+        sourceFileLinkField,
+        sourceUrlBoundaryField,
+        sourceFootnoteMarkerField,
+        sourceTableHeaderLineField,
+        sourceFrontmatterField,
+        gitDiffLineHighlightsField,
+        ...headingCollapseSourceSpacerExtensions(),
+        ...mergeConflictSourceExtensions(),
+    ];
 }
 
-const blockedInlineSelectionAncestors = new Set([
-  'FencedCode',
-  'CodeBlock',
-  'CodeText',
-  'InlineCode',
-  'URL',
-  'Autolink',
-  'HTMLBlock',
-  'HTMLTag',
-  'TableDelimiter'
-]);
+const blockedInlineSelectionAncestors = new Set(["FencedCode", "CodeBlock", "CodeText", "InlineCode", "URL", "Autolink", "HTMLBlock", "HTMLTag", "TableDelimiter"]);
 
 const latexSelectionBlockCache = new WeakMap<object, Array<{ from: number; to: number }>>();
 
 function hasBlockedInlineAncestor(state, position) {
-  let node = syntaxTree(state).resolveInner(position, 1);
-  while (node) {
-    if (blockedInlineSelectionAncestors.has(node.name)) {
-      return true;
+    let node = syntaxTree(state).resolveInner(position, 1);
+    while (node) {
+        if (blockedInlineSelectionAncestors.has(node.name)) {
+            return true;
+        }
+        node = node.parent;
     }
-    node = node.parent;
-  }
-  return false;
+    return false;
 }
 
 function getLatexSelectionBlockRanges(state) {
-  const docKey = state.doc as unknown as object;
-  const cached = latexSelectionBlockCache.get(docKey);
-  if (cached) {
-    return cached;
-  }
+    const docKey = state.doc as unknown as object;
+    const cached = latexSelectionBlockCache.get(docKey);
+    if (cached) {
+        return cached;
+    }
 
-  const text = state.doc.toString();
-  if (text.indexOf('$') === -1) {
-    latexSelectionBlockCache.set(docKey, []);
-    return [];
-  }
+    const text = state.doc.toString();
+    if (text.indexOf("$") === -1) {
+        latexSelectionBlockCache.set(docKey, []);
+        return [];
+    }
 
-  const ranges = collectLatexMathRanges(text).map((range) => ({ from: range.from, to: range.to }));
-  latexSelectionBlockCache.set(docKey, ranges);
-  return ranges;
+    const ranges = collectLatexMathRanges(text).map((range) => ({ from: range.from, to: range.to }));
+    latexSelectionBlockCache.set(docKey, ranges);
+    return ranges;
 }
 
 function overlapsLatexMathSelection(state, from, to) {
-  if (to <= from) {
-    return false;
-  }
-  const ranges = getLatexSelectionBlockRanges(state);
-  for (const range of ranges) {
-    if (range.from < to && range.to > from) {
-      return true;
+    if (to <= from) {
+        return false;
     }
-  }
-  return false;
+    const ranges = getLatexSelectionBlockRanges(state);
+    for (const range of ranges) {
+        if (range.from < to && range.to > from) {
+            return true;
+        }
+    }
+    return false;
 }
 
 function isRegularInlineSelection(state, from, to) {
-  if (to <= from) {
-    return false;
-  }
-  const text = state.doc.sliceString(from, to);
-  const trimmedText = text.trim();
-  if (!trimmedText) {
-    return false;
-  }
-  if (trimmedText.includes('\n')) {
-    return false;
-  }
-  if (hasBlockedInlineAncestor(state, from) || hasBlockedInlineAncestor(state, to - 1)) {
-    return false;
-  }
-  if (overlapsLatexMathSelection(state, from, to)) {
-    return false;
-  }
-  return true;
+    if (to <= from) {
+        return false;
+    }
+    const text = state.doc.sliceString(from, to);
+    const trimmedText = text.trim();
+    if (!trimmedText) {
+        return false;
+    }
+    if (trimmedText.includes("\n")) {
+        return false;
+    }
+    if (hasBlockedInlineAncestor(state, from) || hasBlockedInlineAncestor(state, to - 1)) {
+        return false;
+    }
+    if (overlapsLatexMathSelection(state, from, to)) {
+        return false;
+    }
+    return true;
 }

--- a/webview/src/editor.ts
+++ b/webview/src/editor.ts
@@ -1,2233 +1,2389 @@
-import { EditorState, Compartment, Transaction, StateEffect, StateField, RangeSetBuilder, type ChangeSpec } from "@codemirror/state";
-import { EditorView, keymap, highlightActiveLine, lineNumbers, highlightActiveLineGutter, scrollPastEnd, Decoration, type ViewUpdate } from "@codemirror/view";
-import { defaultKeymap, history, historyKeymap, indentMore, indentLess, undo, redo } from "@codemirror/commands";
-import { markdown, markdownKeymap, markdownLanguage } from "@codemirror/lang-markdown";
-import { indentUnit, syntaxHighlighting, syntaxTree, forceParsing } from "@codemirror/language";
-import { vim, Vim } from "@replit/codemirror-vim";
-import { highlightStyle } from "./theme";
-import { liveModeExtensions } from "./liveMode";
-import { headingCollapseSharedExtensions, headingCollapseSourceSpacerExtensions } from "./helpers/headingCollapse";
-import { resolveCodeLanguage, insertCodeBlock, sourceCodeBlockField } from "./helpers/codeBlocks";
-import { sourceStrikeMarkerField } from "./helpers/strikeMarkers";
-import { sourceWikiMarkerField } from "./helpers/wikiLinks";
-import { sourceFileLinkField } from "./helpers/sourceRawLinks";
-import { sourceUrlBoundaryField } from "./helpers/sourceUrlBoundaries";
-import { sourceFootnoteMarkerField } from "./helpers/sourceFootnotes";
-import { getLinkHrefAtPointer, isPrimaryModifierPointerClick } from "./helpers/linkNavigation";
-import { gitDiffGutterBaselineExtensions, gitDiffGutterLiveRenderExtensions, gitDiffGutterRenderExtensions, setGitBaseline as applyGitBaseline } from "./helpers/gitDiffGutter";
-import { gitDiffLineHighlightsField } from "./helpers/gitDiffLineHighlights";
-import { createGitDiffOverviewRulerController } from "./helpers/gitDiffOverviewRuler";
-import { createGitBlameHoverController } from "./helpers/gitBlameHover";
-import { mergeConflictSourceExtensions } from "./helpers/mergeConflicts";
-import { resolvedSyntaxTree, extractHeadings, extractHeadingSections } from "./helpers/markdownSyntax";
-import { sourceListBorderField, sourceListMarkerField, listMarkerData, handleArrowLeftAtListContentStart, handleArrowRightAtListLineStart, handleBackspaceAtListContentStart, handleEnterAtListContentStart, handleEnterOnEmptyListItem, handleEnterContinueList, handleEnterBeforeNestedList, collectOrderedListRenumberChanges, indentListByTwoSpaces, outdentListByTwoSpaces } from "./helpers/listMarkers";
-import { insertTable, sourceTableHeaderLineField } from "./helpers/tables";
-import { parseFrontmatter, sourceFrontmatterField } from "./helpers/frontmatter";
-import { collectLatexMathRanges } from "./helpers/math";
+import { EditorState, Compartment, Transaction, StateEffect, StateField, RangeSetBuilder, type ChangeSpec } from '@codemirror/state';
+import { EditorView, keymap, highlightActiveLine, lineNumbers, highlightActiveLineGutter, scrollPastEnd, Decoration, type ViewUpdate } from '@codemirror/view';
+import { defaultKeymap, history, historyKeymap, indentMore, indentLess, undo, redo } from '@codemirror/commands';
+import { markdown, markdownKeymap, markdownLanguage } from '@codemirror/lang-markdown';
+import { indentUnit, syntaxHighlighting, syntaxTree, forceParsing } from '@codemirror/language';
+import { vim, Vim } from '@replit/codemirror-vim';
+import { highlightStyle } from './theme';
+import { liveModeExtensions } from './liveMode';
+import { headingCollapseSharedExtensions, headingCollapseSourceSpacerExtensions } from './helpers/headingCollapse';
+import { resolveCodeLanguage, insertCodeBlock, sourceCodeBlockField } from './helpers/codeBlocks';
+import { sourceStrikeMarkerField } from './helpers/strikeMarkers';
+import { sourceWikiMarkerField } from './helpers/wikiLinks';
+import { sourceFileLinkField } from './helpers/sourceRawLinks';
+import { sourceUrlBoundaryField } from './helpers/sourceUrlBoundaries';
+import { sourceFootnoteMarkerField } from './helpers/sourceFootnotes';
+import { getLinkHrefAtPointer, isPrimaryModifierPointerClick } from './helpers/linkNavigation';
+import {
+  gitDiffGutterBaselineExtensions,
+  gitDiffGutterLiveRenderExtensions,
+  gitDiffGutterRenderExtensions,
+  setGitBaseline as applyGitBaseline
+} from './helpers/gitDiffGutter';
+import { gitDiffLineHighlightsField } from './helpers/gitDiffLineHighlights';
+import { createGitDiffOverviewRulerController } from './helpers/gitDiffOverviewRuler';
+import { createGitBlameHoverController } from './helpers/gitBlameHover';
+import { mergeConflictSourceExtensions } from './helpers/mergeConflicts';
+import { resolvedSyntaxTree, extractHeadings, extractHeadingSections } from './helpers/markdownSyntax';
+import {
+  sourceListBorderField,
+  sourceListMarkerField,
+  listMarkerData,
+  handleArrowLeftAtListContentStart,
+  handleArrowRightAtListLineStart,
+  handleBackspaceAtListContentStart,
+  handleEnterAtListContentStart,
+  handleEnterOnEmptyListItem,
+  handleEnterContinueList,
+  handleEnterBeforeNestedList,
+  collectOrderedListRenumberChanges,
+  indentListByTwoSpaces,
+  outdentListByTwoSpaces
+} from './helpers/listMarkers';
+import { insertTable, sourceTableHeaderLineField } from './helpers/tables';
+import { parseFrontmatter, sourceFrontmatterField } from './helpers/frontmatter';
+import { collectLatexMathRanges } from './helpers/math';
 
-declare module "@codemirror/view" {
-    interface EditorView {
-        EDIT_CONTEXT?: boolean;
-    }
+declare module '@codemirror/view' {
+  interface EditorView {
+    EDIT_CONTEXT?: boolean;
+  }
 }
 
 type SearchOptions = {
-    wholeWord?: boolean;
-    caseSensitive?: boolean;
+  wholeWord?: boolean;
+  caseSensitive?: boolean;
 };
 
 type SearchQueryState = {
-    text: string;
-    wholeWord: boolean;
-    caseSensitive: boolean;
+  text: string;
+  wholeWord: boolean;
+  caseSensitive: boolean;
 };
 
 type SearchMatchRange = {
-    start: number;
-    end: number;
+  start: number;
+  end: number;
 };
 
 type InlineSelectionRange = {
-    from: number;
-    to: number;
-    anchor: number;
-    head: number;
-    empty: boolean;
+  from: number;
+  to: number;
+  anchor: number;
+  head: number;
+  empty: boolean;
 };
 
 type MarkerReplacementContext = {
-    contentStart: number;
-    oldMarkerLen: number;
-    isExistingTask: boolean;
+  contentStart: number;
+  oldMarkerLen: number;
+  isExistingTask: boolean;
 };
 
 const setSearchQueryEffect = StateEffect.define<SearchQueryState>();
 const refreshDecorationsEffect = StateEffect.define();
-const searchMatchMark = Decoration.mark({ class: "meo-search-match" });
+const searchMatchMark = Decoration.mark({ class: 'meo-search-match' });
 const existingListMarkerRegex = /^(\s*)([-+*]\s+\[[ xX~\-]\]|[-+*]|\d+[.)])\s+/;
 const existingHeadingMarkerRegex = /^(\s*)(#{1,6})\s+/;
 const existingTaskMarkerRegex = /^[-+*]\s+\[[ xX~\-]\]/;
 const blockquoteLinePrefixRegex = /^[ \t]{0,3}(?:>[ \t]?)+/;
-const quotedCodeBlockAncestorNames = new Set(["FencedCode", "CodeBlock"]);
+const quotedCodeBlockAncestorNames = new Set(['FencedCode', 'CodeBlock']);
 
 const buildSearchDecorations = (doc, searchQuery: SearchQueryState) => {
-    if (!searchQuery.text) {
-        return Decoration.none;
-    }
+  if (!searchQuery.text) {
+    return Decoration.none;
+  }
 
-    const builder = new RangeSetBuilder();
-    const textValue = doc.toString();
-    const matches = findSearchMatchRanges(textValue, searchQuery.text, searchQuery);
-    for (const match of matches) {
-        builder.add(match.start, match.end, searchMatchMark);
-    }
-    return builder.finish();
+  const builder = new RangeSetBuilder();
+  const textValue = doc.toString();
+  const matches = findSearchMatchRanges(textValue, searchQuery.text, searchQuery);
+  for (const match of matches) {
+    builder.add(match.start, match.end, searchMatchMark);
+  }
+  return builder.finish();
 };
 
 const searchQueryField = StateField.define({
-    create() {
-        return createSearchQueryState("");
-    },
-    update(value, tr) {
-        for (const effect of tr.effects) {
-            if (effect.is(setSearchQueryEffect)) {
-                return effect.value;
-            }
-        }
-        return value;
-    },
+  create() {
+    return createSearchQueryState('');
+  },
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setSearchQueryEffect)) {
+        return effect.value;
+      }
+    }
+    return value;
+  }
 });
 
 const searchMatchField = StateField.define<any>({
-    create() {
-        return Decoration.none;
-    },
-    update(value: any, tr: Transaction) {
-        if (tr.docChanged) {
-            const searchQuery = tr.state.field(searchQueryField);
-            return buildSearchDecorations(tr.state.doc, searchQuery);
-        }
+  create() {
+    return Decoration.none;
+  },
+  update(value: any, tr: Transaction) {
+    if (tr.docChanged) {
+      const searchQuery = tr.state.field(searchQueryField);
+      return buildSearchDecorations(tr.state.doc, searchQuery);
+    }
 
-        for (const effect of tr.effects) {
-            if (effect.is(setSearchQueryEffect)) {
-                return buildSearchDecorations(tr.state.doc, effect.value);
-            }
-        }
+    for (const effect of tr.effects) {
+      if (effect.is(setSearchQueryEffect)) {
+        return buildSearchDecorations(tr.state.doc, effect.value);
+      }
+    }
 
-        return value;
-    },
-    provide(field: any) {
-        return EditorView.decorations.from(field);
-    },
+    return value;
+  },
+  provide(field: any) {
+    return EditorView.decorations.from(field);
+  }
 });
 
-export function createEditor({ parent, text, onApplyChanges, onOpenLink, onSelectionChange, onViewportChange, onRequestGitBlame, onOpenGitRevisionForLine, onOpenGitWorktreeForLine, initialMode = "source", initialTopLine = null, initialTopLineOffset = 0, initialLineNumbers = true, initialGitGutter = true, initialVimMode = false, initialVimKeybindings = [], initialVimLeader = "\\" }) {
-    // VS Code webviews can hit cross-origin window access issues in the EditContext path.
-    // Disable it explicitly for stability in embedded Chromium.
-    (EditorView as any).EDIT_CONTEXT = false;
+export function createEditor({
+  parent,
+  text,
+  onApplyChanges,
+  onOpenLink,
+  onSelectionChange,
+  onViewportChange,
+  onRequestGitBlame,
+  onOpenGitRevisionForLine,
+  onOpenGitWorktreeForLine,
+  initialMode = 'source',
+  initialTopLine = null,
+  initialTopLineOffset = 0,
+  initialLineNumbers = true,
+  initialGitGutter = true,
+  initialVimMode = false,
+  initialVimKeybindings = [],
+  initialVimLeader = '\\'
+}) {
+  // VS Code webviews can hit cross-origin window access issues in the EditContext path.
+  // Disable it explicitly for stability in embedded Chromium.
+  (EditorView as any).EDIT_CONTEXT = false;
 
-    const modeCompartment = new Compartment();
-    const gitGutterCompartment = new Compartment();
-    const vimCompartment = new Compartment();
-    const startMode = initialMode === "live" ? "live" : "source";
-    let lineNumbersVisible = initialLineNumbers !== false;
-    let gitGutterVisible = initialGitGutter !== false;
-    let vimModeEnabled = initialVimMode === true;
-    let appliedVimKeybindings: Array<{ before: string; mode: string }> = [];
+  const modeCompartment = new Compartment();
+  const gitGutterCompartment = new Compartment();
+  const vimCompartment = new Compartment();
+  const startMode = initialMode === 'live' ? 'live' : 'source';
+  let lineNumbersVisible = initialLineNumbers !== false;
+  let gitGutterVisible = initialGitGutter !== false;
+  let vimModeEnabled = initialVimMode === true;
+  let vimKeybindings = initialVimKeybindings;
+  let vimLeader = initialVimLeader;
+  let appliedVimKeybindings: Array<{ before: string; mode: string }> = [];
 
-    const applyVimKeybindings = (bindings: Array<{ before: string; after: string; mode: string; recursive: boolean }>, leaderKey: string) => {
-        for (const { before, mode } of appliedVimKeybindings) {
-            try {
-                Vim.unmap(before, mode);
-            } catch {
-                /* ignore unmapping errors */
-            }
-        }
-        appliedVimKeybindings = [];
-        try {
-            Vim.setOption("leader", leaderKey);
-        } catch {
-            /* ignore */
-        }
-        for (const { before, after, mode, recursive } of bindings) {
-            try {
-                if (recursive) {
-                    Vim.map(before, after, mode);
-                } else {
-                    Vim.noremap(before, after, mode);
-                }
-                appliedVimKeybindings.push({ before, mode });
-            } catch {
-                /* ignore individual mapping errors */
-            }
-        }
-    };
-
-    if (initialVimMode === true) {
-        applyVimKeybindings(initialVimKeybindings, initialVimLeader);
+  const expandVimLeader = (keys: string, leaderKey: string) => keys.replace(/<leader>/gi, leaderKey || '\\');
+  const clearVimKeybindings = () => {
+    for (const { before, mode } of appliedVimKeybindings) {
+      try {
+        Vim.unmap(before, mode);
+      } catch {
+        // Ignore stale or unsupported mappings.
+      }
     }
-    let applyingExternal = false;
-    let capturedPointerId = null;
-    let inlineCodeClick = null;
-    let checkboxClick = null;
-    let frontmatterBoundaryClick = null;
-    let view = null;
-    let currentMode = startMode;
-    let applyingRenumber = false;
-    // External syncs may carry stale selections in their history entries.
-    // Preserve the user's current cursor once on the next undo of such a change.
-    let pendingExternalUndoSelectionPreserve = false;
-    let tableInteractionActive = false;
-    let onTableInteraction = null;
-    let onTableOpenLink = null;
-    let onTableSelectionChange = null;
-    let onScroll = null;
-    let gitBlameHover = null;
-    let gitDiffOverviewRuler = null;
-    let sourceLinkHoverPointerActive = false;
-    const normalizeTopLineOffset = (value) => {
-        if (!Number.isFinite(value)) {
-            return 0;
-        }
-        return Math.max(0, Number(value));
-    };
-    const vimExtensionsForState = () => (vimModeEnabled ? vim() : []);
-    const getLineStartOffset = (docText, targetLineNumber) => {
-        const targetLine = Math.max(1, Math.floor(targetLineNumber));
-        if (targetLine === 1) {
-            return 0;
-        }
-        let line = 1;
-        for (let index = 0; index < docText.length; index += 1) {
-            if (docText.charCodeAt(index) !== 10) {
-                continue;
-            }
-            line += 1;
-            if (line === targetLine) {
-                return index + 1;
-            }
-        }
-        return docText.length;
-    };
-    const initialCursorPos = (() => {
-        if (typeof initialTopLine === "number" && Number.isFinite(initialTopLine)) {
-            return getLineStartOffset(text ?? "", initialTopLine);
-        }
-        if (!text) {
-            return 0;
-        }
-        const firstLineEnd = text.indexOf("\n");
-        return firstLineEnd === -1 ? text.length : firstLineEnd;
-    })();
-    const targetElementFrom = (target) => (target instanceof Element ? target : target instanceof Node ? target.parentElement : null);
-    const openLinkIfModifierClick = (event, editorView) => {
-        if (!isPrimaryModifierPointerClick(event)) {
-            return false;
-        }
-        const href = getLinkHrefAtPointer(event, editorView);
-        if (!href) {
-            return false;
-        }
-        event.preventDefault();
-        event.stopPropagation();
-        onOpenLink?.(href);
-        return true;
-    };
-    const setSourceLinkHoverCursor = (editorView, active) => {
-        if (sourceLinkHoverPointerActive === active) {
-            return;
-        }
-        sourceLinkHoverPointerActive = active;
-        const cursor = active ? "pointer" : "";
-        editorView.dom.style.cursor = cursor;
-        editorView.contentDOM.style.cursor = cursor;
-    };
-    const updateSourceLinkHoverCursor = (event, editorView) => {
-        if (currentMode !== "source") {
-            setSourceLinkHoverCursor(editorView, false);
-            return;
-        }
-        const target = event.target;
-        if (!(target instanceof Node) || !editorView.contentDOM.contains(target)) {
-            setSourceLinkHoverCursor(editorView, false);
-            return;
-        }
-        const href = getLinkHrefAtPointer(event, editorView, { exactTextHit: true });
-        setSourceLinkHoverCursor(editorView, Boolean(href));
-    };
-    const isLiveMode = (editorView) => editorView.dom.classList.contains("meo-mode-live");
-    const isPlainPrimaryPointerEvent = (event) => event.button === 0 && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey;
-    const frontmatterBoundaryCursorEnd = (state, pos) => {
-        const frontmatter = parseFrontmatter(state);
-        if (!frontmatter) {
-            return null;
-        }
-        const line = state.doc.lineAt(pos);
-        const openingLineNo = state.doc.lineAt(frontmatter.openingFrom).number;
-        const closingLineNo = state.doc.lineAt(frontmatter.closingFrom).number;
-        if (line.number !== openingLineNo && line.number !== closingLineNo) {
-            return null;
-        }
-        const lineText = state.doc.sliceString(line.from, line.to);
-        const markerStart = lineText.indexOf("---");
-        return markerStart >= 0 ? line.from + markerStart + 3 : null;
-    };
-    const emptyBlockquoteLineCursorEnd = (state, pos) => {
-        const line = state.doc.lineAt(pos);
-        const lineText = state.doc.sliceString(line.from, line.to);
-        const quoteMatch = /^[ \t]{0,3}(?:>[ \t]?)+$/.exec(lineText);
-        if (!quoteMatch) {
-            return null;
-        }
-
-        const probePos = Math.min(line.to, line.from + 1);
-        let node = resolvedSyntaxTree(state).resolveInner(probePos, 1);
-        while (node) {
-            if (node.name === "Blockquote") {
-                return line.from + quoteMatch[0].length;
-            }
-            node = node.parent;
-        }
-
-        return null;
-    };
-    const trackFrontmatterBoundaryClick = (event, editorView) => {
-        frontmatterBoundaryClick = null;
-        if (!isLiveMode(editorView) || !isPlainPrimaryPointerEvent(event)) {
-            return;
-        }
-        const clickedPos = editorView.posAtCoords({ x: event.clientX, y: event.clientY });
-        if (clickedPos === null) {
-            return;
-        }
-        const cursorEnd = frontmatterBoundaryCursorEnd(editorView.state, clickedPos);
-        if (cursorEnd === null) {
-            return;
-        }
-        frontmatterBoundaryClick = {
-            pointerId: event.pointerId,
-            cursorEnd,
-        };
-    };
-
-    const setTableInteractionActive = (active) => {
-        if (!view || tableInteractionActive === active) {
-            return;
-        }
-        tableInteractionActive = active;
-        view.dom.classList.toggle("meo-table-interaction-active", active);
-    };
-    const tableEntryCellSelector = "th[data-table-row][data-table-col], td[data-table-row][data-table-col]";
-    const tableEntryProbeOffsetsY = [1, 4, 8, 12, 18];
-    const focusTableEntryInput = (input) => {
-        if (!(input instanceof HTMLTextAreaElement)) {
-            return false;
-        }
-        input.focus({ preventScroll: true });
-        const caret = input.value.length;
-        input.setSelectionRange(caret, caret);
-        input.closest(tableEntryCellSelector)?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
-        return true;
-    };
-    const findTableEntryInput = (wrap, hit, direction) => {
-        const cell = hit.closest(tableEntryCellSelector);
-        if (cell instanceof HTMLElement && wrap.contains(cell)) {
-            const cellInput = cell.querySelector("textarea");
-            if (cellInput instanceof HTMLTextAreaElement) {
-                return cellInput;
-            }
-        }
-
-        if (direction === "down") {
-            const first = wrap.querySelector("textarea");
-            return first instanceof HTMLTextAreaElement ? first : null;
-        }
-
-        const inputs = wrap.querySelectorAll("textarea");
-        const last = inputs.length ? inputs[inputs.length - 1] : null;
-        return last instanceof HTMLTextAreaElement ? last : null;
-    };
-
-    const tryEnterAdjacentTable = (editorView, direction) => {
-        if ((direction !== "down" && direction !== "up") || currentMode !== "live" || tableInteractionActive) {
-            return false;
-        }
-
-        const selection = editorView.state.selection.main;
-        if (!selection.empty) {
-            return false;
-        }
-
-        const caretRect = editorView.coordsAtPos(selection.head);
-        if (!caretRect) {
-            return false;
-        }
-
-        const contentRect = editorView.contentDOM.getBoundingClientRect();
-        if (!contentRect || contentRect.width <= 0 || contentRect.height <= 0) {
-            return false;
-        }
-
-        const clampX = (x) => Math.min(Math.max(x, contentRect.left + 1), contentRect.right - 1);
-        const probeXs = [clampX(caretRect.left + 1), clampX(contentRect.left + Math.min(24, Math.max(8, contentRect.width * 0.05)))];
-
-        for (const offsetY of tableEntryProbeOffsetsY) {
-            const y = direction === "down" ? caretRect.bottom + offsetY : caretRect.top - offsetY;
-            if (y < 0 || y >= window.innerHeight) {
-                if (direction === "down" && y >= window.innerHeight) break;
-                continue;
-            }
-            for (const x of probeXs) {
-                const hit = document.elementFromPoint(x, y);
-                if (!(hit instanceof Element)) {
-                    continue;
-                }
-                const wrap = hit.closest(".meo-md-html-table-wrap");
-                if (!(wrap instanceof HTMLElement) || !editorView.dom.contains(wrap)) {
-                    continue;
-                }
-                const input = findTableEntryInput(wrap, hit, direction);
-                if (!focusTableEntryInput(input)) {
-                    continue;
-                }
-                return true;
-            }
-        }
-
-        return false;
-    };
-
-    const syncModeClasses = () => {
-        if (!view) {
-            return;
-        }
-        const isLiveModeActive = currentMode === "live";
-        view.dom.classList.toggle("meo-mode-live", currentMode === "live");
-        view.dom.classList.toggle("meo-mode-source", currentMode !== "live");
-        // Keep active typography vars explicitly synced to mode so source/live
-        // font sizing and line-height don't depend on selector cascade.
-        view.dom.style.setProperty("--meo-active-editor-font", isLiveModeActive ? "var(--meo-font-live)" : "var(--meo-font-source)");
-        view.dom.style.setProperty("--meo-active-editor-font-weight", isLiveModeActive ? "var(--meo-font-live-weight)" : "var(--meo-font-source-weight)");
-        view.dom.style.setProperty("--meo-active-editor-font-size", isLiveModeActive ? "var(--meo-font-live-size)" : "var(--meo-font-source-size)");
-        view.dom.style.setProperty("--meo-active-editor-line-height", isLiveModeActive ? "var(--meo-line-height-live)" : "var(--meo-line-height-source)");
-        if (currentMode !== "source") {
-            setSourceLinkHoverCursor(view, false);
-        }
-    };
-
-    const syncLineNumbersVisibility = () => {
-        if (!view) {
-            return;
-        }
-        view.dom.classList.toggle("meo-line-numbers-hidden", !lineNumbersVisible);
-    };
-
-    const syncGitGutterVisibility = () => {
-        if (!view) {
-            return;
-        }
-        const shouldShowGitGutter = gitGutterVisible;
-        view.dom.classList.toggle("meo-git-gutter-hidden", !shouldShowGitGutter);
-        if (!shouldShowGitGutter) {
-            gitBlameHover?.hide();
-        }
-        gitDiffOverviewRuler?.refresh();
-    };
-
-    const releasePointerCaptureIfHeld = (pointerId) => {
-        if (!view || pointerId === null) {
-            return;
-        }
-        if (view.dom.releasePointerCapture && view.dom.hasPointerCapture(pointerId)) {
-            view.dom.releasePointerCapture(pointerId);
-        }
-    };
-
-    const syncSelectionClass = () => {
-        if (!view) {
-            return;
-        }
-        const hasSelection = view.state.selection.ranges.some((range) => !range.empty);
-        view.dom.classList.toggle("has-selection", hasSelection);
-    };
-
-    const getActiveTableInput = () => {
-        if (!view) {
-            return null;
-        }
-        const active = document.activeElement;
-        if (!(active instanceof HTMLTextAreaElement)) {
-            return null;
-        }
-        if (!view.dom.contains(active)) {
-            return null;
-        }
-        return active.closest(".meo-md-html-table-wrap") ? active : null;
-    };
-
-    const measureTextareaSelectionStart = (input, index) => {
-        const doc = input.ownerDocument;
-        const mirror = doc.createElement("div");
-        const marker = doc.createElement("span");
-        const computed = window.getComputedStyle(input);
-
-        mirror.style.position = "fixed";
-        mirror.style.left = "0";
-        mirror.style.top = "0";
-        mirror.style.visibility = "hidden";
-        mirror.style.pointerEvents = "none";
-        mirror.style.whiteSpace = "pre-wrap";
-        mirror.style.overflowWrap = "break-word";
-        mirror.style.wordBreak = "break-word";
-        mirror.style.boxSizing = computed.boxSizing;
-        mirror.style.width = `${input.getBoundingClientRect().width}px`;
-        mirror.style.minHeight = computed.height;
-        mirror.style.padding = computed.padding;
-        mirror.style.border = computed.border;
-        mirror.style.font = computed.font;
-        mirror.style.fontFamily = computed.fontFamily;
-        mirror.style.fontSize = computed.fontSize;
-        mirror.style.fontWeight = computed.fontWeight;
-        mirror.style.fontStyle = computed.fontStyle;
-        mirror.style.letterSpacing = computed.letterSpacing;
-        mirror.style.lineHeight = computed.lineHeight;
-        mirror.style.textTransform = computed.textTransform;
-        mirror.style.textIndent = computed.textIndent;
-        mirror.style.tabSize = computed.tabSize;
-
-        mirror.textContent = input.value.slice(0, index);
-        marker.textContent = "\u200b";
-        mirror.appendChild(marker);
-        doc.body.appendChild(mirror);
-
-        const markerRect = marker.getBoundingClientRect();
-        const mirrorRect = mirror.getBoundingClientRect();
-        const inputRect = input.getBoundingClientRect();
-        const coords = {
-            left: inputRect.left + (markerRect.left - mirrorRect.left),
-            top: inputRect.top + (markerRect.top - mirrorRect.top),
-        };
-
-        mirror.remove();
-        return coords;
-    };
-
-    const getActiveTableSelectionState = (input) => {
-        const rawStart = input.selectionStart ?? 0;
-        const rawEnd = input.selectionEnd ?? rawStart;
-        if (rawStart === rawEnd) {
-            return null;
-        }
-        const selectionStart = Math.min(rawStart, rawEnd);
-        const coords = measureTextareaSelectionStart(input, selectionStart);
-        return {
-            visible: true,
-            anchorX: coords.left,
-            anchorY: coords.top,
-        };
-    };
-
-    const updateActiveTableInput = (input, nextValue, anchor, head = anchor) => {
-        input.value = nextValue;
-        input.focus({ preventScroll: true });
-        input.setSelectionRange(Math.min(anchor, head), Math.max(anchor, head), anchor <= head ? "forward" : "backward");
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-        emitSelectionChange();
-        return true;
-    };
-
-    const editActiveTableInputWithSelection = (input, transform) => {
-        const rawStart = input.selectionStart ?? 0;
-        const rawEnd = input.selectionEnd ?? rawStart;
-        const start = Math.min(rawStart, rawEnd);
-        const end = Math.max(rawStart, rawEnd);
-        return transform(input.value, start, end);
-    };
-
-    const trimTrailingNewlines = (value, start, end) => {
-        let nextEnd = end;
-        while (nextEnd > start && value.slice(nextEnd - 1, nextEnd) === "\n") {
-            nextEnd -= 1;
-        }
-        return nextEnd;
-    };
-
-    const wrapActiveTableInputSelection = (input, openMarker, closeMarker = openMarker, { toggle = true, selectWrapped = true } = {}) => {
-        return editActiveTableInputWithSelection(input, (value, start, end) => {
-            if (start === end) {
-                const insert = `${openMarker}${closeMarker}`;
-                const nextValue = value.slice(0, start) + insert + value.slice(end);
-                return updateActiveTableInput(input, nextValue, start + openMarker.length);
-            }
-
-            const trimmedEnd = trimTrailingNewlines(value, start, end);
-            if (toggle) {
-                const hasOpenMarker = start >= openMarker.length && value.slice(start - openMarker.length, start) === openMarker;
-                const hasCloseMarker = value.slice(trimmedEnd, trimmedEnd + closeMarker.length) === closeMarker;
-                if (hasOpenMarker && hasCloseMarker) {
-                    const nextValue = value.slice(0, start - openMarker.length) + value.slice(start, trimmedEnd) + value.slice(trimmedEnd + closeMarker.length);
-                    return updateActiveTableInput(input, nextValue, start - openMarker.length, trimmedEnd - openMarker.length);
-                }
-            }
-
-            const nextValue = value.slice(0, start) + openMarker + value.slice(start, trimmedEnd) + closeMarker + value.slice(trimmedEnd);
-            if (!selectWrapped) {
-                const cursor = start + openMarker.length + (trimmedEnd - start) + closeMarker.length;
-                return updateActiveTableInput(input, nextValue, cursor);
-            }
-            return updateActiveTableInput(input, nextValue, start + openMarker.length, trimmedEnd + openMarker.length);
-        });
-    };
-
-    const insertFormatInActiveTableInput = (input, action) => {
-        switch (action) {
-            case "inlineCode":
-                return wrapActiveTableInputSelection(input, "`", "`", { toggle: false, selectWrapped: false });
-            case "kbd":
-                return wrapActiveTableInputSelection(input, "<kbd>", "</kbd>");
-            case "bold":
-                return wrapActiveTableInputSelection(input, "**");
-            case "italic":
-                return wrapActiveTableInputSelection(input, "*");
-            case "lineover":
-            case "strike":
-                return wrapActiveTableInputSelection(input, "~~");
-            case "link":
-                return editActiveTableInputWithSelection(input, (value, start, end) => {
-                    if (start !== end) {
-                        const trimmedEnd = trimTrailingNewlines(value, start, end);
-                        const selectedText = value.slice(start, trimmedEnd);
-                        const insert = `[${selectedText}]()`;
-                        const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
-                        return updateActiveTableInput(input, nextValue, start + insert.length - 1);
-                    }
-
-                    const insert = "[]()";
-                    const nextValue = value.slice(0, start) + insert + value.slice(end);
-                    return updateActiveTableInput(input, nextValue, start + 3);
-                });
-            case "wikiLink":
-                return editActiveTableInputWithSelection(input, (value, start, end) => {
-                    if (start !== end) {
-                        const trimmedEnd = trimTrailingNewlines(value, start, end);
-                        const selectedText = value.slice(start, trimmedEnd);
-                        const insert = `[[${selectedText}]]`;
-                        const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
-                        return updateActiveTableInput(input, nextValue, start + insert.length);
-                    }
-
-                    const insert = "[[]]";
-                    const nextValue = value.slice(0, start) + insert + value.slice(end);
-                    return updateActiveTableInput(input, nextValue, start + 2);
-                });
-            default:
-                return false;
-        }
-    };
-
-    const forEachSelectedLine = (state: EditorState, callback: (line: { from: number; to: number; number: number }) => void): void => {
-        const seen = new Set<number>();
-        for (const range of state.selection.ranges) {
-            const fromLine = state.doc.lineAt(range.from).number;
-            const toPos = Math.max(range.from, range.to - (range.empty ? 0 : 1));
-            const toLine = state.doc.lineAt(toPos).number;
-            for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
-                if (seen.has(lineNumber)) {
-                    continue;
-                }
-                seen.add(lineNumber);
-                callback(state.doc.line(lineNumber));
-            }
-        }
-    };
-
-    const lineMarkerReplacementContext = (state: EditorState, line: { from: number; to: number }): MarkerReplacementContext => {
-        const lineText = state.doc.sliceString(line.from, line.to);
-        const existingMarker = existingListMarkerRegex.exec(lineText);
-        const existingHeading = existingHeadingMarkerRegex.exec(lineText);
-        const leadingWhitespace = existingMarker?.[1] ?? existingHeading?.[1] ?? /^(\s*)/.exec(lineText)[1];
-
-        const contentStart = line.from + leadingWhitespace.length;
-        let oldMarkerLen = 0;
-        if (existingMarker) {
-            oldMarkerLen = existingMarker[0].length - leadingWhitespace.length;
-        } else if (existingHeading) {
-            oldMarkerLen = existingHeading[0].length - leadingWhitespace.length;
-        }
-
-        const isExistingTask = Boolean(existingMarker && existingTaskMarkerRegex.test(existingMarker[0]));
-        return { contentStart, oldMarkerLen, isExistingTask };
-    };
-
-    const buildListFormatChangesForSelection = (state: EditorState, insert: string): ChangeSpec[] => {
-        const changes: ChangeSpec[] = [];
-        forEachSelectedLine(state, (line) => {
-            const { contentStart, oldMarkerLen } = lineMarkerReplacementContext(state, line);
-            changes.push({ from: contentStart, to: contentStart + oldMarkerLen, insert });
-        });
-        return changes;
-    };
-
-    const dispatchSelectedListFormatChanges = (state: EditorState, changes: ChangeSpec[], shouldRenumberOrdered: boolean): void => {
-        if (!changes.length) {
-            return;
-        }
-
-        if (!shouldRenumberOrdered) {
-            view.dispatch({ changes });
-            return;
-        }
-
-        const withMarkers = state.update({ changes });
-        const renumberChanges = collectOrderedListRenumberChanges(withMarkers.state);
-        if (!renumberChanges.length) {
-            view.dispatch(withMarkers);
-            return;
-        }
-
-        view.dispatch(state.update({ changes }, { changes: renumberChanges, sequential: true }));
-    };
-
-    const isSearchMatchSelection = (from, to) => {
-        if (!view || from >= to) {
-            return false;
-        }
-
-        const searchQuery = view.state.field(searchQueryField);
-        if (!searchQuery.text || to - from !== searchQuery.text.length) {
-            return false;
-        }
-
-        let isMatchSelection = false;
-        view.state.field(searchMatchField).between(from, to, (matchFrom, matchTo) => {
-            if (matchFrom === from && matchTo === to) {
-                isMatchSelection = true;
-            }
-        });
-        return isMatchSelection;
-    };
-
-    const resolveNativeSelectionAnchor = (): { anchorX: number; anchorY: number } | null => {
-        if (!view) {
-            return null;
-        }
-
-        const nativeSelection = window.getSelection();
-        if (!nativeSelection || nativeSelection.isCollapsed || nativeSelection.rangeCount === 0) {
-            return null;
-        }
-
-        let topRect: DOMRect | null = null;
-        for (let rangeIndex = 0; rangeIndex < nativeSelection.rangeCount; rangeIndex += 1) {
-            const range = nativeSelection.getRangeAt(rangeIndex);
-            const ancestor = range.commonAncestorContainer;
-            if (!view.dom.contains(ancestor)) {
-                continue;
-            }
-
-            const rects = range.getClientRects();
-            for (let rectIndex = 0; rectIndex < rects.length; rectIndex += 1) {
-                const rect = rects.item(rectIndex);
-                if (!rect || (rect.width <= 0 && rect.height <= 0)) {
-                    continue;
-                }
-                if (!topRect || rect.top < topRect.top || (rect.top === topRect.top && rect.left < topRect.left)) {
-                    topRect = rect;
-                }
-            }
-        }
-
-        if (!topRect) {
-            return null;
-        }
-
-        return {
-            anchorX: topRect.left,
-            anchorY: topRect.top,
-        };
-    };
-
-    const emitSelectionChange = () => {
-        if (!view || typeof onSelectionChange !== "function") {
-            return;
-        }
-
-        const activeTableInput = getActiveTableInput();
-        if (activeTableInput) {
-            onSelectionChange(getActiveTableSelectionState(activeTableInput) ?? { visible: false });
-            return;
-        }
-
-        const selection = view.state.selection.main;
-        if (selection.empty) {
-            onSelectionChange({ visible: false });
-            return;
-        }
-
-        const from = Math.min(selection.from, selection.to);
-        const to = Math.max(selection.from, selection.to);
-        if (isSearchMatchSelection(from, to)) {
-            onSelectionChange({ visible: false });
-            return;
-        }
-
-        if (!isRegularInlineSelection(view.state, from, to)) {
-            onSelectionChange({ visible: false });
-            return;
-        }
-
-        const nativeAnchor = resolveNativeSelectionAnchor();
-        if (nativeAnchor) {
-            onSelectionChange({
-                visible: true,
-                from,
-                to,
-                anchorX: nativeAnchor.anchorX,
-                anchorY: nativeAnchor.anchorY,
-            });
-            return;
-        }
-
-        const fromCoords = view.coordsAtPos(from);
-        const toCoords = view.coordsAtPos(to);
-        if (!fromCoords || !toCoords) {
-            onSelectionChange({ visible: false });
-            return;
-        }
-
-        const fromCharCoords = view.coordsForChar(from);
-        const anchorX = fromCharCoords?.left ?? fromCoords.left;
-        const anchorY = fromCharCoords ? Math.min(fromCoords.top, fromCharCoords.top) : fromCoords.top;
-
-        onSelectionChange({
-            visible: true,
-            from,
-            to,
-            anchorX,
-            anchorY,
-        });
-    };
-
-    const isHistoryReplayUpdate = (update: ViewUpdate): boolean => {
-        return update.transactions.some((transaction) => {
-            const userEvent = transaction.annotation(Transaction.userEvent);
-            return typeof userEvent === "string" && (userEvent === "undo" || userEvent === "redo" || userEvent.startsWith("undo.") || userEvent.startsWith("redo."));
-        });
-    };
-
-    const inlineCodeCaretPosition = (state, position) => {
-        let node = syntaxTree(state).resolveInner(position, -1);
-        while (node && node.name !== "InlineCode" && node.name !== "CodeText") {
-            node = node.parent;
-        }
-        if (!node) {
-            return null;
-        }
-
-        const text = state.doc.sliceString(node.from, node.to);
-        const openTicks = (/^`+/.exec(text) ?? [""])[0].length;
-        const closeTicks = (/`+$/.exec(text) ?? [""])[0].length;
-        if (!openTicks || !closeTicks) {
-            return null;
-        }
-
-        const min = node.from + openTicks;
-        const max = node.to - closeTicks;
-        if (min > max) {
-            return null;
-        }
-        if (position < min) {
-            return min;
-        }
-        if (position > max) {
-            return max;
-        }
-        return null;
-    };
-
-    const selectSearchMatch = (from, to, { focusEditor = true } = {}) => {
-        view.dispatch({
-            selection: { anchor: from, head: to },
-            effects: EditorView.scrollIntoView(from, { y: "center" }),
-        });
-        if (focusEditor) {
-            view.focus();
-        }
-    };
-
-    const applyRevealSelection = (anchor, head = anchor, { focusEditor = true, align = "center" } = {}) => {
-        const max = view.state.doc.length;
-        const nextAnchor = Math.max(0, Math.min(anchor, max));
-        const nextHead = Math.max(0, Math.min(head, max));
-        const y = align === "top" ? "start" : "center";
-        const selection = view.state.selection.main;
-
-        if (selection.anchor === nextAnchor && selection.head === nextHead) {
-            view.dispatch({
-                effects: EditorView.scrollIntoView(nextAnchor, { y }),
-            });
-            if (focusEditor) {
-                view.focus();
-            }
-            return;
-        }
-
-        view.dispatch({
-            selection: { anchor: nextAnchor, head: nextHead },
-            effects: EditorView.scrollIntoView(nextAnchor, { y }),
-        });
-        if (focusEditor) {
-            view.focus();
-        }
-    };
-
-    const TOP_LINE_VISIBILITY_EPSILON = 0.5;
-    const SCROLL_RESTORE_EPSILON = 0.5;
-    const SCROLL_RESTORE_MAX_ATTEMPTS = 3;
-
-    const getTopLineMetrics = (scrollTopValue = view.scrollDOM.scrollTop) => {
-        const scrollTop = Math.max(0, scrollTopValue);
-        const lineBlock = view.lineBlockAtHeight(scrollTop);
-        const line = view.state.doc.lineAt(lineBlock.from);
-        return {
-            line,
-            lineBlock,
-            hiddenTopPixels: scrollTop - lineBlock.top,
-        };
-    };
-
-    const topVisibleLineAtCurrentScroll = () => {
-        const { line, hiddenTopPixels } = getTopLineMetrics();
-        if (hiddenTopPixels <= TOP_LINE_VISIBILITY_EPSILON) {
-            return line;
-        }
-
-        const nextLineNumber = Math.min(view.state.doc.lines, line.number + 1);
-        return view.state.doc.line(nextLineNumber);
-    };
-
-    const syncCursorToTopVisibleLine = () => {
-        const line = topVisibleLineAtCurrentScroll();
-        const anchor = line.from;
-        const selection = view.state.selection.main;
-        if (selection.anchor === anchor && selection.head === anchor) {
-            return;
-        }
-        view.dispatch({
-            selection: { anchor },
-            annotations: Transaction.addToHistory.of(false),
-        });
-    };
-
-    const computeTopVisiblePosition = () => {
-        const { line, hiddenTopPixels } = getTopLineMetrics();
-        return {
-            lineNumber: line.number,
-            lineOffset: normalizeTopLineOffset(hiddenTopPixels),
-        };
-    };
-
-    const restoreTopVisibleLine = (lineNumber, lineOffset = 0, { syncCursor = true } = {}) => {
-        const targetLineNumber = Math.min(Math.max(1, Math.floor(lineNumber || 1)), view.state.doc.lines);
-        const targetOffset = normalizeTopLineOffset(lineOffset);
-        let attempts = 0;
-        const restoreScroll = () => {
-            if (!view || ++attempts > SCROLL_RESTORE_MAX_ATTEMPTS) {
-                if (syncCursor && view) {
-                    syncCursorToTopVisibleLine();
-                }
-                return;
-            }
-            const targetLine = view.state.doc.line(targetLineNumber);
-            const targetTop = Math.max(0, view.lineBlockAt(targetLine.from).top + targetOffset);
-            const currentTop = view.scrollDOM.scrollTop;
-            view.scrollDOM.scrollTop = targetTop;
-            if (Math.abs(currentTop - targetTop) <= SCROLL_RESTORE_EPSILON) {
-                if (syncCursor) {
-                    syncCursorToTopVisibleLine();
-                }
-                return;
-            }
-            requestAnimationFrame(restoreScroll);
-        };
-        restoreScroll();
-    };
-
-    const findMatch = (query, backward = false, { focusEditor = true, ...searchOptions }: SearchOptions & { focusEditor?: boolean } = {}) => {
-        if (!query) {
-            return { found: false, current: 0, total: 0 };
-        }
-
-        const text = view.state.doc.toString();
-        const selection = view.state.selection.main;
-        const from = Math.min(selection.from, selection.to);
-        const to = Math.max(selection.from, selection.to);
-        const matches = findSearchMatchRanges(text, query, searchOptions);
-        const total = matches.length;
-
-        if (!total) {
-            return { found: false, current: 0, total };
-        }
-
-        let matchIndex = -1;
-        if (backward) {
-            for (let index = matches.length - 1; index >= 0; index -= 1) {
-                if (matches[index].start < from) {
-                    matchIndex = index;
-                    break;
-                }
-            }
-            if (matchIndex < 0) {
-                matchIndex = matches.length - 1;
-            }
+    appliedVimKeybindings = [];
+  };
+  const applyVimKeybindings = (
+    bindings: Array<{ before: string; after: string; mode: string; recursive: boolean }>,
+    leaderKey: string
+  ) => {
+    clearVimKeybindings();
+    try {
+      Vim.setOption('leader', leaderKey);
+    } catch {
+      // Keep Vim usable if the embedded Vim implementation rejects the option.
+    }
+    for (const { before, after, mode, recursive } of bindings) {
+      const mappedBefore = expandVimLeader(before, leaderKey);
+      const mappedAfter = expandVimLeader(after, leaderKey);
+      try {
+        if (recursive) {
+          Vim.map(mappedBefore, mappedAfter, mode);
         } else {
-            for (let index = 0; index < matches.length; index += 1) {
-                if (matches[index].start >= to) {
-                    matchIndex = index;
-                    break;
-                }
-            }
-            if (matchIndex < 0) {
-                matchIndex = 0;
-            }
+          Vim.noremap(mappedBefore, mappedAfter, mode);
         }
-
-        const match = matches[matchIndex];
-        selectSearchMatch(match.start, match.end, { focusEditor });
-        return {
-            found: true,
-            current: matchIndex + 1,
-            total,
-        };
-    };
-
-    const replaceCurrentMatch = (query, replacement, options: SearchOptions = {}) => {
-        if (!query) {
-            return { replaced: false, found: false, current: 0, total: 0 };
-        }
-
-        const text = view.state.doc.toString();
-        const selection = view.state.selection.main;
-        const from = Math.min(selection.from, selection.to);
-        const to = Math.max(selection.from, selection.to);
-        const matches = findSearchMatchRanges(text, query, options);
-        const matchIndex = findSelectedSearchMatchIndex(matches, from, to);
-        if (matchIndex < 0) {
-            return { replaced: false, ...findMatch(query, false, options) };
-        }
-
-        view.dispatch({
-            changes: { from, to, insert: replacement },
-            selection: { anchor: from, head: from + replacement.length },
-        });
-        const nextMatch = findMatch(query, false, options);
-        if (nextMatch.found) {
-            return { replaced: true, ...nextMatch };
-        }
-
-        const remaining = countMatches(view.state.doc.toString(), query, options);
-        return { replaced: true, found: false, current: 0, total: remaining };
-    };
-
-    const state = EditorState.create({
-        doc: text,
-        selection: { anchor: initialCursorPos },
-        extensions: [
-            EditorState.tabSize.of(4),
-            indentUnit.of("  "),
-            vimCompartment.of(vimExtensionsForState()),
-            keymap.of([
-                { key: "Tab", run: (view) => indentListByTwoSpaces(view) || indentMore(view) },
-                { key: "Shift-Tab", run: (view) => outdentListByTwoSpaces(view) || indentLess(view) },
-                { key: "Backspace", run: deleteBackwardSmart },
-                { key: "ArrowLeft", run: (view) => isLiveMode(view) && handleArrowLeftAtListContentStart(view) },
-                { key: "ArrowRight", run: (view) => isLiveMode(view) && handleArrowRightAtListLineStart(view) },
-                {
-                    key: "Enter",
-                    run: (view) => handleEnterContinueQuotedCodeBlock(view) || handleEnterOnEmptyListItem(view) || handleEnterAtListContentStart(view) || handleEnterContinueList(view) || handleEnterBeforeNestedList(view),
-                },
-                { key: "Shift-Enter", run: insertTableCellLineBreak },
-                { key: "ArrowUp", run: (view) => tryEnterAdjacentTable(view, "up") },
-                { key: "ArrowDown", run: (view) => tryEnterAdjacentTable(view, "down") },
-                ...markdownKeymap,
-                ...defaultKeymap,
-                ...historyKeymap,
-            ]),
-            history(),
-            lineNumbers(),
-            ...gitDiffGutterBaselineExtensions(),
-            gitGutterCompartment.of(startMode === "live" ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()),
-            highlightActiveLineGutter(),
-            highlightActiveLine(),
-            EditorView.lineWrapping,
-            scrollPastEnd(),
-            EditorView.domEventHandlers({
-                pointerdown(event, view) {
-                    if (event.button !== 0) {
-                        frontmatterBoundaryClick = null;
-                        return false;
-                    }
-                    if (openLinkIfModifierClick(event, view)) {
-                        frontmatterBoundaryClick = null;
-                        return true;
-                    }
-
-                    const target = event.target;
-                    const targetElement = targetElementFrom(target);
-                    if (!(target instanceof Node) || !view.contentDOM.contains(target)) {
-                        return false;
-                    }
-
-                    trackFrontmatterBoundaryClick(event, view);
-
-                    if (targetElement && targetElement.closest(".meo-mermaid-zoom-controls")) {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        return true;
-                    }
-
-                    if (targetElement && targetElement.closest(".meo-task-checkbox")) {
-                        checkboxClick = { pointerId: event.pointerId };
-                        return false;
-                    }
-
-                    // Let interactive HTML table widget controls handle focus/click natively.
-                    if (targetElement && targetElement.closest(".meo-md-html-table-wrap")) {
-                        inlineCodeClick = null;
-                        checkboxClick = null;
-                        return false;
-                    }
-
-                    inlineCodeClick = {
-                        pointerId: event.pointerId,
-                        inInlineCode: currentMode === "live" && targetElement && targetElement.closest(".meo-md-inline-code") !== null,
-                    };
-
-                    if (view.dom.setPointerCapture) {
-                        view.dom.setPointerCapture(event.pointerId);
-                        capturedPointerId = event.pointerId;
-                    }
-                    return false;
-                },
-                pointerup(event, view) {
-                    if (checkboxClick?.pointerId === event.pointerId) {
-                        frontmatterBoundaryClick = null;
-                        checkboxClick = null;
-                        return false;
-                    }
-
-                    if (capturedPointerId !== event.pointerId) {
-                        if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
-                            frontmatterBoundaryClick = null;
-                        }
-                        return false;
-                    }
-
-                    releasePointerCaptureIfHeld(event.pointerId);
-                    capturedPointerId = null;
-
-                    if (inlineCodeClick?.pointerId === event.pointerId && inlineCodeClick.inInlineCode && isLiveMode(view)) {
-                        const { head, empty } = view.state.selection.main;
-                        if (empty) {
-                            const clamped = inlineCodeCaretPosition(view.state, head);
-                            if (clamped !== null && clamped !== head) {
-                                view.dispatch({ selection: { anchor: clamped } });
-                            }
-                        }
-                    }
-
-                    if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
-                        if (isLiveMode(view)) {
-                            const selection = view.state.selection.main;
-                            if (selection.empty && selection.head !== frontmatterBoundaryClick.cursorEnd) {
-                                view.dispatch({ selection: { anchor: frontmatterBoundaryClick.cursorEnd } });
-                            }
-                        }
-                        frontmatterBoundaryClick = null;
-                    }
-
-                    if (isLiveMode(view)) {
-                        const { head, empty } = view.state.selection.main;
-                        if (empty) {
-                            const emptyQuoteCursorEnd = emptyBlockquoteLineCursorEnd(view.state, head);
-                            if (emptyQuoteCursorEnd !== null && head < emptyQuoteCursorEnd) {
-                                view.dispatch({ selection: { anchor: emptyQuoteCursorEnd } });
-                                return false;
-                            }
-
-                            const node = resolvedSyntaxTree(view.state).resolveInner(head, -1);
-                            if (node.name === "HorizontalRule") {
-                                const line = view.state.doc.lineAt(head);
-                                const lineText = view.state.doc.sliceString(line.from, line.to);
-                                const hrMatch = /^[ \t]*(-{3,}|\*{3,}|_{3,})/.exec(lineText);
-                                if (hrMatch) {
-                                    const cursorEnd = line.from + hrMatch[0].length;
-                                    if (head !== cursorEnd) {
-                                        view.dispatch({ selection: { anchor: cursorEnd } });
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    inlineCodeClick = null;
-                    return false;
-                },
-                pointercancel(event, _view) {
-                    if (capturedPointerId !== event.pointerId) {
-                        if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
-                            frontmatterBoundaryClick = null;
-                        }
-                        return false;
-                    }
-
-                    releasePointerCaptureIfHeld(event.pointerId);
-                    capturedPointerId = null;
-                    frontmatterBoundaryClick = null;
-                    inlineCodeClick = null;
-                    checkboxClick = null;
-                    return false;
-                },
-                pointermove(event, view) {
-                    updateSourceLinkHoverCursor(event, view);
-                    return false;
-                },
-                pointerleave(_event, view) {
-                    setSourceLinkHoverCursor(view, false);
-                    return false;
-                },
-            }),
-            ...headingCollapseSharedExtensions(),
-            modeCompartment.of(startMode === "live" ? liveModeExtensions() : sourceMode()),
-            searchQueryField,
-            searchMatchField,
-            EditorView.updateListener.of((update) => {
-                syncModeClasses();
-                syncLineNumbersVisibility();
-                syncGitGutterVisibility();
-
-                if (update.selectionSet) {
-                    syncSelectionClass();
-                    emitSelectionChange();
-                } else if (update.viewportChanged) {
-                    emitSelectionChange();
-                    onViewportChange?.();
-                }
-
-                if (!update.docChanged || applyingExternal || applyingRenumber) {
-                    return;
-                }
-
-                gitBlameHover?.hide();
-
-                pendingExternalUndoSelectionPreserve = false;
-
-                if (isHistoryReplayUpdate(update)) {
-                    onApplyChanges(update.state.doc.toString());
-                    return;
-                }
-
-                const renumberChanges = collectOrderedListRenumberChanges(update.state);
-                if (renumberChanges.length) {
-                    applyingRenumber = true;
-                    view.dispatch({
-                        changes: renumberChanges,
-                        annotations: Transaction.addToHistory.of(false),
-                    });
-                    applyingRenumber = false;
-                    onApplyChanges(view.state.doc.toString());
-                    return;
-                }
-
-                onApplyChanges(update.state.doc.toString());
-            }),
-        ],
-    });
-
-    const initialScrollTo = (() => {
-        if (typeof initialTopLine !== "number" || !Number.isFinite(initialTopLine)) {
-            return undefined;
-        }
-        const lineNumber = Math.min(Math.max(1, Math.floor(initialTopLine)), state.doc.lines);
-        const line = state.doc.line(lineNumber);
-        return EditorView.scrollIntoView(line.from, { y: "start" });
-    })();
-
-    view = new EditorView({
-        state,
-        parent,
-        scrollTo: initialScrollTo,
-    });
-    if (typeof initialTopLine === "number" && Number.isFinite(initialTopLine)) {
-        restoreTopVisibleLine(initialTopLine, initialTopLineOffset, { syncCursor: true });
+        appliedVimKeybindings.push({ before: mappedBefore, mode });
+      } catch {
+        // Ignore individual mappings that CodeMirror Vim cannot represent.
+      }
     }
-    onTableInteraction = (event) => {
-        const active = Boolean(event?.detail?.active);
-        setTableInteractionActive(active);
-    };
-    view.dom.addEventListener("meo-table-interaction", onTableInteraction);
-    onTableOpenLink = (event) => {
-        const href = event?.detail?.href;
-        if (typeof href !== "string" || !href) {
-            return;
-        }
-        onOpenLink?.(href);
-    };
-    view.dom.addEventListener("meo-open-link", onTableOpenLink);
-    onTableSelectionChange = () => {
-        emitSelectionChange();
-    };
-    view.dom.addEventListener("meo-table-selection-change", onTableSelectionChange);
-    onScroll = () => {
-        emitSelectionChange();
-        gitBlameHover?.hide();
-        onViewportChange?.();
-    };
-    view.scrollDOM.addEventListener("scroll", onScroll, { passive: true });
-    if (typeof onRequestGitBlame === "function") {
-        gitBlameHover = createGitBlameHoverController({
-            view,
-            getMode: () => currentMode,
-            requestBlame: onRequestGitBlame,
-            openRevisionForLine: onOpenGitRevisionForLine,
-            openWorktreeForLine: onOpenGitWorktreeForLine,
-        });
+  };
+
+  if (initialVimMode === true) {
+    applyVimKeybindings(vimKeybindings, vimLeader);
+  }
+  let applyingExternal = false;
+  let capturedPointerId = null;
+  let inlineCodeClick = null;
+  let checkboxClick = null;
+  let frontmatterBoundaryClick = null;
+  let view = null;
+  let currentMode = startMode;
+  let applyingRenumber = false;
+  // External syncs may carry stale selections in their history entries.
+  // Preserve the user's current cursor once on the next undo of such a change.
+  let pendingExternalUndoSelectionPreserve = false;
+  let tableInteractionActive = false;
+  let onTableInteraction = null;
+  let onTableOpenLink = null;
+  let onTableSelectionChange = null;
+  let onScroll = null;
+  let gitBlameHover = null;
+  let gitDiffOverviewRuler = null;
+  let sourceLinkHoverPointerActive = false;
+  const normalizeTopLineOffset = (value) => {
+    if (!Number.isFinite(value)) {
+      return 0;
     }
-    gitDiffOverviewRuler = createGitDiffOverviewRulerController({
-        view,
-        getMode: () => currentMode,
-        isGitChangesVisible: () => gitGutterVisible,
-    });
-    syncModeClasses();
-    syncLineNumbersVisibility();
-    syncGitGutterVisibility();
-    syncSelectionClass();
+    return Math.max(0, Number(value));
+  };
+  const vimExtensionsForState = () => (vimModeEnabled ? vim() : []);
+  const getLineStartOffset = (docText, targetLineNumber) => {
+    const targetLine = Math.max(1, Math.floor(targetLineNumber));
+    if (targetLine === 1) {
+      return 0;
+    }
+    let line = 1;
+    for (let index = 0; index < docText.length; index += 1) {
+      if (docText.charCodeAt(index) !== 10) {
+        continue;
+      }
+      line += 1;
+      if (line === targetLine) {
+        return index + 1;
+      }
+    }
+    return docText.length;
+  };
+  const initialCursorPos = (() => {
+    if (typeof initialTopLine === 'number' && Number.isFinite(initialTopLine)) {
+      return getLineStartOffset(text ?? '', initialTopLine);
+    }
+    if (!text) {
+      return 0;
+    }
+    const firstLineEnd = text.indexOf('\n');
+    return firstLineEnd === -1 ? text.length : firstLineEnd;
+  })();
+  const targetElementFrom = (target) => (
+    target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+  );
+  const openLinkIfModifierClick = (event, editorView) => {
+    if (!isPrimaryModifierPointerClick(event)) {
+      return false;
+    }
+    const href = getLinkHrefAtPointer(event, editorView);
+    if (!href) {
+      return false;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    onOpenLink?.(href);
+    return true;
+  };
+  const setSourceLinkHoverCursor = (editorView, active) => {
+    if (sourceLinkHoverPointerActive === active) {
+      return;
+    }
+    sourceLinkHoverPointerActive = active;
+    const cursor = active ? 'pointer' : '';
+    editorView.dom.style.cursor = cursor;
+    editorView.contentDOM.style.cursor = cursor;
+  };
+  const updateSourceLinkHoverCursor = (event, editorView) => {
+    if (currentMode !== 'source') {
+      setSourceLinkHoverCursor(editorView, false);
+      return;
+    }
+    const target = event.target;
+    if (!(target instanceof Node) || !editorView.contentDOM.contains(target)) {
+      setSourceLinkHoverCursor(editorView, false);
+      return;
+    }
+    const href = getLinkHrefAtPointer(event, editorView, { exactTextHit: true });
+    setSourceLinkHoverCursor(editorView, Boolean(href));
+  };
+  const isLiveMode = (editorView) => editorView.dom.classList.contains('meo-mode-live');
+  const isPlainPrimaryPointerEvent = (event) => (
+    event.button === 0 && !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey
+  );
+  const frontmatterBoundaryCursorEnd = (state, pos) => {
+    const frontmatter = parseFrontmatter(state);
+    if (!frontmatter) {
+      return null;
+    }
+    const line = state.doc.lineAt(pos);
+    const openingLineNo = state.doc.lineAt(frontmatter.openingFrom).number;
+    const closingLineNo = state.doc.lineAt(frontmatter.closingFrom).number;
+    if (line.number !== openingLineNo && line.number !== closingLineNo) {
+      return null;
+    }
+    const lineText = state.doc.sliceString(line.from, line.to);
+    const markerStart = lineText.indexOf('---');
+    return markerStart >= 0 ? line.from + markerStart + 3 : null;
+  };
+  const emptyBlockquoteLineCursorEnd = (state, pos) => {
+    const line = state.doc.lineAt(pos);
+    const lineText = state.doc.sliceString(line.from, line.to);
+    const quoteMatch = /^[ \t]{0,3}(?:>[ \t]?)+$/.exec(lineText);
+    if (!quoteMatch) {
+      return null;
+    }
+
+    const probePos = Math.min(line.to, line.from + 1);
+    let node = resolvedSyntaxTree(state).resolveInner(probePos, 1);
+    while (node) {
+      if (node.name === 'Blockquote') {
+        return line.from + quoteMatch[0].length;
+      }
+      node = node.parent;
+    }
+
+    return null;
+  };
+  const trackFrontmatterBoundaryClick = (event, editorView) => {
+    frontmatterBoundaryClick = null;
+    if (!isLiveMode(editorView) || !isPlainPrimaryPointerEvent(event)) {
+      return;
+    }
+    const clickedPos = editorView.posAtCoords({ x: event.clientX, y: event.clientY });
+    if (clickedPos === null) {
+      return;
+    }
+    const cursorEnd = frontmatterBoundaryCursorEnd(editorView.state, clickedPos);
+    if (cursorEnd === null) {
+      return;
+    }
+    frontmatterBoundaryClick = {
+      pointerId: event.pointerId,
+      cursorEnd
+    };
+  };
+
+  const setTableInteractionActive = (active) => {
+    if (!view || tableInteractionActive === active) {
+      return;
+    }
+    tableInteractionActive = active;
+    view.dom.classList.toggle('meo-table-interaction-active', active);
+  };
+  const tableEntryCellSelector = 'th[data-table-row][data-table-col], td[data-table-row][data-table-col]';
+  const tableEntryProbeOffsetsY = [1, 4, 8, 12, 18];
+  const focusTableEntryInput = (input) => {
+    if (!(input instanceof HTMLTextAreaElement)) {
+      return false;
+    }
+    input.focus({ preventScroll: true });
+    const caret = input.value.length;
+    input.setSelectionRange(caret, caret);
+    input.closest(tableEntryCellSelector)?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+    return true;
+  };
+  const findTableEntryInput = (wrap, hit, direction) => {
+    const cell = hit.closest(tableEntryCellSelector);
+    if (cell instanceof HTMLElement && wrap.contains(cell)) {
+      const cellInput = cell.querySelector('textarea');
+      if (cellInput instanceof HTMLTextAreaElement) {
+        return cellInput;
+      }
+    }
+
+    if (direction === 'down') {
+      const first = wrap.querySelector('textarea');
+      return first instanceof HTMLTextAreaElement ? first : null;
+    }
+
+    const inputs = wrap.querySelectorAll('textarea');
+    const last = inputs.length ? inputs[inputs.length - 1] : null;
+    return last instanceof HTMLTextAreaElement ? last : null;
+  };
+
+  const tryEnterAdjacentTable = (editorView, direction) => {
+    if ((direction !== 'down' && direction !== 'up') || currentMode !== 'live' || tableInteractionActive) {
+      return false;
+    }
+
+    const selection = editorView.state.selection.main;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const caretRect = editorView.coordsAtPos(selection.head);
+    if (!caretRect) {
+      return false;
+    }
+
+    const contentRect = editorView.contentDOM.getBoundingClientRect();
+    if (!contentRect || contentRect.width <= 0 || contentRect.height <= 0) {
+      return false;
+    }
+
+    const clampX = (x) => Math.min(Math.max(x, contentRect.left + 1), contentRect.right - 1);
+    const probeXs = [
+      clampX(caretRect.left + 1),
+      clampX(contentRect.left + Math.min(24, Math.max(8, contentRect.width * 0.05)))
+    ];
+
+    for (const offsetY of tableEntryProbeOffsetsY) {
+      const y = direction === 'down'
+        ? caretRect.bottom + offsetY
+        : caretRect.top - offsetY;
+      if (y < 0 || y >= window.innerHeight) {
+        if (direction === 'down' && y >= window.innerHeight) break;
+        continue;
+      }
+      for (const x of probeXs) {
+        const hit = document.elementFromPoint(x, y);
+        if (!(hit instanceof Element)) {
+          continue;
+        }
+        const wrap = hit.closest('.meo-md-html-table-wrap');
+        if (!(wrap instanceof HTMLElement) || !editorView.dom.contains(wrap)) {
+          continue;
+        }
+        const input = findTableEntryInput(wrap, hit, direction);
+        if (!focusTableEntryInput(input)) {
+          continue;
+        }
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  const syncModeClasses = () => {
+    if (!view) {
+      return;
+    }
+    const isLiveModeActive = currentMode === 'live';
+    view.dom.classList.toggle('meo-mode-live', currentMode === 'live');
+    view.dom.classList.toggle('meo-mode-source', currentMode !== 'live');
+    // Keep active typography vars explicitly synced to mode so source/live
+    // font sizing and line-height don't depend on selector cascade.
+    view.dom.style.setProperty('--meo-active-editor-font', isLiveModeActive ? 'var(--meo-font-live)' : 'var(--meo-font-source)');
+    view.dom.style.setProperty('--meo-active-editor-font-weight', isLiveModeActive ? 'var(--meo-font-live-weight)' : 'var(--meo-font-source-weight)');
+    view.dom.style.setProperty('--meo-active-editor-font-size', isLiveModeActive ? 'var(--meo-font-live-size)' : 'var(--meo-font-source-size)');
+    view.dom.style.setProperty('--meo-active-editor-line-height', isLiveModeActive ? 'var(--meo-line-height-live)' : 'var(--meo-line-height-source)');
+    if (currentMode !== 'source') {
+      setSourceLinkHoverCursor(view, false);
+    }
+  };
+
+  const syncLineNumbersVisibility = () => {
+    if (!view) {
+      return;
+    }
+    view.dom.classList.toggle('meo-line-numbers-hidden', !lineNumbersVisible);
+  };
+
+  const syncGitGutterVisibility = () => {
+    if (!view) {
+      return;
+    }
+    const shouldShowGitGutter = gitGutterVisible;
+    view.dom.classList.toggle('meo-git-gutter-hidden', !shouldShowGitGutter);
+    if (!shouldShowGitGutter) {
+      gitBlameHover?.hide();
+    }
+    gitDiffOverviewRuler?.refresh();
+  };
+
+  const releasePointerCaptureIfHeld = (pointerId) => {
+    if (!view || pointerId === null) {
+      return;
+    }
+    if (view.dom.releasePointerCapture && view.dom.hasPointerCapture(pointerId)) {
+      view.dom.releasePointerCapture(pointerId);
+    }
+  };
+
+  const syncSelectionClass = () => {
+    if (!view) {
+      return;
+    }
+    const hasSelection = view.state.selection.ranges.some((range) => !range.empty);
+    view.dom.classList.toggle('has-selection', hasSelection);
+  };
+
+  const getActiveTableInput = () => {
+    if (!view) {
+      return null;
+    }
+    const active = document.activeElement;
+    if (!(active instanceof HTMLTextAreaElement)) {
+      return null;
+    }
+    if (!view.dom.contains(active)) {
+      return null;
+    }
+    return active.closest('.meo-md-html-table-wrap') ? active : null;
+  };
+
+  const measureTextareaSelectionStart = (input, index) => {
+    const doc = input.ownerDocument;
+    const mirror = doc.createElement('div');
+    const marker = doc.createElement('span');
+    const computed = window.getComputedStyle(input);
+
+    mirror.style.position = 'fixed';
+    mirror.style.left = '0';
+    mirror.style.top = '0';
+    mirror.style.visibility = 'hidden';
+    mirror.style.pointerEvents = 'none';
+    mirror.style.whiteSpace = 'pre-wrap';
+    mirror.style.overflowWrap = 'break-word';
+    mirror.style.wordBreak = 'break-word';
+    mirror.style.boxSizing = computed.boxSizing;
+    mirror.style.width = `${input.getBoundingClientRect().width}px`;
+    mirror.style.minHeight = computed.height;
+    mirror.style.padding = computed.padding;
+    mirror.style.border = computed.border;
+    mirror.style.font = computed.font;
+    mirror.style.fontFamily = computed.fontFamily;
+    mirror.style.fontSize = computed.fontSize;
+    mirror.style.fontWeight = computed.fontWeight;
+    mirror.style.fontStyle = computed.fontStyle;
+    mirror.style.letterSpacing = computed.letterSpacing;
+    mirror.style.lineHeight = computed.lineHeight;
+    mirror.style.textTransform = computed.textTransform;
+    mirror.style.textIndent = computed.textIndent;
+    mirror.style.tabSize = computed.tabSize;
+
+    mirror.textContent = input.value.slice(0, index);
+    marker.textContent = '\u200b';
+    mirror.appendChild(marker);
+    doc.body.appendChild(mirror);
+
+    const markerRect = marker.getBoundingClientRect();
+    const mirrorRect = mirror.getBoundingClientRect();
+    const inputRect = input.getBoundingClientRect();
+    const coords = {
+      left: inputRect.left + (markerRect.left - mirrorRect.left),
+      top: inputRect.top + (markerRect.top - mirrorRect.top)
+    };
+
+    mirror.remove();
+    return coords;
+  };
+
+  const getActiveTableSelectionState = (input) => {
+    const rawStart = input.selectionStart ?? 0;
+    const rawEnd = input.selectionEnd ?? rawStart;
+    if (rawStart === rawEnd) {
+      return null;
+    }
+    const selectionStart = Math.min(rawStart, rawEnd);
+    const coords = measureTextareaSelectionStart(input, selectionStart);
+    return {
+      visible: true,
+      anchorX: coords.left,
+      anchorY: coords.top
+    };
+  };
+
+  const updateActiveTableInput = (input, nextValue, anchor, head = anchor) => {
+    input.value = nextValue;
+    input.focus({ preventScroll: true });
+    input.setSelectionRange(
+      Math.min(anchor, head),
+      Math.max(anchor, head),
+      anchor <= head ? 'forward' : 'backward'
+    );
+    input.dispatchEvent(new Event('input', { bubbles: true }));
     emitSelectionChange();
+    return true;
+  };
+
+  const editActiveTableInputWithSelection = (input, transform) => {
+    const rawStart = input.selectionStart ?? 0;
+    const rawEnd = input.selectionEnd ?? rawStart;
+    const start = Math.min(rawStart, rawEnd);
+    const end = Math.max(rawStart, rawEnd);
+    return transform(input.value, start, end);
+  };
+
+  const trimTrailingNewlines = (value, start, end) => {
+    let nextEnd = end;
+    while (nextEnd > start && value.slice(nextEnd - 1, nextEnd) === '\n') {
+      nextEnd -= 1;
+    }
+    return nextEnd;
+  };
+
+  const wrapActiveTableInputSelection = (
+    input,
+    openMarker,
+    closeMarker = openMarker,
+    { toggle = true, selectWrapped = true } = {}
+  ) => {
+    return editActiveTableInputWithSelection(input, (value, start, end) => {
+      if (start === end) {
+        const insert = `${openMarker}${closeMarker}`;
+        const nextValue = value.slice(0, start) + insert + value.slice(end);
+        return updateActiveTableInput(input, nextValue, start + openMarker.length);
+      }
+
+      const trimmedEnd = trimTrailingNewlines(value, start, end);
+      if (toggle) {
+        const hasOpenMarker =
+          start >= openMarker.length && value.slice(start - openMarker.length, start) === openMarker;
+        const hasCloseMarker = value.slice(trimmedEnd, trimmedEnd + closeMarker.length) === closeMarker;
+        if (hasOpenMarker && hasCloseMarker) {
+          const nextValue =
+            value.slice(0, start - openMarker.length) +
+            value.slice(start, trimmedEnd) +
+            value.slice(trimmedEnd + closeMarker.length);
+          return updateActiveTableInput(
+            input,
+            nextValue,
+            start - openMarker.length,
+            trimmedEnd - openMarker.length
+          );
+        }
+      }
+
+      const nextValue =
+        value.slice(0, start) +
+        openMarker +
+        value.slice(start, trimmedEnd) +
+        closeMarker +
+        value.slice(trimmedEnd);
+      if (!selectWrapped) {
+        const cursor = start + openMarker.length + (trimmedEnd - start) + closeMarker.length;
+        return updateActiveTableInput(input, nextValue, cursor);
+      }
+      return updateActiveTableInput(input, nextValue, start + openMarker.length, trimmedEnd + openMarker.length);
+    });
+  };
+
+  const insertFormatInActiveTableInput = (input, action) => {
+    switch (action) {
+      case 'inlineCode':
+        return wrapActiveTableInputSelection(input, '`', '`', { toggle: false, selectWrapped: false });
+      case 'kbd':
+        return wrapActiveTableInputSelection(input, '<kbd>', '</kbd>');
+      case 'bold':
+        return wrapActiveTableInputSelection(input, '**');
+      case 'italic':
+        return wrapActiveTableInputSelection(input, '*');
+      case 'lineover':
+      case 'strike':
+        return wrapActiveTableInputSelection(input, '~~');
+      case 'link':
+        return editActiveTableInputWithSelection(input, (value, start, end) => {
+          if (start !== end) {
+            const trimmedEnd = trimTrailingNewlines(value, start, end);
+            const selectedText = value.slice(start, trimmedEnd);
+            const insert = `[${selectedText}]()`;
+            const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
+            return updateActiveTableInput(input, nextValue, start + insert.length - 1);
+          }
+
+          const insert = '[]()';
+          const nextValue = value.slice(0, start) + insert + value.slice(end);
+          return updateActiveTableInput(input, nextValue, start + 3);
+        });
+      case 'wikiLink':
+        return editActiveTableInputWithSelection(input, (value, start, end) => {
+          if (start !== end) {
+            const trimmedEnd = trimTrailingNewlines(value, start, end);
+            const selectedText = value.slice(start, trimmedEnd);
+            const insert = `[[${selectedText}]]`;
+            const nextValue = value.slice(0, start) + insert + value.slice(trimmedEnd);
+            return updateActiveTableInput(input, nextValue, start + insert.length);
+          }
+
+          const insert = '[[]]';
+          const nextValue = value.slice(0, start) + insert + value.slice(end);
+          return updateActiveTableInput(input, nextValue, start + 2);
+        });
+      default:
+        return false;
+    }
+  };
+
+  const forEachSelectedLine = (
+    state: EditorState,
+    callback: (line: { from: number; to: number; number: number }) => void
+  ): void => {
+    const seen = new Set<number>();
+    for (const range of state.selection.ranges) {
+      const fromLine = state.doc.lineAt(range.from).number;
+      const toPos = Math.max(range.from, range.to - (range.empty ? 0 : 1));
+      const toLine = state.doc.lineAt(toPos).number;
+      for (let lineNumber = fromLine; lineNumber <= toLine; lineNumber += 1) {
+        if (seen.has(lineNumber)) {
+          continue;
+        }
+        seen.add(lineNumber);
+        callback(state.doc.line(lineNumber));
+      }
+    }
+  };
+
+  const lineMarkerReplacementContext = (
+    state: EditorState,
+    line: { from: number; to: number }
+  ): MarkerReplacementContext => {
+    const lineText = state.doc.sliceString(line.from, line.to);
+    const existingMarker = existingListMarkerRegex.exec(lineText);
+    const existingHeading = existingHeadingMarkerRegex.exec(lineText);
+    const leadingWhitespace = existingMarker?.[1] ?? existingHeading?.[1] ?? /^(\s*)/.exec(lineText)[1];
+
+    const contentStart = line.from + leadingWhitespace.length;
+    let oldMarkerLen = 0;
+    if (existingMarker) {
+      oldMarkerLen = existingMarker[0].length - leadingWhitespace.length;
+    } else if (existingHeading) {
+      oldMarkerLen = existingHeading[0].length - leadingWhitespace.length;
+    }
+
+    const isExistingTask = Boolean(existingMarker && existingTaskMarkerRegex.test(existingMarker[0]));
+    return { contentStart, oldMarkerLen, isExistingTask };
+  };
+
+  const buildListFormatChangesForSelection = (state: EditorState, insert: string): ChangeSpec[] => {
+    const changes: ChangeSpec[] = [];
+    forEachSelectedLine(state, (line) => {
+      const { contentStart, oldMarkerLen } = lineMarkerReplacementContext(state, line);
+      changes.push({ from: contentStart, to: contentStart + oldMarkerLen, insert });
+    });
+    return changes;
+  };
+
+  const dispatchSelectedListFormatChanges = (
+    state: EditorState,
+    changes: ChangeSpec[],
+    shouldRenumberOrdered: boolean
+  ): void => {
+    if (!changes.length) {
+      return;
+    }
+
+    if (!shouldRenumberOrdered) {
+      view.dispatch({ changes });
+      return;
+    }
+
+    const withMarkers = state.update({ changes });
+    const renumberChanges = collectOrderedListRenumberChanges(withMarkers.state);
+    if (!renumberChanges.length) {
+      view.dispatch(withMarkers);
+      return;
+    }
+
+    view.dispatch(
+      state.update(
+        { changes },
+        { changes: renumberChanges, sequential: true }
+      )
+    );
+  };
+
+  const isSearchMatchSelection = (from, to) => {
+    if (!view || from >= to) {
+      return false;
+    }
+
+    const searchQuery = view.state.field(searchQueryField);
+    if (!searchQuery.text || to - from !== searchQuery.text.length) {
+      return false;
+    }
+
+    let isMatchSelection = false;
+    view.state.field(searchMatchField).between(from, to, (matchFrom, matchTo) => {
+      if (matchFrom === from && matchTo === to) {
+        isMatchSelection = true;
+      }
+    });
+    return isMatchSelection;
+  };
+
+  const resolveNativeSelectionAnchor = (): { anchorX: number; anchorY: number } | null => {
+    if (!view) {
+      return null;
+    }
+
+    const nativeSelection = window.getSelection();
+    if (!nativeSelection || nativeSelection.isCollapsed || nativeSelection.rangeCount === 0) {
+      return null;
+    }
+
+    let topRect: DOMRect | null = null;
+    for (let rangeIndex = 0; rangeIndex < nativeSelection.rangeCount; rangeIndex += 1) {
+      const range = nativeSelection.getRangeAt(rangeIndex);
+      const ancestor = range.commonAncestorContainer;
+      if (!view.dom.contains(ancestor)) {
+        continue;
+      }
+
+      const rects = range.getClientRects();
+      for (let rectIndex = 0; rectIndex < rects.length; rectIndex += 1) {
+        const rect = rects.item(rectIndex);
+        if (!rect || (rect.width <= 0 && rect.height <= 0)) {
+          continue;
+        }
+        if (!topRect || rect.top < topRect.top || (rect.top === topRect.top && rect.left < topRect.left)) {
+          topRect = rect;
+        }
+      }
+    }
+
+    if (!topRect) {
+      return null;
+    }
 
     return {
-        view,
-        state: view.state,
-        getText() {
-            return view.state.doc.toString();
-        },
-        selectAll() {
-            view.dispatch({
-                selection: {
-                    anchor: 0,
-                    head: view.state.doc.length,
-                },
-            });
-            return true;
-        },
-        undo() {
-            const shouldPreserveSelection = pendingExternalUndoSelectionPreserve;
-            const { anchor, head } = view.state.selection.main;
-            const applied = undo(view);
-            if (!applied) {
-                return false;
-            }
-            if (!shouldPreserveSelection) {
-                return true;
-            }
-
-            pendingExternalUndoSelectionPreserve = false;
-            const nextAnchor = Math.min(anchor, view.state.doc.length);
-            const nextHead = Math.min(head, view.state.doc.length);
-            const selection = view.state.selection.main;
-            if (selection.anchor === nextAnchor && selection.head === nextHead) {
-                return true;
-            }
-
-            view.dispatch({
-                selection: { anchor: nextAnchor, head: nextHead },
-                annotations: Transaction.addToHistory.of(false),
-            });
-            return true;
-        },
-        redo() {
-            return redo(view);
-        },
-        findNext(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
-            return findMatch(query, false, options);
-        },
-        findPrevious(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
-            return findMatch(query, true, options);
-        },
-        replaceCurrent(query, replacement, options: SearchOptions = {}) {
-            return replaceCurrentMatch(query, replacement, options);
-        },
-        replaceAll(query, replacement, options: SearchOptions = {}) {
-            if (!query) {
-                return { replaced: 0, total: 0 };
-            }
-
-            const text = view.state.doc.toString();
-            const matches = findSearchMatchRanges(text, query, options);
-            const replaced = matches.length;
-            if (!replaced) {
-                return { replaced: 0, total: 0 };
-            }
-
-            const nextText = replaceMatchRanges(text, matches, replacement);
-            view.dispatch({
-                changes: { from: 0, to: text.length, insert: nextText },
-                selection: { anchor: 0 },
-            });
-            return { replaced, total: countMatches(nextText, query, options) };
-        },
-        countMatches(query, options: SearchOptions = {}) {
-            if (!query) {
-                return 0;
-            }
-            return countMatches(view.state.doc.toString(), query, options);
-        },
-        setSearchQuery(query, options: SearchOptions = {}) {
-            const nextQuery = createSearchQueryState(query, options);
-            const currentQuery = view.state.field(searchQueryField);
-            if (currentQuery.text === nextQuery.text && currentQuery.wholeWord === nextQuery.wholeWord && currentQuery.caseSensitive === nextQuery.caseSensitive) {
-                return;
-            }
-            view.dispatch({
-                effects: setSearchQueryEffect.of(nextQuery),
-            });
-        },
-        hasFocus() {
-            return view.hasFocus;
-        },
-        focus() {
-            const activeTableInput = getActiveTableInput();
-            if (activeTableInput) {
-                activeTableInput.focus({ preventScroll: true });
-                return;
-            }
-            view.focus();
-        },
-        destroy() {
-            gitBlameHover?.destroy();
-            gitBlameHover = null;
-            gitDiffOverviewRuler?.destroy();
-            gitDiffOverviewRuler = null;
-            if (onScroll) {
-                view.scrollDOM.removeEventListener("scroll", onScroll);
-                onScroll = null;
-            }
-            if (onTableInteraction) {
-                view.dom.removeEventListener("meo-table-interaction", onTableInteraction);
-                onTableInteraction = null;
-            }
-            if (onTableOpenLink) {
-                view.dom.removeEventListener("meo-open-link", onTableOpenLink);
-                onTableOpenLink = null;
-            }
-            if (onTableSelectionChange) {
-                view.dom.removeEventListener("meo-table-selection-change", onTableSelectionChange);
-                onTableSelectionChange = null;
-            }
-            if (capturedPointerId !== null) {
-                releasePointerCaptureIfHeld(capturedPointerId);
-                capturedPointerId = null;
-            }
-            setSourceLinkHoverCursor(view, false);
-            view.destroy();
-        },
-        setText(textValue) {
-            gitBlameHover?.hide();
-            const currentText = view.state.doc.toString();
-            const syncChange = findSyncChange(currentText, textValue);
-            if (!syncChange) {
-                return;
-            }
-
-            const { anchor, head } = view.state.selection.main;
-            const newLength = textValue.length;
-            const mappedAnchor = Math.min(mapPositionThroughChange(anchor, syncChange), newLength);
-            const mappedHead = Math.min(mapPositionThroughChange(head, syncChange), newLength);
-            applyingExternal = true;
-            view.dispatch({
-                changes: syncChange,
-                selection: { anchor: mappedAnchor, head: mappedHead },
-            });
-            applyingExternal = false;
-            pendingExternalUndoSelectionPreserve = true;
-            syncSelectionClass();
-            emitSelectionChange();
-        },
-        setMode(mode) {
-            gitBlameHover?.hide();
-            const nextMode = mode === "live" ? "live" : "source";
-            if (nextMode === currentMode) {
-                return;
-            }
-
-            const topPosition = computeTopVisiblePosition();
-
-            const previousMode = currentMode;
-            currentMode = nextMode;
-            try {
-                view.dispatch({
-                    effects: [modeCompartment.reconfigure(nextMode === "live" ? liveModeExtensions() : sourceMode()), gitGutterCompartment.reconfigure(nextMode === "live" ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()), vimCompartment.reconfigure(vimExtensionsForState())],
-                });
-                forceParsing(view, view.state.doc.length, 500);
-            } catch (error) {
-                currentMode = previousMode;
-                syncModeClasses();
-                throw error;
-            }
-            syncModeClasses();
-            syncGitGutterVisibility();
-
-            restoreTopVisibleLine(topPosition.lineNumber, topPosition.lineOffset, { syncCursor: false });
-        },
-        setLineNumbers(visible) {
-            const nextVisible = visible !== false;
-            if (nextVisible === lineNumbersVisible) {
-                return;
-            }
-            lineNumbersVisible = nextVisible;
-            syncLineNumbersVisibility();
-        },
-        setGitGutterVisible(visible) {
-            const nextVisible = visible !== false;
-            if (nextVisible === gitGutterVisible) {
-                return;
-            }
-            gitGutterVisible = nextVisible;
-            syncGitGutterVisibility();
-        },
-        setVimMode(enabled) {
-            const nextEnabled = enabled === true;
-            if (nextEnabled === vimModeEnabled) {
-                return;
-            }
-            vimModeEnabled = nextEnabled;
-            view.dispatch({
-                effects: vimCompartment.reconfigure(vimExtensionsForState()),
-            });
-        },
-        setVimKeybindings(bindings: Array<{ before: string; after: string; mode: string; recursive: boolean }>, leaderKey: string) {
-            applyVimKeybindings(bindings, leaderKey);
-        },
-        insertFormat(action, level) {
-            const activeTableInput = getActiveTableInput();
-            if (activeTableInput) {
-                return insertFormatInActiveTableInput(activeTableInput, action);
-            }
-
-            const { state } = view;
-            const selection = state.selection.main;
-            let cachedInlineSelection: InlineSelectionRange | null = null;
-            const inlineSelection = (): InlineSelectionRange => {
-                if (cachedInlineSelection) {
-                    return cachedInlineSelection;
-                }
-                cachedInlineSelection = currentMode === "live" ? normalizeLiveInlineSelectionForListContent(state, selection) : selection;
-                return cachedInlineSelection;
-            };
-
-            let insert = "";
-            switch (action) {
-                case "heading":
-                    insert = `${"#".repeat(level ?? 1)} `;
-                    break;
-                case "bulletList":
-                    insert = "- ";
-                    break;
-                case "numberedList":
-                    insert = "1. ";
-                    break;
-                case "task":
-                    insert = "- [ ] ";
-                    break;
-                case "codeBlock":
-                    return insertCodeBlock(view, selection);
-                case "inlineCode":
-                    return insertInlineCode(view, inlineSelection());
-                case "kbd":
-                    return insertKbd(view, inlineSelection());
-                case "bold":
-                    return insertInlineFence(view, inlineSelection(), "**");
-                case "italic":
-                    return insertInlineFence(view, inlineSelection(), "*");
-                case "lineover":
-                case "strike":
-                    return insertInlineFence(view, inlineSelection(), "~~");
-                case "quote":
-                    return insertQuote(view, selection);
-                case "hr":
-                    return insertHr(view, selection);
-                case "table":
-                    return insertTable(view, selection, level?.cols, level?.rows);
-                case "link":
-                    return insertLink(view, inlineSelection());
-                case "wikiLink":
-                    return insertWikiLink(view, inlineSelection());
-                case "image":
-                    return insertImage(view, inlineSelection());
-            }
-
-            if (!selection.empty && (action === "bulletList" || action === "numberedList")) {
-                const changes = buildListFormatChangesForSelection(state, insert);
-                dispatchSelectedListFormatChanges(state, changes, action === "numberedList");
-                return;
-            }
-
-            const line = state.doc.lineAt(selection.from);
-            const { contentStart, oldMarkerLen, isExistingTask } = lineMarkerReplacementContext(state, line);
-            if (action === "task" && isExistingTask) {
-                return;
-            }
-
-            const newMarkerLen = insert.length;
-            const cursorOffset = selection.from - (contentStart + oldMarkerLen);
-            const newCursorPos = contentStart + newMarkerLen + Math.max(0, cursorOffset);
-
-            view.dispatch({
-                changes: { from: contentStart, to: contentStart + oldMarkerLen, insert },
-                selection: { anchor: newCursorPos },
-            });
-        },
-        getHeadings() {
-            return extractHeadings(view.state);
-        },
-        moveHeadingSection(sourceHeadingFrom, targetHeadingFrom, placement) {
-            if (placement !== "before" && placement !== "after") {
-                return false;
-            }
-
-            const sections = extractHeadingSections(view.state);
-            const source = sections.find((heading) => heading.from === sourceHeadingFrom);
-            const target = sections.find((heading) => heading.from === targetHeadingFrom);
-            if (!source || !target) {
-                return false;
-            }
-
-            const insertionPoint = placement === "before" ? target.sectionFrom : target.sectionTo;
-            if (insertionPoint > source.sectionFrom && insertionPoint < source.sectionTo) {
-                return false;
-            }
-
-            const currentText = view.state.doc.toString();
-            const movedText = currentText.slice(source.sectionFrom, source.sectionTo);
-            if (!movedText) {
-                return false;
-            }
-
-            const textWithoutSource = currentText.slice(0, source.sectionFrom) + currentText.slice(source.sectionTo);
-            const sourceLength = source.sectionTo - source.sectionFrom;
-            const adjustedInsertionPoint = insertionPoint >= source.sectionTo ? insertionPoint - sourceLength : insertionPoint;
-            const nextText = textWithoutSource.slice(0, adjustedInsertionPoint) + movedText + textWithoutSource.slice(adjustedInsertionPoint);
-
-            if (nextText === currentText) {
-                return false;
-            }
-
-            const nextAnchor = Math.min(adjustedInsertionPoint, nextText.length);
-            view.dispatch({
-                changes: { from: 0, to: currentText.length, insert: nextText },
-                selection: { anchor: nextAnchor },
-                effects: EditorView.scrollIntoView(nextAnchor, { y: "start" }),
-            });
-            return true;
-        },
-        scrollToLine(lineNumber, align = "center") {
-            const line = view.state.doc.line(Math.min(lineNumber, view.state.doc.lines));
-            applyRevealSelection(line.from, line.from, { focusEditor: true, align });
-        },
-        restoreTopLine(lineNumber, lineOffset) {
-            restoreTopVisibleLine(lineNumber, lineOffset, { syncCursor: true });
-        },
-        getTopVisiblePosition() {
-            const position = computeTopVisiblePosition();
-            return {
-                line: position.lineNumber,
-                lineOffset: position.lineOffset,
-            };
-        },
-        getTopVisibleLine() {
-            return computeTopVisiblePosition().lineNumber;
-        },
-        revealSelection(anchor, head, options) {
-            applyRevealSelection(anchor, head, options);
-        },
-        refreshSelectionOverlay() {
-            emitSelectionChange();
-        },
-        refreshDecorations() {
-            view.dispatch({ effects: refreshDecorationsEffect.of(null) });
-        },
-        refreshLayout() {
-            view.requestMeasure();
-            if (currentMode === "live") {
-                forceParsing(view, view.state.doc.length, 500);
-            }
-            emitSelectionChange();
-        },
-        setGitBaseline(snapshot) {
-            applyGitBaseline(view, snapshot);
-            gitBlameHover?.hide();
-            gitDiffOverviewRuler?.refresh();
-        },
-        clearGitUiTransientState() {
-            gitBlameHover?.hide();
-        },
+      anchorX: topRect.left,
+      anchorY: topRect.top
     };
+  };
+
+  const emitSelectionChange = () => {
+    if (!view || typeof onSelectionChange !== 'function') {
+      return;
+    }
+
+    const activeTableInput = getActiveTableInput();
+    if (activeTableInput) {
+      onSelectionChange(getActiveTableSelectionState(activeTableInput) ?? { visible: false });
+      return;
+    }
+
+    const selection = view.state.selection.main;
+    if (selection.empty) {
+      onSelectionChange({ visible: false });
+      return;
+    }
+
+    const from = Math.min(selection.from, selection.to);
+    const to = Math.max(selection.from, selection.to);
+    if (isSearchMatchSelection(from, to)) {
+      onSelectionChange({ visible: false });
+      return;
+    }
+
+    if (!isRegularInlineSelection(view.state, from, to)) {
+      onSelectionChange({ visible: false });
+      return;
+    }
+
+    const nativeAnchor = resolveNativeSelectionAnchor();
+    if (nativeAnchor) {
+      onSelectionChange({
+        visible: true,
+        from,
+        to,
+        anchorX: nativeAnchor.anchorX,
+        anchorY: nativeAnchor.anchorY
+      });
+      return;
+    }
+
+    const fromCoords = view.coordsAtPos(from);
+    const toCoords = view.coordsAtPos(to);
+    if (!fromCoords || !toCoords) {
+      onSelectionChange({ visible: false });
+      return;
+    }
+
+    const fromCharCoords = view.coordsForChar(from);
+    const anchorX = fromCharCoords?.left ?? fromCoords.left;
+    const anchorY = fromCharCoords ? Math.min(fromCoords.top, fromCharCoords.top) : fromCoords.top;
+
+    onSelectionChange({
+      visible: true,
+      from,
+      to,
+      anchorX,
+      anchorY
+    });
+  };
+
+  const isHistoryReplayUpdate = (update: ViewUpdate): boolean => {
+    return update.transactions.some((transaction) => {
+      const userEvent = transaction.annotation(Transaction.userEvent);
+      return (
+        typeof userEvent === 'string' &&
+        (userEvent === 'undo' || userEvent === 'redo' || userEvent.startsWith('undo.') || userEvent.startsWith('redo.'))
+      );
+    });
+  };
+
+  const inlineCodeCaretPosition = (state, position) => {
+    let node = syntaxTree(state).resolveInner(position, -1);
+    while (node && node.name !== 'InlineCode' && node.name !== 'CodeText') {
+      node = node.parent;
+    }
+    if (!node) {
+      return null;
+    }
+
+    const text = state.doc.sliceString(node.from, node.to);
+    const openTicks = (/^`+/.exec(text) ?? [''])[0].length;
+    const closeTicks = (/`+$/.exec(text) ?? [''])[0].length;
+    if (!openTicks || !closeTicks) {
+      return null;
+    }
+
+    const min = node.from + openTicks;
+    const max = node.to - closeTicks;
+    if (min > max) {
+      return null;
+    }
+    if (position < min) {
+      return min;
+    }
+    if (position > max) {
+      return max;
+    }
+    return null;
+  };
+
+  const selectSearchMatch = (from, to, { focusEditor = true } = {}) => {
+    view.dispatch({
+      selection: { anchor: from, head: to },
+      effects: EditorView.scrollIntoView(from, { y: 'center' })
+    });
+    if (focusEditor) {
+      view.focus();
+    }
+  };
+
+  const applyRevealSelection = (anchor, head = anchor, { focusEditor = true, align = 'center' } = {}) => {
+    const max = view.state.doc.length;
+    const nextAnchor = Math.max(0, Math.min(anchor, max));
+    const nextHead = Math.max(0, Math.min(head, max));
+    const y = align === 'top' ? 'start' : 'center';
+    const selection = view.state.selection.main;
+
+    if (selection.anchor === nextAnchor && selection.head === nextHead) {
+      view.dispatch({
+        effects: EditorView.scrollIntoView(nextAnchor, { y })
+      });
+      if (focusEditor) {
+        view.focus();
+      }
+      return;
+    }
+
+    view.dispatch({
+      selection: { anchor: nextAnchor, head: nextHead },
+      effects: EditorView.scrollIntoView(nextAnchor, { y })
+    });
+    if (focusEditor) {
+      view.focus();
+    }
+  };
+
+  const TOP_LINE_VISIBILITY_EPSILON = 0.5;
+  const SCROLL_RESTORE_EPSILON = 0.5;
+  const SCROLL_RESTORE_MAX_ATTEMPTS = 3;
+
+  const getTopLineMetrics = (scrollTopValue = view.scrollDOM.scrollTop) => {
+    const scrollTop = Math.max(0, scrollTopValue);
+    const lineBlock = view.lineBlockAtHeight(scrollTop);
+    const line = view.state.doc.lineAt(lineBlock.from);
+    return {
+      line,
+      lineBlock,
+      hiddenTopPixels: scrollTop - lineBlock.top
+    };
+  };
+
+  const topVisibleLineAtCurrentScroll = () => {
+    const { line, hiddenTopPixels } = getTopLineMetrics();
+    if (hiddenTopPixels <= TOP_LINE_VISIBILITY_EPSILON) {
+      return line;
+    }
+
+    const nextLineNumber = Math.min(view.state.doc.lines, line.number + 1);
+    return view.state.doc.line(nextLineNumber);
+  };
+
+  const syncCursorToTopVisibleLine = () => {
+    const line = topVisibleLineAtCurrentScroll();
+    const anchor = line.from;
+    const selection = view.state.selection.main;
+    if (selection.anchor === anchor && selection.head === anchor) {
+      return;
+    }
+    view.dispatch({
+      selection: { anchor },
+      annotations: Transaction.addToHistory.of(false)
+    });
+  };
+
+  const computeTopVisiblePosition = () => {
+    const { line, hiddenTopPixels } = getTopLineMetrics();
+    return {
+      lineNumber: line.number,
+      lineOffset: normalizeTopLineOffset(hiddenTopPixels)
+    };
+  };
+
+  const restoreTopVisibleLine = (lineNumber, lineOffset = 0, { syncCursor = true } = {}) => {
+    const targetLineNumber = Math.min(Math.max(1, Math.floor(lineNumber || 1)), view.state.doc.lines);
+    const targetOffset = normalizeTopLineOffset(lineOffset);
+    let attempts = 0;
+    const restoreScroll = () => {
+      if (!view || ++attempts > SCROLL_RESTORE_MAX_ATTEMPTS) {
+        if (syncCursor && view) {
+          syncCursorToTopVisibleLine();
+        }
+        return;
+      }
+      const targetLine = view.state.doc.line(targetLineNumber);
+      const targetTop = Math.max(0, view.lineBlockAt(targetLine.from).top + targetOffset);
+      const currentTop = view.scrollDOM.scrollTop;
+      view.scrollDOM.scrollTop = targetTop;
+      if (Math.abs(currentTop - targetTop) <= SCROLL_RESTORE_EPSILON) {
+        if (syncCursor) {
+          syncCursorToTopVisibleLine();
+        }
+        return;
+      }
+      requestAnimationFrame(restoreScroll);
+    };
+    restoreScroll();
+  };
+
+  const findMatch = (
+    query,
+    backward = false,
+    { focusEditor = true, ...searchOptions }: SearchOptions & { focusEditor?: boolean } = {}
+  ) => {
+    if (!query) {
+      return { found: false, current: 0, total: 0 };
+    }
+
+    const text = view.state.doc.toString();
+    const selection = view.state.selection.main;
+    const from = Math.min(selection.from, selection.to);
+    const to = Math.max(selection.from, selection.to);
+    const matches = findSearchMatchRanges(text, query, searchOptions);
+    const total = matches.length;
+
+    if (!total) {
+      return { found: false, current: 0, total };
+    }
+
+    let matchIndex = -1;
+    if (backward) {
+      for (let index = matches.length - 1; index >= 0; index -= 1) {
+        if (matches[index].start < from) {
+          matchIndex = index;
+          break;
+        }
+      }
+      if (matchIndex < 0) {
+        matchIndex = matches.length - 1;
+      }
+    } else {
+      for (let index = 0; index < matches.length; index += 1) {
+        if (matches[index].start >= to) {
+          matchIndex = index;
+          break;
+        }
+      }
+      if (matchIndex < 0) {
+        matchIndex = 0;
+      }
+    }
+
+    const match = matches[matchIndex];
+    selectSearchMatch(match.start, match.end, { focusEditor });
+    return {
+      found: true,
+      current: matchIndex + 1,
+      total
+    };
+  };
+
+  const replaceCurrentMatch = (query, replacement, options: SearchOptions = {}) => {
+    if (!query) {
+      return { replaced: false, found: false, current: 0, total: 0 };
+    }
+
+    const text = view.state.doc.toString();
+    const selection = view.state.selection.main;
+    const from = Math.min(selection.from, selection.to);
+    const to = Math.max(selection.from, selection.to);
+    const matches = findSearchMatchRanges(text, query, options);
+    const matchIndex = findSelectedSearchMatchIndex(matches, from, to);
+    if (matchIndex < 0) {
+      return { replaced: false, ...findMatch(query, false, options) };
+    }
+
+    view.dispatch({
+      changes: { from, to, insert: replacement },
+      selection: { anchor: from, head: from + replacement.length }
+    });
+    const nextMatch = findMatch(query, false, options);
+    if (nextMatch.found) {
+      return { replaced: true, ...nextMatch };
+    }
+
+    const remaining = countMatches(view.state.doc.toString(), query, options);
+    return { replaced: true, found: false, current: 0, total: remaining };
+  };
+
+  const state = EditorState.create({
+    doc: text,
+    selection: { anchor: initialCursorPos },
+    extensions: [
+      EditorState.tabSize.of(4),
+      indentUnit.of('  '),
+      vimCompartment.of(vimExtensionsForState()),
+      keymap.of([
+        { key: 'Tab', run: (view) => indentListByTwoSpaces(view) || indentMore(view) },
+        { key: 'Shift-Tab', run: (view) => outdentListByTwoSpaces(view) || indentLess(view) },
+        { key: 'Backspace', run: deleteBackwardSmart },
+        { key: 'ArrowLeft', run: (view) => isLiveMode(view) && handleArrowLeftAtListContentStart(view) },
+        { key: 'ArrowRight', run: (view) => isLiveMode(view) && handleArrowRightAtListLineStart(view) },
+        {
+          key: 'Enter',
+          run: (view) =>
+            handleEnterContinueQuotedCodeBlock(view) ||
+            handleEnterOnEmptyListItem(view) ||
+            handleEnterAtListContentStart(view) ||
+            handleEnterContinueList(view) ||
+            handleEnterBeforeNestedList(view)
+        },
+        { key: 'Shift-Enter', run: insertTableCellLineBreak },
+        { key: 'ArrowUp', run: (view) => tryEnterAdjacentTable(view, 'up') },
+        { key: 'ArrowDown', run: (view) => tryEnterAdjacentTable(view, 'down') },
+        ...markdownKeymap,
+        ...defaultKeymap,
+        ...historyKeymap
+      ]),
+      history(),
+      lineNumbers(),
+      ...gitDiffGutterBaselineExtensions(),
+      gitGutterCompartment.of(startMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()),
+      highlightActiveLineGutter(),
+      highlightActiveLine(),
+      EditorView.lineWrapping,
+      scrollPastEnd(),
+      EditorView.domEventHandlers({
+        pointerdown(event, view) {
+          if (event.button !== 0) {
+            frontmatterBoundaryClick = null;
+            return false;
+          }
+          if (openLinkIfModifierClick(event, view)) {
+            frontmatterBoundaryClick = null;
+            return true;
+          }
+
+          const target = event.target;
+          const targetElement = targetElementFrom(target);
+          if (!(target instanceof Node) || !view.contentDOM.contains(target)) {
+            return false;
+          }
+
+          trackFrontmatterBoundaryClick(event, view);
+
+          if (targetElement && targetElement.closest('.meo-mermaid-zoom-controls')) {
+            event.preventDefault();
+            event.stopPropagation();
+            return true;
+          }
+
+          if (targetElement && targetElement.closest('.meo-task-checkbox')) {
+            checkboxClick = { pointerId: event.pointerId };
+            return false;
+          }
+
+          // Let interactive HTML table widget controls handle focus/click natively.
+          if (targetElement && targetElement.closest('.meo-md-html-table-wrap')) {
+            inlineCodeClick = null;
+            checkboxClick = null;
+            return false;
+          }
+
+          inlineCodeClick = {
+            pointerId: event.pointerId,
+            inInlineCode:
+              currentMode === 'live' &&
+              targetElement &&
+              targetElement.closest('.meo-md-inline-code') !== null
+          };
+
+          if (view.dom.setPointerCapture) {
+            view.dom.setPointerCapture(event.pointerId);
+            capturedPointerId = event.pointerId;
+          }
+          return false;
+        },
+        pointerup(event, view) {
+          if (checkboxClick?.pointerId === event.pointerId) {
+            frontmatterBoundaryClick = null;
+            checkboxClick = null;
+            return false;
+          }
+
+          if (capturedPointerId !== event.pointerId) {
+            if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
+              frontmatterBoundaryClick = null;
+            }
+            return false;
+          }
+
+          releasePointerCaptureIfHeld(event.pointerId);
+          capturedPointerId = null;
+
+          if (
+            inlineCodeClick?.pointerId === event.pointerId &&
+            inlineCodeClick.inInlineCode &&
+            isLiveMode(view)
+          ) {
+            const { head, empty } = view.state.selection.main;
+            if (empty) {
+              const clamped = inlineCodeCaretPosition(view.state, head);
+              if (clamped !== null && clamped !== head) {
+                view.dispatch({ selection: { anchor: clamped } });
+              }
+            }
+          }
+
+          if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
+            if (isLiveMode(view)) {
+              const selection = view.state.selection.main;
+              if (selection.empty && selection.head !== frontmatterBoundaryClick.cursorEnd) {
+                view.dispatch({ selection: { anchor: frontmatterBoundaryClick.cursorEnd } });
+              }
+            }
+            frontmatterBoundaryClick = null;
+          }
+
+          if (isLiveMode(view)) {
+            const { head, empty } = view.state.selection.main;
+            if (empty) {
+              const emptyQuoteCursorEnd = emptyBlockquoteLineCursorEnd(view.state, head);
+              if (emptyQuoteCursorEnd !== null && head < emptyQuoteCursorEnd) {
+                view.dispatch({ selection: { anchor: emptyQuoteCursorEnd } });
+                return false;
+              }
+
+              const node = resolvedSyntaxTree(view.state).resolveInner(head, -1);
+              if (node.name === 'HorizontalRule') {
+                const line = view.state.doc.lineAt(head);
+                const lineText = view.state.doc.sliceString(line.from, line.to);
+                const hrMatch = /^[ \t]*(-{3,}|\*{3,}|_{3,})/.exec(lineText);
+                if (hrMatch) {
+                  const cursorEnd = line.from + hrMatch[0].length;
+                  if (head !== cursorEnd) {
+                    view.dispatch({ selection: { anchor: cursorEnd } });
+                  }
+                }
+              }
+            }
+          }
+
+          inlineCodeClick = null;
+          return false;
+        },
+        pointercancel(event, _view) {
+          if (capturedPointerId !== event.pointerId) {
+            if (frontmatterBoundaryClick?.pointerId === event.pointerId) {
+              frontmatterBoundaryClick = null;
+            }
+            return false;
+          }
+
+          releasePointerCaptureIfHeld(event.pointerId);
+          capturedPointerId = null;
+          frontmatterBoundaryClick = null;
+          inlineCodeClick = null;
+          checkboxClick = null;
+          return false;
+        },
+        pointermove(event, view) {
+          updateSourceLinkHoverCursor(event, view);
+          return false;
+        },
+        pointerleave(_event, view) {
+          setSourceLinkHoverCursor(view, false);
+          return false;
+        }
+      }),
+      ...headingCollapseSharedExtensions(),
+      modeCompartment.of(startMode === 'live' ? liveModeExtensions() : sourceMode()),
+      searchQueryField,
+      searchMatchField,
+      EditorView.updateListener.of((update) => {
+        syncModeClasses();
+        syncLineNumbersVisibility();
+        syncGitGutterVisibility();
+
+        if (update.selectionSet) {
+          syncSelectionClass();
+          emitSelectionChange();
+        } else if (update.viewportChanged) {
+          emitSelectionChange();
+          onViewportChange?.();
+        }
+
+        if (!update.docChanged || applyingExternal || applyingRenumber) {
+          return;
+        }
+
+        gitBlameHover?.hide();
+
+        pendingExternalUndoSelectionPreserve = false;
+
+        if (isHistoryReplayUpdate(update)) {
+          onApplyChanges(update.state.doc.toString());
+          return;
+        }
+
+        const renumberChanges = collectOrderedListRenumberChanges(update.state);
+        if (renumberChanges.length) {
+          applyingRenumber = true;
+          view.dispatch({
+            changes: renumberChanges,
+            annotations: Transaction.addToHistory.of(false)
+          });
+          applyingRenumber = false;
+          onApplyChanges(view.state.doc.toString());
+          return;
+        }
+
+        onApplyChanges(update.state.doc.toString());
+      })
+    ]
+  });
+
+  const initialScrollTo = (() => {
+    if (typeof initialTopLine !== 'number' || !Number.isFinite(initialTopLine)) {
+      return undefined;
+    }
+    const lineNumber = Math.min(Math.max(1, Math.floor(initialTopLine)), state.doc.lines);
+    const line = state.doc.line(lineNumber);
+    return EditorView.scrollIntoView(line.from, { y: 'start' });
+  })();
+
+  view = new EditorView({
+    state,
+    parent,
+    scrollTo: initialScrollTo
+  });
+  if (typeof initialTopLine === 'number' && Number.isFinite(initialTopLine)) {
+    restoreTopVisibleLine(initialTopLine, initialTopLineOffset, { syncCursor: true });
+  }
+  onTableInteraction = (event) => {
+    const active = Boolean(event?.detail?.active);
+    setTableInteractionActive(active);
+  };
+  view.dom.addEventListener('meo-table-interaction', onTableInteraction);
+  onTableOpenLink = (event) => {
+    const href = event?.detail?.href;
+    if (typeof href !== 'string' || !href) {
+      return;
+    }
+    onOpenLink?.(href);
+  };
+  view.dom.addEventListener('meo-open-link', onTableOpenLink);
+  onTableSelectionChange = () => {
+    emitSelectionChange();
+  };
+  view.dom.addEventListener('meo-table-selection-change', onTableSelectionChange);
+  onScroll = () => {
+    emitSelectionChange();
+    gitBlameHover?.hide();
+    onViewportChange?.();
+  };
+  view.scrollDOM.addEventListener('scroll', onScroll, { passive: true });
+  if (typeof onRequestGitBlame === 'function') {
+    gitBlameHover = createGitBlameHoverController({
+      view,
+      getMode: () => currentMode,
+      requestBlame: onRequestGitBlame,
+      openRevisionForLine: onOpenGitRevisionForLine,
+      openWorktreeForLine: onOpenGitWorktreeForLine
+    });
+  }
+  gitDiffOverviewRuler = createGitDiffOverviewRulerController({
+    view,
+    getMode: () => currentMode,
+    isGitChangesVisible: () => gitGutterVisible
+  });
+  syncModeClasses();
+  syncLineNumbersVisibility();
+  syncGitGutterVisibility();
+  syncSelectionClass();
+  emitSelectionChange();
+
+  return {
+    view,
+    state: view.state,
+    getText() {
+      return view.state.doc.toString();
+    },
+    selectAll() {
+      view.dispatch({
+        selection: {
+          anchor: 0,
+          head: view.state.doc.length
+        }
+      });
+      return true;
+    },
+    undo() {
+      const shouldPreserveSelection = pendingExternalUndoSelectionPreserve;
+      const { anchor, head } = view.state.selection.main;
+      const applied = undo(view);
+      if (!applied) {
+        return false;
+      }
+      if (!shouldPreserveSelection) {
+        return true;
+      }
+
+      pendingExternalUndoSelectionPreserve = false;
+      const nextAnchor = Math.min(anchor, view.state.doc.length);
+      const nextHead = Math.min(head, view.state.doc.length);
+      const selection = view.state.selection.main;
+      if (selection.anchor === nextAnchor && selection.head === nextHead) {
+        return true;
+      }
+
+      view.dispatch({
+        selection: { anchor: nextAnchor, head: nextHead },
+        annotations: Transaction.addToHistory.of(false)
+      });
+      return true;
+    },
+    redo() {
+      return redo(view);
+    },
+    findNext(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
+      return findMatch(query, false, options);
+    },
+    findPrevious(query, options: SearchOptions & { focusEditor?: boolean } = {}) {
+      return findMatch(query, true, options);
+    },
+    replaceCurrent(query, replacement, options: SearchOptions = {}) {
+      return replaceCurrentMatch(query, replacement, options);
+    },
+    replaceAll(query, replacement, options: SearchOptions = {}) {
+      if (!query) {
+        return { replaced: 0, total: 0 };
+      }
+
+      const text = view.state.doc.toString();
+      const matches = findSearchMatchRanges(text, query, options);
+      const replaced = matches.length;
+      if (!replaced) {
+        return { replaced: 0, total: 0 };
+      }
+
+      const nextText = replaceMatchRanges(text, matches, replacement);
+      view.dispatch({
+        changes: { from: 0, to: text.length, insert: nextText },
+        selection: { anchor: 0 }
+      });
+      return { replaced, total: countMatches(nextText, query, options) };
+    },
+    countMatches(query, options: SearchOptions = {}) {
+      if (!query) {
+        return 0;
+      }
+      return countMatches(view.state.doc.toString(), query, options);
+    },
+    setSearchQuery(query, options: SearchOptions = {}) {
+      const nextQuery = createSearchQueryState(query, options);
+      const currentQuery = view.state.field(searchQueryField);
+      if (
+        currentQuery.text === nextQuery.text &&
+        currentQuery.wholeWord === nextQuery.wholeWord &&
+        currentQuery.caseSensitive === nextQuery.caseSensitive
+      ) {
+        return;
+      }
+      view.dispatch({
+        effects: setSearchQueryEffect.of(nextQuery)
+      });
+    },
+    hasFocus() {
+      return view.hasFocus;
+    },
+    focus() {
+      const activeTableInput = getActiveTableInput();
+      if (activeTableInput) {
+        activeTableInput.focus({ preventScroll: true });
+        return;
+      }
+      view.focus();
+    },
+    destroy() {
+      gitBlameHover?.destroy();
+      gitBlameHover = null;
+      gitDiffOverviewRuler?.destroy();
+      gitDiffOverviewRuler = null;
+      if (onScroll) {
+        view.scrollDOM.removeEventListener('scroll', onScroll);
+        onScroll = null;
+      }
+      if (onTableInteraction) {
+        view.dom.removeEventListener('meo-table-interaction', onTableInteraction);
+        onTableInteraction = null;
+      }
+      if (onTableOpenLink) {
+        view.dom.removeEventListener('meo-open-link', onTableOpenLink);
+        onTableOpenLink = null;
+      }
+      if (onTableSelectionChange) {
+        view.dom.removeEventListener('meo-table-selection-change', onTableSelectionChange);
+        onTableSelectionChange = null;
+      }
+      if (capturedPointerId !== null) {
+        releasePointerCaptureIfHeld(capturedPointerId);
+        capturedPointerId = null;
+      }
+      setSourceLinkHoverCursor(view, false);
+      view.destroy();
+    },
+    setText(textValue) {
+      gitBlameHover?.hide();
+      const currentText = view.state.doc.toString();
+      const syncChange = findSyncChange(currentText, textValue);
+      if (!syncChange) {
+        return;
+      }
+
+      const { anchor, head } = view.state.selection.main;
+      const newLength = textValue.length;
+      const mappedAnchor = Math.min(mapPositionThroughChange(anchor, syncChange), newLength);
+      const mappedHead = Math.min(mapPositionThroughChange(head, syncChange), newLength);
+      applyingExternal = true;
+      view.dispatch({
+        changes: syncChange,
+        selection: { anchor: mappedAnchor, head: mappedHead }
+      });
+      applyingExternal = false;
+      pendingExternalUndoSelectionPreserve = true;
+      syncSelectionClass();
+      emitSelectionChange();
+    },
+    setMode(mode) {
+      gitBlameHover?.hide();
+      const nextMode = mode === 'live' ? 'live' : 'source';
+      if (nextMode === currentMode) {
+        return;
+      }
+
+      const topPosition = computeTopVisiblePosition();
+
+      const previousMode = currentMode;
+      currentMode = nextMode;
+      try {
+        view.dispatch({
+          effects: [
+            modeCompartment.reconfigure(nextMode === 'live' ? liveModeExtensions() : sourceMode()),
+            gitGutterCompartment.reconfigure(
+              nextMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()
+            ),
+            vimCompartment.reconfigure(vimExtensionsForState())
+          ]
+        });
+        forceParsing(view, view.state.doc.length, 500);
+      } catch (error) {
+        currentMode = previousMode;
+        syncModeClasses();
+        throw error;
+      }
+      syncModeClasses();
+      syncGitGutterVisibility();
+
+      restoreTopVisibleLine(topPosition.lineNumber, topPosition.lineOffset, { syncCursor: false });
+    },
+    setLineNumbers(visible) {
+      const nextVisible = visible !== false;
+      if (nextVisible === lineNumbersVisible) {
+        return;
+      }
+      lineNumbersVisible = nextVisible;
+      syncLineNumbersVisibility();
+    },
+    setGitGutterVisible(visible) {
+      const nextVisible = visible !== false;
+      if (nextVisible === gitGutterVisible) {
+        return;
+      }
+      gitGutterVisible = nextVisible;
+      syncGitGutterVisibility();
+    },
+    setVimMode(enabled) {
+      const nextEnabled = enabled === true;
+      if (nextEnabled === vimModeEnabled) {
+        return;
+      }
+      vimModeEnabled = nextEnabled;
+      if (vimModeEnabled) {
+        applyVimKeybindings(vimKeybindings, vimLeader);
+      } else {
+        clearVimKeybindings();
+      }
+      view.dispatch({
+        effects: vimCompartment.reconfigure(vimExtensionsForState())
+      });
+    },
+    setVimKeybindings(bindings: Array<{ before: string; after: string; mode: string; recursive: boolean }>, leaderKey: string) {
+      vimKeybindings = bindings;
+      vimLeader = leaderKey;
+      if (vimModeEnabled) {
+        applyVimKeybindings(vimKeybindings, vimLeader);
+      }
+    },
+    insertFormat(action, level) {
+      const activeTableInput = getActiveTableInput();
+      if (activeTableInput) {
+        return insertFormatInActiveTableInput(activeTableInput, action);
+      }
+
+      const { state } = view;
+      const selection = state.selection.main;
+      let cachedInlineSelection: InlineSelectionRange | null = null;
+      const inlineSelection = (): InlineSelectionRange => {
+        if (cachedInlineSelection) {
+          return cachedInlineSelection;
+        }
+        cachedInlineSelection = currentMode === 'live'
+          ? normalizeLiveInlineSelectionForListContent(state, selection)
+          : selection;
+        return cachedInlineSelection;
+      };
+
+      let insert = '';
+      switch (action) {
+        case 'heading':
+          insert = `${'#'.repeat(level ?? 1)} `;
+          break;
+        case 'bulletList':
+          insert = '- ';
+          break;
+        case 'numberedList':
+          insert = '1. ';
+          break;
+        case 'task':
+          insert = '- [ ] ';
+          break;
+        case 'codeBlock':
+          return insertCodeBlock(view, selection);
+        case 'inlineCode':
+          return insertInlineCode(view, inlineSelection());
+        case 'kbd':
+          return insertKbd(view, inlineSelection());
+        case 'bold':
+          return insertInlineFence(view, inlineSelection(), '**');
+        case 'italic':
+          return insertInlineFence(view, inlineSelection(), '*');
+        case 'lineover':
+        case 'strike':
+          return insertInlineFence(view, inlineSelection(), '~~');
+        case 'quote':
+          return insertQuote(view, selection);
+        case 'hr':
+          return insertHr(view, selection);
+        case 'table':
+          return insertTable(view, selection, level?.cols, level?.rows);
+        case 'link':
+          return insertLink(view, inlineSelection());
+        case 'wikiLink':
+          return insertWikiLink(view, inlineSelection());
+        case 'image':
+          return insertImage(view, inlineSelection());
+      }
+
+      if (!selection.empty && (action === 'bulletList' || action === 'numberedList')) {
+        const changes = buildListFormatChangesForSelection(state, insert);
+        dispatchSelectedListFormatChanges(state, changes, action === 'numberedList');
+        return;
+      }
+
+      const line = state.doc.lineAt(selection.from);
+      const { contentStart, oldMarkerLen, isExistingTask } = lineMarkerReplacementContext(state, line);
+      if (action === 'task' && isExistingTask) {
+        return;
+      }
+
+      const newMarkerLen = insert.length;
+      const cursorOffset = selection.from - (contentStart + oldMarkerLen);
+      const newCursorPos = contentStart + newMarkerLen + Math.max(0, cursorOffset);
+
+      view.dispatch({
+        changes: { from: contentStart, to: contentStart + oldMarkerLen, insert },
+        selection: { anchor: newCursorPos }
+      });
+    },
+    getHeadings() {
+      return extractHeadings(view.state);
+    },
+    moveHeadingSection(sourceHeadingFrom, targetHeadingFrom, placement) {
+      if (placement !== 'before' && placement !== 'after') {
+        return false;
+      }
+
+      const sections = extractHeadingSections(view.state);
+      const source = sections.find((heading) => heading.from === sourceHeadingFrom);
+      const target = sections.find((heading) => heading.from === targetHeadingFrom);
+      if (!source || !target) {
+        return false;
+      }
+
+      const insertionPoint = placement === 'before' ? target.sectionFrom : target.sectionTo;
+      if (insertionPoint > source.sectionFrom && insertionPoint < source.sectionTo) {
+        return false;
+      }
+
+      const currentText = view.state.doc.toString();
+      const movedText = currentText.slice(source.sectionFrom, source.sectionTo);
+      if (!movedText) {
+        return false;
+      }
+
+      const textWithoutSource = currentText.slice(0, source.sectionFrom) + currentText.slice(source.sectionTo);
+      const sourceLength = source.sectionTo - source.sectionFrom;
+      const adjustedInsertionPoint = insertionPoint >= source.sectionTo ? insertionPoint - sourceLength : insertionPoint;
+      const nextText =
+        textWithoutSource.slice(0, adjustedInsertionPoint) +
+        movedText +
+        textWithoutSource.slice(adjustedInsertionPoint);
+
+      if (nextText === currentText) {
+        return false;
+      }
+
+      const nextAnchor = Math.min(adjustedInsertionPoint, nextText.length);
+      view.dispatch({
+        changes: { from: 0, to: currentText.length, insert: nextText },
+        selection: { anchor: nextAnchor },
+        effects: EditorView.scrollIntoView(nextAnchor, { y: 'start' })
+      });
+      return true;
+    },
+    scrollToLine(lineNumber, align = 'center') {
+      const line = view.state.doc.line(Math.min(lineNumber, view.state.doc.lines));
+      applyRevealSelection(line.from, line.from, { focusEditor: true, align });
+    },
+    restoreTopLine(lineNumber, lineOffset) {
+      restoreTopVisibleLine(lineNumber, lineOffset, { syncCursor: true });
+    },
+    getTopVisiblePosition() {
+      const position = computeTopVisiblePosition();
+      return {
+        line: position.lineNumber,
+        lineOffset: position.lineOffset
+      };
+    },
+    getTopVisibleLine() {
+      return computeTopVisiblePosition().lineNumber;
+    },
+    revealSelection(anchor, head, options) {
+      applyRevealSelection(anchor, head, options);
+    },
+    refreshSelectionOverlay() {
+      emitSelectionChange();
+    },
+    refreshDecorations() {
+      view.dispatch({ effects: refreshDecorationsEffect.of(null) });
+    },
+    refreshLayout() {
+      view.requestMeasure();
+      if (currentMode === 'live') {
+        forceParsing(view, view.state.doc.length, 500);
+      }
+      emitSelectionChange();
+    },
+    setGitBaseline(snapshot) {
+      applyGitBaseline(view, snapshot);
+      gitBlameHover?.hide();
+      gitDiffOverviewRuler?.refresh();
+    },
+    clearGitUiTransientState() {
+      gitBlameHover?.hide();
+    }
+  };
 }
 
 function insertTableCellLineBreak(view) {
-    const { state } = view;
-    const selection = state.selection.main;
-    if (!isInsideTableCell(state, selection.from) || !isInsideTableCell(state, selection.to)) {
-        return false;
-    }
+  const { state } = view;
+  const selection = state.selection.main;
+  if (!isInsideTableCell(state, selection.from) || !isInsideTableCell(state, selection.to)) {
+    return false;
+  }
 
-    const insert = "<br>";
-    view.dispatch({
-        changes: { from: selection.from, to: selection.to, insert },
-        selection: { anchor: selection.from + insert.length },
-    });
-    return true;
+  const insert = '<br>';
+  view.dispatch({
+    changes: { from: selection.from, to: selection.to, insert },
+    selection: { anchor: selection.from + insert.length }
+  });
+  return true;
 }
 
 function handleEnterContinueQuotedCodeBlock(view) {
-    const { state } = view;
-    const selection = state.selection.main;
-    if (!selection.empty) {
-        return false;
-    }
+  const { state } = view;
+  const selection = state.selection.main;
+  if (!selection.empty) {
+    return false;
+  }
 
-    const quotePrefix = getQuotedCodeBlockLinePrefix(state, selection.from);
-    if (!quotePrefix) {
-        return false;
-    }
+  const quotePrefix = getQuotedCodeBlockLinePrefix(state, selection.from);
+  if (!quotePrefix) {
+    return false;
+  }
 
-    const insert = `\n${quotePrefix}`;
-    const nextPos = selection.from + insert.length;
-    view.dispatch({
-        changes: { from: selection.from, to: selection.from, insert },
-        selection: { anchor: nextPos },
-    });
-    return true;
+  const insert = `\n${quotePrefix}`;
+  const nextPos = selection.from + insert.length;
+  view.dispatch({
+    changes: { from: selection.from, to: selection.from, insert },
+    selection: { anchor: nextPos }
+  });
+  return true;
 }
 
 function getQuotedCodeBlockLinePrefix(state, position) {
-    const line = state.doc.lineAt(position);
-    const lineText = state.doc.sliceString(line.from, line.to);
-    const match = blockquoteLinePrefixRegex.exec(lineText);
-    if (!match) {
-        return null;
-    }
+  const line = state.doc.lineAt(position);
+  const lineText = state.doc.sliceString(line.from, line.to);
+  const match = blockquoteLinePrefixRegex.exec(lineText);
+  if (!match) {
+    return null;
+  }
 
-    return isInsideQuotedCodeBlock(state, position) ? match[0] : null;
+  return isInsideQuotedCodeBlock(state, position) ? match[0] : null;
 }
 
 function isInsideQuotedCodeBlock(state, position) {
-    let node = syntaxTree(state).resolveInner(position, -1);
-    let insideCodeBlock = false;
-    let insideBlockquote = false;
+  let node = syntaxTree(state).resolveInner(position, -1);
+  let insideCodeBlock = false;
+  let insideBlockquote = false;
 
-    while (node) {
-        if (quotedCodeBlockAncestorNames.has(node.name)) {
-            insideCodeBlock = true;
-        } else if (node.name === "Blockquote") {
-            insideBlockquote = true;
-        }
-        if (insideCodeBlock && insideBlockquote) {
-            return true;
-        }
-        node = node.parent;
+  while (node) {
+    if (quotedCodeBlockAncestorNames.has(node.name)) {
+      insideCodeBlock = true;
+    } else if (node.name === 'Blockquote') {
+      insideBlockquote = true;
     }
+    if (insideCodeBlock && insideBlockquote) {
+      return true;
+    }
+    node = node.parent;
+  }
 
-    return false;
+  return false;
 }
 
 function deleteTableCellLineBreakBackward(view) {
-    const { state } = view;
-    const selection = state.selection.main;
-    if (!selection.empty) {
-        return false;
-    }
+  const { state } = view;
+  const selection = state.selection.main;
+  if (!selection.empty) {
+    return false;
+  }
 
-    const pos = selection.from;
-    if (!isInsideTableCell(state, pos)) {
-        return false;
-    }
+  const pos = selection.from;
+  if (!isInsideTableCell(state, pos)) {
+    return false;
+  }
 
-    const from = Math.max(0, pos - 8);
-    const before = state.doc.sliceString(from, pos);
-    const match = /<br\s*\/?>$/i.exec(before);
-    if (!match) {
-        return false;
-    }
+  const from = Math.max(0, pos - 8);
+  const before = state.doc.sliceString(from, pos);
+  const match = /<br\s*\/?>$/i.exec(before);
+  if (!match) {
+    return false;
+  }
 
-    const start = pos - match[0].length;
-    view.dispatch({
-        changes: { from: start, to: pos },
-        selection: { anchor: start },
-    });
-    return true;
+  const start = pos - match[0].length;
+  view.dispatch({
+    changes: { from: start, to: pos },
+    selection: { anchor: start }
+  });
+  return true;
 }
 
 function deleteBackwardSmart(view) {
-    return handleBackspaceAtListContentStart(view) || deleteTableCellLineBreakBackward(view);
+  return handleBackspaceAtListContentStart(view) || deleteTableCellLineBreakBackward(view);
 }
 
 function isInsideTableCell(state, position) {
-    let node = syntaxTree(state).resolveInner(position, -1);
-    while (node) {
-        if (node.name === "TableCell") {
-            return true;
-        }
-        if (node.name === "TableDelimiter" || node.name === "Table") {
-            return false;
-        }
-        node = node.parent;
+  let node = syntaxTree(state).resolveInner(position, -1);
+  while (node) {
+    if (node.name === 'TableCell') {
+      return true;
     }
-    return false;
+    if (node.name === 'TableDelimiter' || node.name === 'Table') {
+      return false;
+    }
+    node = node.parent;
+  }
+  return false;
 }
 
 function findSyncChange(previousText, nextText) {
-    if (previousText === nextText) {
-        return null;
-    }
+  if (previousText === nextText) {
+    return null;
+  }
 
-    let from = 0;
-    const maxStart = Math.min(previousText.length, nextText.length);
-    while (from < maxStart && previousText.charCodeAt(from) === nextText.charCodeAt(from)) {
-        from += 1;
-    }
+  let from = 0;
+  const maxStart = Math.min(previousText.length, nextText.length);
+  while (from < maxStart && previousText.charCodeAt(from) === nextText.charCodeAt(from)) {
+    from += 1;
+  }
 
-    let previousTo = previousText.length;
-    let nextTo = nextText.length;
-    while (previousTo > from && nextTo > from && previousText.charCodeAt(previousTo - 1) === nextText.charCodeAt(nextTo - 1)) {
-        previousTo -= 1;
-        nextTo -= 1;
-    }
+  let previousTo = previousText.length;
+  let nextTo = nextText.length;
+  while (
+    previousTo > from &&
+    nextTo > from &&
+    previousText.charCodeAt(previousTo - 1) === nextText.charCodeAt(nextTo - 1)
+  ) {
+    previousTo -= 1;
+    nextTo -= 1;
+  }
 
-    return {
-        from,
-        to: previousTo,
-        insert: nextText.slice(from, nextTo),
-    };
+  return {
+    from,
+    to: previousTo,
+    insert: nextText.slice(from, nextTo)
+  };
 }
 
 // Map a position through a single replace change so external syncs keep the cursor nearby.
 function mapPositionThroughChange(position, change) {
-    const insertLength = change.insert.length;
-    const deletedLength = change.to - change.from;
-    const delta = insertLength - deletedLength;
+  const insertLength = change.insert.length;
+  const deletedLength = change.to - change.from;
+  const delta = insertLength - deletedLength;
 
-    if (position <= change.from) {
-        return position;
-    }
+  if (position <= change.from) {
+    return position;
+  }
 
-    if (position >= change.to) {
-        return position + delta;
-    }
+  if (position >= change.to) {
+    return position + delta;
+  }
 
-    return change.from + insertLength;
+  return change.from + insertLength;
 }
 
 function createSearchQueryState(query: string | null | undefined, options: SearchOptions = {}): SearchQueryState {
-    return {
-        text: query ?? "",
-        wholeWord: options.wholeWord === true,
-        caseSensitive: options.caseSensitive === true,
-    };
+  return {
+    text: query ?? '',
+    wholeWord: options.wholeWord === true,
+    caseSensitive: options.caseSensitive === true
+  };
 }
 
 function isWordBoundaryCharacter(value: string): boolean {
-    return /[0-9A-Za-z_]/.test(value);
+  return /[0-9A-Za-z_]/.test(value);
 }
 
 function isWholeWordRange(text: string, start: number, end: number): boolean {
-    const previous = start > 0 ? text.slice(start - 1, start) : "";
-    const next = end < text.length ? text.slice(end, end + 1) : "";
-    return !isWordBoundaryCharacter(previous) && !isWordBoundaryCharacter(next);
+  const previous = start > 0 ? text.slice(start - 1, start) : '';
+  const next = end < text.length ? text.slice(end, end + 1) : '';
+  return !isWordBoundaryCharacter(previous) && !isWordBoundaryCharacter(next);
 }
 
 function findSearchMatchRanges(text: string, query: string, options: SearchOptions = {}): SearchMatchRange[] {
-    if (!query) {
-        return [];
+  if (!query) {
+    return [];
+  }
+
+  const haystack = options.caseSensitive ? text : text.toLocaleLowerCase();
+  const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
+  const matches: SearchMatchRange[] = [];
+  let offset = 0;
+  while (offset <= text.length) {
+    const index = haystack.indexOf(needle, offset);
+    if (index < 0) {
+      break;
     }
 
-    const haystack = options.caseSensitive ? text : text.toLocaleLowerCase();
-    const needle = options.caseSensitive ? query : query.toLocaleLowerCase();
-    const matches: SearchMatchRange[] = [];
-    let offset = 0;
-    while (offset <= text.length) {
-        const index = haystack.indexOf(needle, offset);
-        if (index < 0) {
-            break;
-        }
-
-        const end = index + query.length;
-        if (!options.wholeWord || isWholeWordRange(text, index, end)) {
-            matches.push({ start: index, end });
-        }
-        offset = end;
+    const end = index + query.length;
+    if (!options.wholeWord || isWholeWordRange(text, index, end)) {
+      matches.push({ start: index, end });
     }
-    return matches;
+    offset = end;
+  }
+  return matches;
 }
 
 function countMatches(text, query, options: SearchOptions = {}) {
-    if (!query) {
-        return 0;
-    }
+  if (!query) {
+    return 0;
+  }
 
-    return findSearchMatchRanges(text, query, options).length;
+  return findSearchMatchRanges(text, query, options).length;
 }
 
 function findSelectedSearchMatchIndex(matches: SearchMatchRange[], from: number, to: number): number {
-    for (let index = 0; index < matches.length; index += 1) {
-        if (matches[index].start === from && matches[index].end === to) {
-            return index;
-        }
+  for (let index = 0; index < matches.length; index += 1) {
+    if (matches[index].start === from && matches[index].end === to) {
+      return index;
     }
-    return -1;
+  }
+  return -1;
 }
 
 function replaceMatchRanges(text: string, matches: SearchMatchRange[], replacement: string): string {
-    if (!matches.length) {
-        return text;
-    }
+  if (!matches.length) {
+    return text;
+  }
 
-    let nextText = "";
-    let offset = 0;
-    for (const match of matches) {
-        nextText += text.slice(offset, match.start);
-        nextText += replacement;
-        offset = match.end;
-    }
-    nextText += text.slice(offset);
-    return nextText;
+  let nextText = '';
+  let offset = 0;
+  for (const match of matches) {
+    nextText += text.slice(offset, match.start);
+    nextText += replacement;
+    offset = match.end;
+  }
+  nextText += text.slice(offset);
+  return nextText;
 }
 
-function normalizeLiveInlineSelectionForListContent(state: EditorState, selection: InlineSelectionRange): InlineSelectionRange {
-    if (selection.empty) {
-        return selection;
-    }
+function normalizeLiveInlineSelectionForListContent(
+  state: EditorState,
+  selection: InlineSelectionRange
+): InlineSelectionRange {
+  if (selection.empty) {
+    return selection;
+  }
 
-    let from = Math.min(selection.from, selection.to);
-    const to = Math.max(selection.from, selection.to);
-    if (to <= from) {
-        return selection;
-    }
+  let from = Math.min(selection.from, selection.to);
+  const to = Math.max(selection.from, selection.to);
+  if (to <= from) {
+    return selection;
+  }
 
-    const startLine = state.doc.lineAt(from);
-    const endLine = state.doc.lineAt(to - 1);
-    if (startLine.number !== endLine.number) {
-        return selection;
-    }
+  const startLine = state.doc.lineAt(from);
+  const endLine = state.doc.lineAt(to - 1);
+  if (startLine.number !== endLine.number) {
+    return selection;
+  }
 
-    const lineText = state.doc.sliceString(startLine.from, startLine.to);
-    const marker = listMarkerData(lineText);
-    if (!marker) {
-        return selection;
-    }
+  const lineText = state.doc.sliceString(startLine.from, startLine.to);
+  const marker = listMarkerData(lineText);
+  if (!marker) {
+    return selection;
+  }
 
-    const contentFrom = startLine.from + marker.toOffset;
-    if (from >= contentFrom || to <= contentFrom) {
-        return selection;
-    }
+  const contentFrom = startLine.from + marker.toOffset;
+  if (from >= contentFrom || to <= contentFrom) {
+    return selection;
+  }
 
-    from = contentFrom;
-    if (from >= to) {
-        return selection;
-    }
+  from = contentFrom;
+  if (from >= to) {
+    return selection;
+  }
 
-    if (selection.anchor <= selection.head) {
-        return { from, to, anchor: from, head: to, empty: false };
-    }
-    return { from, to, anchor: to, head: from, empty: false };
+  if (selection.anchor <= selection.head) {
+    return { from, to, anchor: from, head: to, empty: false };
+  }
+  return { from, to, anchor: to, head: from, empty: false };
 }
 
 function insertInlineCode(view, selection) {
-    const { state } = view;
+  const { state } = view;
 
-    if (!selection.empty) {
-        let from = Math.min(selection.from, selection.to);
-        let to = Math.max(selection.from, selection.to);
-        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
-            to -= 1;
-        }
-        const selectedText = state.doc.sliceString(from, to);
-        const insert = `\`${selectedText}\``;
-        view.dispatch({
-            changes: { from, to, insert },
-            selection: { anchor: from + insert.length },
-        });
-        return;
+  if (!selection.empty) {
+    let from = Math.min(selection.from, selection.to);
+    let to = Math.max(selection.from, selection.to);
+    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
+      to -= 1;
     }
-
-    const insert = "``";
+    const selectedText = state.doc.sliceString(from, to);
+    const insert = `\`${selectedText}\``;
     view.dispatch({
-        changes: { from: selection.from, insert },
-        selection: { anchor: selection.from + 1 },
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length }
     });
+    return;
+  }
+
+  const insert = '``';
+  view.dispatch({
+    changes: { from: selection.from, insert },
+    selection: { anchor: selection.from + 1 }
+  });
 }
 
 function toggleInlineWrapper(view, selection, openMarker, closeMarker = openMarker) {
-    const { state } = view;
+  const { state } = view;
 
-    if (selection.empty) {
-        const insert = `${openMarker}${closeMarker}`;
-        view.dispatch({
-            changes: { from: selection.from, insert },
-            selection: { anchor: selection.from + openMarker.length },
-        });
-        return;
-    }
-
-    const from = Math.min(selection.from, selection.to);
-    let to = Math.max(selection.from, selection.to);
-    while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
-        to -= 1;
-    }
-
-    const hasOpenMarker = from >= openMarker.length && state.doc.sliceString(from - openMarker.length, from) === openMarker;
-    const hasCloseMarker = state.doc.sliceString(to, to + closeMarker.length) === closeMarker;
-
-    if (hasOpenMarker && hasCloseMarker) {
-        view.dispatch({
-            changes: [
-                { from: to, to: to + closeMarker.length, insert: "" },
-                { from: from - openMarker.length, to: from, insert: "" },
-            ],
-            selection: {
-                anchor: from - openMarker.length,
-                head: to - openMarker.length,
-            },
-        });
-        return;
-    }
-
+  if (selection.empty) {
+    const insert = `${openMarker}${closeMarker}`;
     view.dispatch({
-        changes: [
-            { from: to, insert: closeMarker },
-            { from, insert: openMarker },
-        ],
-        selection: {
-            anchor: from + openMarker.length,
-            head: to + openMarker.length,
-        },
+      changes: { from: selection.from, insert },
+      selection: { anchor: selection.from + openMarker.length }
     });
+    return;
+  }
+
+  const from = Math.min(selection.from, selection.to);
+  let to = Math.max(selection.from, selection.to);
+  while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
+    to -= 1;
+  }
+
+  const hasOpenMarker =
+    from >= openMarker.length && state.doc.sliceString(from - openMarker.length, from) === openMarker;
+  const hasCloseMarker = state.doc.sliceString(to, to + closeMarker.length) === closeMarker;
+
+  if (hasOpenMarker && hasCloseMarker) {
+    view.dispatch({
+      changes: [
+        { from: to, to: to + closeMarker.length, insert: '' },
+        { from: from - openMarker.length, to: from, insert: '' }
+      ],
+      selection: {
+        anchor: from - openMarker.length,
+        head: to - openMarker.length
+      }
+    });
+    return;
+  }
+
+  view.dispatch({
+    changes: [
+      { from: to, insert: closeMarker },
+      { from, insert: openMarker }
+    ],
+    selection: {
+      anchor: from + openMarker.length,
+      head: to + openMarker.length
+    }
+  });
 }
 
 function insertKbd(view, selection) {
-    return toggleInlineWrapper(view, selection, "<kbd>", "</kbd>");
+  return toggleInlineWrapper(view, selection, '<kbd>', '</kbd>');
 }
 
 function insertInlineFence(view, selection, marker) {
-    return toggleInlineWrapper(view, selection, marker);
+  return toggleInlineWrapper(view, selection, marker);
 }
 
 function insertQuote(view, selection) {
-    const { state } = view;
-    const line = state.doc.lineAt(selection.from);
-    const lineText = state.doc.sliceString(line.from, line.to);
+  const { state } = view;
+  const line = state.doc.lineAt(selection.from);
+  const lineText = state.doc.sliceString(line.from, line.to);
 
-    const existingQuote = /^(\s*)(>\s*)/.exec(lineText);
-    if (existingQuote) {
-        return;
-    }
+  const existingQuote = /^(\s*)(>\s*)/.exec(lineText);
+  if (existingQuote) {
+    return;
+  }
 
-    const leadingWhitespace = /^(\s*)/.exec(lineText)[1];
-    const insert = "> ";
-    const contentStart = line.from + leadingWhitespace.length;
-    const cursorOffset = selection.from - contentStart;
+  const leadingWhitespace = /^(\s*)/.exec(lineText)[1];
+  const insert = '> ';
+  const contentStart = line.from + leadingWhitespace.length;
+  const cursorOffset = selection.from - contentStart;
 
-    view.dispatch({
-        changes: { from: contentStart, insert },
-        selection: { anchor: contentStart + insert.length + cursorOffset },
-    });
+  view.dispatch({
+    changes: { from: contentStart, insert },
+    selection: { anchor: contentStart + insert.length + cursorOffset }
+  });
 }
 
 function insertHr(view, selection) {
-    const { state } = view;
-    const line = state.doc.lineAt(selection.from);
-    const lineText = state.doc.sliceString(line.from, line.to);
-    const trimmed = lineText.trim();
+  const { state } = view;
+  const line = state.doc.lineAt(selection.from);
+  const lineText = state.doc.sliceString(line.from, line.to);
+  const trimmed = lineText.trim();
 
-    if (!trimmed) {
-        const insert = "---";
-        const cursorPos = line.from + insert.length;
-        view.dispatch({
-            changes: { from: line.from, to: line.to, insert },
-            selection: { anchor: cursorPos },
-        });
-    } else {
-        const insert = "\n---";
-        const cursorPos = line.to + insert.length;
-        view.dispatch({
-            changes: { from: line.to, insert },
-            selection: { anchor: cursorPos },
-        });
-    }
+  if (!trimmed) {
+    const insert = '---';
+    const cursorPos = line.from + insert.length;
+    view.dispatch({
+      changes: { from: line.from, to: line.to, insert },
+      selection: { anchor: cursorPos }
+    });
+  } else {
+    const insert = '\n---';
+    const cursorPos = line.to + insert.length;
+    view.dispatch({
+      changes: { from: line.to, insert },
+      selection: { anchor: cursorPos }
+    });
+  }
 }
 
 function insertLink(view, selection) {
-    const { state } = view;
+  const { state } = view;
 
-    if (!selection.empty) {
-        let from = Math.min(selection.from, selection.to);
-        let to = Math.max(selection.from, selection.to);
-        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
-            to -= 1;
-        }
-        const selectedText = state.doc.sliceString(from, to);
-        const insert = `[${selectedText}]()`;
-        view.dispatch({
-            changes: { from, to, insert },
-            selection: { anchor: from + insert.length - 1 },
-        });
-        return;
+  if (!selection.empty) {
+    let from = Math.min(selection.from, selection.to);
+    let to = Math.max(selection.from, selection.to);
+    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
+      to -= 1;
     }
-
-    const insert = "[]()";
+    const selectedText = state.doc.sliceString(from, to);
+    const insert = `[${selectedText}]()`;
     view.dispatch({
-        changes: { from: selection.from, insert },
-        selection: { anchor: selection.from + 3 },
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length - 1 }
     });
+    return;
+  }
+
+  const insert = '[]()';
+  view.dispatch({
+    changes: { from: selection.from, insert },
+    selection: { anchor: selection.from + 3 }
+  });
 }
 
 function insertImage(view, selection) {
-    const { state } = view;
+  const { state } = view;
 
-    if (!selection.empty) {
-        let from = Math.min(selection.from, selection.to);
-        let to = Math.max(selection.from, selection.to);
-        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
-            to -= 1;
-        }
-        const selectedText = state.doc.sliceString(from, to);
-        const insert = `![${selectedText}]()`;
-        view.dispatch({
-            changes: { from, to, insert },
-            selection: { anchor: from + insert.length - 1 },
-        });
-        return;
+  if (!selection.empty) {
+    let from = Math.min(selection.from, selection.to);
+    let to = Math.max(selection.from, selection.to);
+    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
+      to -= 1;
     }
-
-    const insert = "![]()";
+    const selectedText = state.doc.sliceString(from, to);
+    const insert = `![${selectedText}]()`;
     view.dispatch({
-        changes: { from: selection.from, insert },
-        selection: { anchor: selection.from + 4 },
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length - 1 }
     });
+    return;
+  }
+
+  const insert = '![]()';
+  view.dispatch({
+    changes: { from: selection.from, insert },
+    selection: { anchor: selection.from + 4 }
+  });
 }
 
 function insertWikiLink(view, selection) {
-    const { state } = view;
+  const { state } = view;
 
-    if (!selection.empty) {
-        let from = Math.min(selection.from, selection.to);
-        let to = Math.max(selection.from, selection.to);
-        while (to > from && state.doc.sliceString(to - 1, to) === "\n") {
-            to -= 1;
-        }
-        const selectedText = state.doc.sliceString(from, to);
-        const insert = `[[${selectedText}]]`;
-        view.dispatch({
-            changes: { from, to, insert },
-            selection: { anchor: from + insert.length },
-        });
-        return;
+  if (!selection.empty) {
+    let from = Math.min(selection.from, selection.to);
+    let to = Math.max(selection.from, selection.to);
+    while (to > from && state.doc.sliceString(to - 1, to) === '\n') {
+      to -= 1;
     }
-
-    const insert = "[[]]";
+    const selectedText = state.doc.sliceString(from, to);
+    const insert = `[[${selectedText}]]`;
     view.dispatch({
-        changes: { from: selection.from, insert },
-        selection: { anchor: selection.from + 2 },
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length }
     });
+    return;
+  }
+
+  const insert = '[[]]';
+  view.dispatch({
+    changes: { from: selection.from, insert },
+    selection: { anchor: selection.from + 2 }
+  });
 }
 
 function sourceMode() {
-    return [
-        markdown({
-            base: markdownLanguage,
-            addKeymap: false,
-            codeLanguages: resolveCodeLanguage,
-            extensions: [{ remove: ["SetextHeading"] }],
-        }),
-        syntaxHighlighting(highlightStyle),
-        sourceCodeBlockField,
-        sourceListBorderField,
-        sourceListMarkerField,
-        sourceStrikeMarkerField,
-        sourceWikiMarkerField,
-        sourceFileLinkField,
-        sourceUrlBoundaryField,
-        sourceFootnoteMarkerField,
-        sourceTableHeaderLineField,
-        sourceFrontmatterField,
-        gitDiffLineHighlightsField,
-        ...headingCollapseSourceSpacerExtensions(),
-        ...mergeConflictSourceExtensions(),
-    ];
+  return [
+    markdown({
+      base: markdownLanguage,
+      addKeymap: false,
+      codeLanguages: resolveCodeLanguage,
+      extensions: [{ remove: ['SetextHeading'] }]
+    }),
+    syntaxHighlighting(highlightStyle),
+    sourceCodeBlockField,
+    sourceListBorderField,
+    sourceListMarkerField,
+    sourceStrikeMarkerField,
+    sourceWikiMarkerField,
+    sourceFileLinkField,
+    sourceUrlBoundaryField,
+    sourceFootnoteMarkerField,
+    sourceTableHeaderLineField,
+    sourceFrontmatterField,
+    gitDiffLineHighlightsField,
+    ...headingCollapseSourceSpacerExtensions(),
+    ...mergeConflictSourceExtensions()
+  ];
 }
 
-const blockedInlineSelectionAncestors = new Set(["FencedCode", "CodeBlock", "CodeText", "InlineCode", "URL", "Autolink", "HTMLBlock", "HTMLTag", "TableDelimiter"]);
+const blockedInlineSelectionAncestors = new Set([
+  'FencedCode',
+  'CodeBlock',
+  'CodeText',
+  'InlineCode',
+  'URL',
+  'Autolink',
+  'HTMLBlock',
+  'HTMLTag',
+  'TableDelimiter'
+]);
 
 const latexSelectionBlockCache = new WeakMap<object, Array<{ from: number; to: number }>>();
 
 function hasBlockedInlineAncestor(state, position) {
-    let node = syntaxTree(state).resolveInner(position, 1);
-    while (node) {
-        if (blockedInlineSelectionAncestors.has(node.name)) {
-            return true;
-        }
-        node = node.parent;
+  let node = syntaxTree(state).resolveInner(position, 1);
+  while (node) {
+    if (blockedInlineSelectionAncestors.has(node.name)) {
+      return true;
     }
-    return false;
+    node = node.parent;
+  }
+  return false;
 }
 
 function getLatexSelectionBlockRanges(state) {
-    const docKey = state.doc as unknown as object;
-    const cached = latexSelectionBlockCache.get(docKey);
-    if (cached) {
-        return cached;
-    }
+  const docKey = state.doc as unknown as object;
+  const cached = latexSelectionBlockCache.get(docKey);
+  if (cached) {
+    return cached;
+  }
 
-    const text = state.doc.toString();
-    if (text.indexOf("$") === -1) {
-        latexSelectionBlockCache.set(docKey, []);
-        return [];
-    }
+  const text = state.doc.toString();
+  if (text.indexOf('$') === -1) {
+    latexSelectionBlockCache.set(docKey, []);
+    return [];
+  }
 
-    const ranges = collectLatexMathRanges(text).map((range) => ({ from: range.from, to: range.to }));
-    latexSelectionBlockCache.set(docKey, ranges);
-    return ranges;
+  const ranges = collectLatexMathRanges(text).map((range) => ({ from: range.from, to: range.to }));
+  latexSelectionBlockCache.set(docKey, ranges);
+  return ranges;
 }
 
 function overlapsLatexMathSelection(state, from, to) {
-    if (to <= from) {
-        return false;
-    }
-    const ranges = getLatexSelectionBlockRanges(state);
-    for (const range of ranges) {
-        if (range.from < to && range.to > from) {
-            return true;
-        }
-    }
+  if (to <= from) {
     return false;
+  }
+  const ranges = getLatexSelectionBlockRanges(state);
+  for (const range of ranges) {
+    if (range.from < to && range.to > from) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isRegularInlineSelection(state, from, to) {
-    if (to <= from) {
-        return false;
-    }
-    const text = state.doc.sliceString(from, to);
-    const trimmedText = text.trim();
-    if (!trimmedText) {
-        return false;
-    }
-    if (trimmedText.includes("\n")) {
-        return false;
-    }
-    if (hasBlockedInlineAncestor(state, from) || hasBlockedInlineAncestor(state, to - 1)) {
-        return false;
-    }
-    if (overlapsLatexMathSelection(state, from, to)) {
-        return false;
-    }
-    return true;
+  if (to <= from) {
+    return false;
+  }
+  const text = state.doc.sliceString(from, to);
+  const trimmedText = text.trim();
+  if (!trimmedText) {
+    return false;
+  }
+  if (trimmedText.includes('\n')) {
+    return false;
+  }
+  if (hasBlockedInlineAncestor(state, from) || hasBlockedInlineAncestor(state, to - 1)) {
+    return false;
+  }
+  if (overlapsLatexMathSelection(state, from, to)) {
+    return false;
+  }
+  return true;
 }

--- a/webview/src/helpers/shortcuts.ts
+++ b/webview/src/helpers/shortcuts.ts
@@ -34,8 +34,8 @@ export const handleEditorShortcut = (
   
   const hasPrimaryModifier = isPrimaryModifier(event);
   const editorFocused = editor.hasFocus();
-  const vimSourceFocused = vimModeEnabled && currentMode === 'source' && editorFocused;
-  const vimWinsCtrlConflicts = vimSourceFocused && !isMac;
+  const vimEditorFocused = vimModeEnabled && editorFocused;
+  const vimWinsCtrlConflicts = vimEditorFocused && !isMac;
   const isPlainAltShiftChord =
     event.altKey &&
     event.shiftKey &&
@@ -51,7 +51,7 @@ export const handleEditorShortcut = (
   }
 
   if (
-    vimSourceFocused &&
+    vimEditorFocused &&
     (
       isPlainAltShiftChord ||
       (isMac && event.metaKey && !event.ctrlKey)

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -1,63 +1,63 @@
-import { createElement, Heading, Heading1, Heading2, Heading3, Heading4, Heading5, Heading6, List, ListOrdered, ListTodo, ListTree, Hash, Code, Terminal, Quote, Minus, Table2, Link, Brackets, Image, Bold, Italic, Strikethrough, Search, Share, GitCompare } from 'lucide';
-import { setImageSrcResolver, initializeImageHandling, resolveImageSrc, settleImageSrcRequest, handleSavedImagePath, handleImagePaste } from './helpers/images';
-import { createGitClient } from './helpers/gitClient';
-import { createOutlineController } from './helpers/outline';
-import { normalizeWikiTarget, replaceWikiLinkStatuses, initializeWikiLinkHandling, collectWikiLinkTargets, requestWikiLinkStatuses, scheduleWikiLinkStatusRefresh, setWikiLinkRefreshContext, cancelPendingWikiStatusRefresh, handleResolvedWikiLinks } from './helpers/wikiLinks';
-import { initializeLocalLinkHandling, requestLocalLinkStatuses, scheduleLocalLinkStatusRefresh, setLocalLinkRefreshContext, cancelPendingLocalLinkStatusRefresh, handleResolvedLocalLinks } from './helpers/localLinks';
-import { setGitDiffLineHighlightsEnabled } from './helpers/gitDiffLineHighlights';
-import { applyThemeSettings } from './helpers/theme';
-import { createFailureNoticeManager, getErrorMessage, isTransientMermaidRuntimeError, shouldAutoFallbackToSourceForLiveError, logWebviewRenderError, type EditorNotice, type FailureNoticeManager } from './helpers/errors';
-import { isPrimaryModifier, isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from './helpers/shortcuts';
-import { createFindPanel, createFindPanelController, type FindPanelController } from './helpers/findPanel';
-import { createSelectionMenu, createSelectionMenuController, type SelectionMenuController } from './helpers/selectionMenu';
-import { createExportHandler, type ExportHandlerContext } from './helpers/export';
+import { createElement, Heading, Heading1, Heading2, Heading3, Heading4, Heading5, Heading6, List, ListOrdered, ListTodo, ListTree, Hash, Code, Terminal, Quote, Minus, Table2, Link, Brackets, Image, Bold, Italic, Strikethrough, Search, Share, GitCompare } from "lucide";
+import { setImageSrcResolver, initializeImageHandling, resolveImageSrc, settleImageSrcRequest, handleSavedImagePath, handleImagePaste } from "./helpers/images";
+import { createGitClient } from "./helpers/gitClient";
+import { createOutlineController } from "./helpers/outline";
+import { normalizeWikiTarget, replaceWikiLinkStatuses, initializeWikiLinkHandling, collectWikiLinkTargets, requestWikiLinkStatuses, scheduleWikiLinkStatusRefresh, setWikiLinkRefreshContext, cancelPendingWikiStatusRefresh, handleResolvedWikiLinks } from "./helpers/wikiLinks";
+import { initializeLocalLinkHandling, requestLocalLinkStatuses, scheduleLocalLinkStatusRefresh, setLocalLinkRefreshContext, cancelPendingLocalLinkStatusRefresh, handleResolvedLocalLinks } from "./helpers/localLinks";
+import { setGitDiffLineHighlightsEnabled } from "./helpers/gitDiffLineHighlights";
+import { applyThemeSettings } from "./helpers/theme";
+import { createFailureNoticeManager, getErrorMessage, isTransientMermaidRuntimeError, shouldAutoFallbackToSourceForLiveError, logWebviewRenderError, type EditorNotice, type FailureNoticeManager } from "./helpers/errors";
+import { isPrimaryModifier, isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from "./helpers/shortcuts";
+import { createFindPanel, createFindPanelController, type FindPanelController } from "./helpers/findPanel";
+import { createSelectionMenu, createSelectionMenuController, type SelectionMenuController } from "./helpers/selectionMenu";
+import { createExportHandler, type ExportHandlerContext } from "./helpers/export";
 
-type CreateEditorFactory = (typeof import('./editor'))['createEditor'];
+type CreateEditorFactory = (typeof import("./editor"))["createEditor"];
 
 type CompatibleVsCodeWebviewApi = {
-  postMessage: (message: WebviewMessage) => void;
-  getState: () => unknown;
-  setState: (state: unknown) => void;
+    postMessage: (message: WebviewMessage) => void;
+    getState: () => unknown;
+    setState: (state: unknown) => void;
 };
 
 function createCompatibleVsCodeApi(): CompatibleVsCodeWebviewApi {
-  const hostApi = acquireVsCodeApi();
-  let fallbackState: unknown;
+    const hostApi = acquireVsCodeApi();
+    let fallbackState: unknown;
 
-  const getState = (): unknown => {
-    if (typeof hostApi.getState !== 'function') {
-      return fallbackState;
-    }
+    const getState = (): unknown => {
+        if (typeof hostApi.getState !== "function") {
+            return fallbackState;
+        }
 
-    try {
-      const hostState = hostApi.getState();
-      if (hostState !== undefined) {
-        fallbackState = hostState;
-      }
-      return hostState;
-    } catch {
-      return fallbackState;
-    }
-  };
+        try {
+            const hostState = hostApi.getState();
+            if (hostState !== undefined) {
+                fallbackState = hostState;
+            }
+            return hostState;
+        } catch {
+            return fallbackState;
+        }
+    };
 
-  const setState = (state: unknown): void => {
-    fallbackState = state;
-    if (typeof hostApi.setState !== 'function') {
-      return;
-    }
+    const setState = (state: unknown): void => {
+        fallbackState = state;
+        if (typeof hostApi.setState !== "function") {
+            return;
+        }
 
-    try {
-      hostApi.setState(state);
-    } catch {
-      // Keep session-local fallback state when host persistence is unavailable.
-    }
-  };
+        try {
+            hostApi.setState(state);
+        } catch {
+            // Keep session-local fallback state when host persistence is unavailable.
+        }
+    };
 
-  return {
-    postMessage: (message: WebviewMessage) => hostApi.postMessage(message),
-    getState,
-    setState
-  };
+    return {
+        postMessage: (message: WebviewMessage) => hostApi.postMessage(message),
+        getState,
+        setState,
+    };
 }
 
 const vscode = createCompatibleVsCodeApi();
@@ -68,375 +68,374 @@ initializeLocalLinkHandling(vscode);
 applyThemeSettings();
 setImageSrcResolver(resolveImageSrc);
 
-const root = document.getElementById('app');
+const root = document.getElementById("app");
 
 if (!root) {
-  throw new Error('Webview root element not found');
+    throw new Error("Webview root element not found");
 }
 
-root.classList.add('editor-root');
+root.classList.add("editor-root");
 
-const existingToolbar = root.querySelector('.mode-toolbar');
-const toolbar = existingToolbar instanceof HTMLElement ? existingToolbar : document.createElement('div');
-toolbar.className = 'mode-toolbar';
-toolbar.classList.remove('meo-preload-toolbar');
-toolbar.removeAttribute('aria-hidden');
-toolbar.setAttribute('role', 'toolbar');
-toolbar.setAttribute('aria-label', 'Editor toolbar');
+const existingToolbar = root.querySelector(".mode-toolbar");
+const toolbar = existingToolbar instanceof HTMLElement ? existingToolbar : document.createElement("div");
+toolbar.className = "mode-toolbar";
+toolbar.classList.remove("meo-preload-toolbar");
+toolbar.removeAttribute("aria-hidden");
+toolbar.setAttribute("role", "toolbar");
+toolbar.setAttribute("aria-label", "Editor toolbar");
 
-const formatGroup = document.createElement('div');
-formatGroup.className = 'format-group';
-formatGroup.setAttribute('role', 'group');
-formatGroup.setAttribute('aria-label', 'Formatting');
+const formatGroup = document.createElement("div");
+formatGroup.className = "format-group";
+formatGroup.setAttribute("role", "group");
+formatGroup.setAttribute("aria-label", "Formatting");
 
-const headingBtn = document.createElement('button');
-headingBtn.type = 'button';
-headingBtn.className = 'format-button';
-headingBtn.dataset.action = 'heading';
-headingBtn.title = 'Heading';
+const headingBtn = document.createElement("button");
+headingBtn.type = "button";
+headingBtn.className = "format-button";
+headingBtn.dataset.action = "heading";
+headingBtn.title = "Heading";
 headingBtn.appendChild(createElement(Heading, { width: 18, height: 18 }));
 
-const headingDropdown = document.createElement('div');
-headingDropdown.className = 'heading-dropdown';
-headingDropdown.setAttribute('role', 'menu');
-headingDropdown.setAttribute('aria-label', 'Heading levels');
+const headingDropdown = document.createElement("div");
+headingDropdown.className = "heading-dropdown";
+headingDropdown.setAttribute("role", "menu");
+headingDropdown.setAttribute("aria-label", "Heading levels");
 
-const headingDropdownWrapper = document.createElement('div');
-headingDropdownWrapper.className = 'heading-dropdown-wrapper';
+const headingDropdownWrapper = document.createElement("div");
+headingDropdownWrapper.className = "heading-dropdown-wrapper";
 
 const headingIcons = [Heading1, Heading2, Heading3, Heading4, Heading5, Heading6];
 
 for (let level = 1; level <= 6; level++) {
-  const option = document.createElement('button');
-  option.type = 'button';
-  option.className = 'heading-dropdown-option';
-  option.dataset.level = String(level);
-  option.title = `Heading ${level}`;
-  option.appendChild(createElement(headingIcons[level - 1], { width: 18, height: 18 }));
-  headingDropdown.appendChild(option);
+    const option = document.createElement("button");
+    option.type = "button";
+    option.className = "heading-dropdown-option";
+    option.dataset.level = String(level);
+    option.title = `Heading ${level}`;
+    option.appendChild(createElement(headingIcons[level - 1], { width: 18, height: 18 }));
+    headingDropdown.appendChild(option);
 }
 
 headingDropdownWrapper.appendChild(headingDropdown);
 
-const headingWrapper = document.createElement('div');
-headingWrapper.className = 'heading-wrapper';
+const headingWrapper = document.createElement("div");
+headingWrapper.className = "heading-wrapper";
 headingWrapper.append(headingBtn, headingDropdownWrapper);
 
-const bulletListBtn = document.createElement('button');
-bulletListBtn.type = 'button';
-bulletListBtn.className = 'format-button';
-bulletListBtn.dataset.action = 'bulletList';
-bulletListBtn.title = 'Bullet List';
+const bulletListBtn = document.createElement("button");
+bulletListBtn.type = "button";
+bulletListBtn.className = "format-button";
+bulletListBtn.dataset.action = "bulletList";
+bulletListBtn.title = "Bullet List";
 bulletListBtn.appendChild(createElement(List, { width: 18, height: 18 }));
 
-const numberedListBtn = document.createElement('button');
-numberedListBtn.type = 'button';
-numberedListBtn.className = 'format-button';
-numberedListBtn.dataset.action = 'numberedList';
-numberedListBtn.title = 'Numbered List';
+const numberedListBtn = document.createElement("button");
+numberedListBtn.type = "button";
+numberedListBtn.className = "format-button";
+numberedListBtn.dataset.action = "numberedList";
+numberedListBtn.title = "Numbered List";
 numberedListBtn.appendChild(createElement(ListOrdered, { width: 18, height: 18 }));
 
-const taskBtn = document.createElement('button');
-taskBtn.type = 'button';
-taskBtn.className = 'format-button';
-taskBtn.dataset.action = 'task';
-taskBtn.title = 'Task';
+const taskBtn = document.createElement("button");
+taskBtn.type = "button";
+taskBtn.className = "format-button";
+taskBtn.dataset.action = "task";
+taskBtn.title = "Task";
 taskBtn.appendChild(createElement(ListTodo, { width: 18, height: 18 }));
 
 let vimModeEnabled = false;
+let vimKeybindingsState: VimKeybinding[] = [];
+let vimLeaderState = "\\";
 
 let lineNumbersVisible = true;
 let gitChangesGutterVisible = true;
 let gitDiffLineHighlightsEnabled = true;
 
-const outlineBtn = document.createElement('button');
-outlineBtn.type = 'button';
-outlineBtn.className = 'format-button toggle-button';
-outlineBtn.dataset.action = 'outline';
-outlineBtn.title = 'Toggle Outline';
+const outlineBtn = document.createElement("button");
+outlineBtn.type = "button";
+outlineBtn.className = "format-button toggle-button";
+outlineBtn.dataset.action = "outline";
+outlineBtn.title = "Toggle Outline";
 outlineBtn.appendChild(createElement(ListTree, { width: 18, height: 18 }));
 
-const lineNumbersBtn = document.createElement('button');
-lineNumbersBtn.type = 'button';
-lineNumbersBtn.className = 'format-button toggle-button is-active';
-lineNumbersBtn.dataset.action = 'lineNumbers';
-lineNumbersBtn.title = 'Hide Line Numbers';
+const lineNumbersBtn = document.createElement("button");
+lineNumbersBtn.type = "button";
+lineNumbersBtn.className = "format-button toggle-button is-active";
+lineNumbersBtn.dataset.action = "lineNumbers";
+lineNumbersBtn.title = "Hide Line Numbers";
 lineNumbersBtn.appendChild(createElement(Hash, { width: 18, height: 18 }));
 
-const gitChangesGutterBtn = document.createElement('button');
-gitChangesGutterBtn.type = 'button';
-gitChangesGutterBtn.className = 'format-button toggle-button is-active';
-gitChangesGutterBtn.dataset.action = 'gitChangesGutter';
-gitChangesGutterBtn.title = 'Hide Git Changes Gutter';
+const gitChangesGutterBtn = document.createElement("button");
+gitChangesGutterBtn.type = "button";
+gitChangesGutterBtn.className = "format-button toggle-button is-active";
+gitChangesGutterBtn.dataset.action = "gitChangesGutter";
+gitChangesGutterBtn.title = "Hide Git Changes Gutter";
 gitChangesGutterBtn.appendChild(createElement(GitCompare, { width: 18, height: 18 }));
 
 const updateLineNumbersUI = () => {
-  lineNumbersBtn.classList.toggle('is-active', lineNumbersVisible);
-  lineNumbersBtn.setAttribute('aria-pressed', lineNumbersVisible ? 'true' : 'false');
-  lineNumbersBtn.title = lineNumbersVisible ? 'Hide Line Numbers' : 'Show Line Numbers';
+    lineNumbersBtn.classList.toggle("is-active", lineNumbersVisible);
+    lineNumbersBtn.setAttribute("aria-pressed", lineNumbersVisible ? "true" : "false");
+    lineNumbersBtn.title = lineNumbersVisible ? "Hide Line Numbers" : "Show Line Numbers";
 };
 
 const updateGitChangesGutterUI = () => {
-  gitChangesGutterBtn.classList.toggle('is-active', gitChangesGutterVisible);
-  gitChangesGutterBtn.setAttribute('aria-pressed', gitChangesGutterVisible ? 'true' : 'false');
-  gitChangesGutterBtn.title = gitChangesGutterVisible ? 'Hide Git Changes' : 'Show Git Changes';
+    gitChangesGutterBtn.classList.toggle("is-active", gitChangesGutterVisible);
+    gitChangesGutterBtn.setAttribute("aria-pressed", gitChangesGutterVisible ? "true" : "false");
+    gitChangesGutterBtn.title = gitChangesGutterVisible ? "Hide Git Changes" : "Show Git Changes";
 };
 
 const syncGitDiffLineHighlights = () => {
-  if (!editor) {
-    return;
-  }
-  setGitDiffLineHighlightsEnabled(
-    editor,
-    currentMode === 'source' && gitChangesGutterVisible && gitDiffLineHighlightsEnabled
-  );
+    if (!editor) {
+        return;
+    }
+    setGitDiffLineHighlightsEnabled(editor, currentMode === "source" && gitChangesGutterVisible && gitDiffLineHighlightsEnabled);
 };
 
 const setLineNumbersVisible = (visible, { post = true } = {}) => {
-  const nextVisible = visible !== false;
-  const changed = nextVisible !== lineNumbersVisible;
-  if (changed) {
-    lineNumbersVisible = nextVisible;
-    editor?.setLineNumbers(lineNumbersVisible);
-  }
-  updateLineNumbersUI();
-  if (post && changed) {
-    vscode.postMessage({ type: 'setLineNumbers', visible: lineNumbersVisible });
-  }
+    const nextVisible = visible !== false;
+    const changed = nextVisible !== lineNumbersVisible;
+    if (changed) {
+        lineNumbersVisible = nextVisible;
+        editor?.setLineNumbers(lineNumbersVisible);
+    }
+    updateLineNumbersUI();
+    if (post && changed) {
+        vscode.postMessage({ type: "setLineNumbers", visible: lineNumbersVisible });
+    }
 };
 
 const setGitChangesGutterVisible = (visible, { post = true } = {}) => {
-  const nextVisible = visible !== false;
-  const changed = nextVisible !== gitChangesGutterVisible;
-  if (changed) {
-    gitChangesGutterVisible = nextVisible;
-    editor?.setGitGutterVisible(gitChangesGutterVisible);
-    syncGitDiffLineHighlights();
-  }
-  updateGitChangesGutterUI();
-  if (post && changed) {
-    vscode.postMessage({ type: 'setGitChangesGutter', visible: gitChangesGutterVisible });
-  }
+    const nextVisible = visible !== false;
+    const changed = nextVisible !== gitChangesGutterVisible;
+    if (changed) {
+        gitChangesGutterVisible = nextVisible;
+        editor?.setGitGutterVisible(gitChangesGutterVisible);
+        syncGitDiffLineHighlights();
+    }
+    updateGitChangesGutterUI();
+    if (post && changed) {
+        vscode.postMessage({ type: "setGitChangesGutter", visible: gitChangesGutterVisible });
+    }
 };
 
 const setOutlineVisible = (visible, { post = true } = {}) => {
-  const nextVisible = visible === true;
-  const changed = nextVisible !== outlineController.isVisible();
-  outlineController.setVisible(nextVisible);
-  if (post && changed) {
-    vscode.postMessage({ type: 'setOutlineVisible', visible: nextVisible });
-  }
+    const nextVisible = visible === true;
+    const changed = nextVisible !== outlineController.isVisible();
+    outlineController.setVisible(nextVisible);
+    if (post && changed) {
+        vscode.postMessage({ type: "setOutlineVisible", visible: nextVisible });
+    }
 };
 
 const setVimModeEnabled = (enabled) => {
-  const nextEnabled = enabled === true;
-  if (nextEnabled === vimModeEnabled) {
-    return;
-  }
-  vimModeEnabled = nextEnabled;
-  editor?.setVimMode(vimModeEnabled);
+    const nextEnabled = enabled === true;
+    if (nextEnabled === vimModeEnabled) {
+        return;
+    }
+    vimModeEnabled = nextEnabled;
+    editor?.setVimMode(vimModeEnabled);
 };
 
 const toggleLineNumbers = () => {
-  setLineNumbersVisible(!lineNumbersVisible);
+    setLineNumbersVisible(!lineNumbersVisible);
 };
 
 const toggleGitChangesGutter = () => {
-  setGitChangesGutterVisible(!gitChangesGutterVisible);
+    setGitChangesGutterVisible(!gitChangesGutterVisible);
 };
 
-const separator = document.createElement('div');
-separator.className = 'format-separator';
-separator.setAttribute('role', 'separator');
+const separator = document.createElement("div");
+separator.className = "format-separator";
+separator.setAttribute("role", "separator");
 
-const codeBlockBtn = document.createElement('button');
-codeBlockBtn.type = 'button';
-codeBlockBtn.className = 'format-button';
-codeBlockBtn.dataset.action = 'codeBlock';
-codeBlockBtn.title = 'Code Block';
+const codeBlockBtn = document.createElement("button");
+codeBlockBtn.type = "button";
+codeBlockBtn.className = "format-button";
+codeBlockBtn.dataset.action = "codeBlock";
+codeBlockBtn.title = "Code Block";
 codeBlockBtn.appendChild(createElement(Code, { width: 18, height: 18 }));
 
-const quoteBtn = document.createElement('button');
-quoteBtn.type = 'button';
-quoteBtn.className = 'format-button';
-quoteBtn.dataset.action = 'quote';
-quoteBtn.title = 'Quote';
+const quoteBtn = document.createElement("button");
+quoteBtn.type = "button";
+quoteBtn.className = "format-button";
+quoteBtn.dataset.action = "quote";
+quoteBtn.title = "Quote";
 quoteBtn.appendChild(createElement(Quote, { width: 18, height: 18 }));
 
-const hrBtn = document.createElement('button');
-hrBtn.type = 'button';
-hrBtn.className = 'format-button';
-hrBtn.dataset.action = 'hr';
-hrBtn.title = 'Horizontal Rule';
+const hrBtn = document.createElement("button");
+hrBtn.type = "button";
+hrBtn.className = "format-button";
+hrBtn.dataset.action = "hr";
+hrBtn.title = "Horizontal Rule";
 hrBtn.appendChild(createElement(Minus, { width: 18, height: 18 }));
 
-const linkBtn = document.createElement('button');
-linkBtn.type = 'button';
-linkBtn.className = 'format-button';
-linkBtn.dataset.action = 'link';
-linkBtn.title = 'Link';
+const linkBtn = document.createElement("button");
+linkBtn.type = "button";
+linkBtn.className = "format-button";
+linkBtn.dataset.action = "link";
+linkBtn.title = "Link";
 linkBtn.appendChild(createElement(Link, { width: 18, height: 18 }));
 
-const wikiLinkBtn = document.createElement('button');
-wikiLinkBtn.type = 'button';
-wikiLinkBtn.className = 'format-button';
-wikiLinkBtn.dataset.action = 'wikiLink';
-wikiLinkBtn.title = 'Wiki Link';
+const wikiLinkBtn = document.createElement("button");
+wikiLinkBtn.type = "button";
+wikiLinkBtn.className = "format-button";
+wikiLinkBtn.dataset.action = "wikiLink";
+wikiLinkBtn.title = "Wiki Link";
 wikiLinkBtn.appendChild(createElement(Brackets, { width: 18, height: 18 }));
 
-const imageBtn = document.createElement('button');
-imageBtn.type = 'button';
-imageBtn.className = 'format-button';
-imageBtn.dataset.action = 'image';
-imageBtn.title = 'Image';
+const imageBtn = document.createElement("button");
+imageBtn.type = "button";
+imageBtn.className = "format-button";
+imageBtn.dataset.action = "image";
+imageBtn.title = "Image";
 imageBtn.appendChild(createElement(Image, { width: 18, height: 18 }));
 
-const tableBtn = document.createElement('button');
-tableBtn.type = 'button';
-tableBtn.className = 'format-button';
-tableBtn.dataset.action = 'table';
-tableBtn.title = 'Table';
+const tableBtn = document.createElement("button");
+tableBtn.type = "button";
+tableBtn.className = "format-button";
+tableBtn.dataset.action = "table";
+tableBtn.title = "Table";
 tableBtn.appendChild(createElement(Table2, { width: 18, height: 18 }));
 
-const tableDropdown = document.createElement('div');
-tableDropdown.className = 'table-dropdown';
+const tableDropdown = document.createElement("div");
+tableDropdown.className = "table-dropdown";
 
-const tableDropdownWrapper = document.createElement('div');
-tableDropdownWrapper.className = 'table-dropdown-wrapper';
+const tableDropdownWrapper = document.createElement("div");
+tableDropdownWrapper.className = "table-dropdown-wrapper";
 
-const tableGrid = document.createElement('div');
-tableGrid.className = 'table-grid';
+const tableGrid = document.createElement("div");
+tableGrid.className = "table-grid";
 
 const gridSize = 5;
 for (let row = 0; row < gridSize; row++) {
-  for (let col = 0; col < gridSize; col++) {
-    const cell = document.createElement('div');
-    cell.className = 'table-grid-cell';
-    cell.dataset.row = String(row + 1);
-    cell.dataset.col = String(col + 1);
-    if (row === 0 && col === 0) {
-      cell.classList.add('is-highlighted');
+    for (let col = 0; col < gridSize; col++) {
+        const cell = document.createElement("div");
+        cell.className = "table-grid-cell";
+        cell.dataset.row = String(row + 1);
+        cell.dataset.col = String(col + 1);
+        if (row === 0 && col === 0) {
+            cell.classList.add("is-highlighted");
+        }
+        tableGrid.appendChild(cell);
     }
-    tableGrid.appendChild(cell);
-  }
 }
 
-const tableSizeLabel = document.createElement('div');
-tableSizeLabel.className = 'table-size-label';
-tableSizeLabel.textContent = '1 x 1';
+const tableSizeLabel = document.createElement("div");
+tableSizeLabel.className = "table-size-label";
+tableSizeLabel.textContent = "1 x 1";
 
 tableDropdown.append(tableGrid, tableSizeLabel);
 tableDropdownWrapper.appendChild(tableDropdown);
 
-const tableWrapper = document.createElement('div');
-tableWrapper.className = 'table-wrapper';
+const tableWrapper = document.createElement("div");
+tableWrapper.className = "table-wrapper";
 tableWrapper.append(tableBtn, tableDropdownWrapper);
 
 let selectedTableCols = 1;
 let selectedTableRows = 1;
 
 const updateTableGridHighlight = (hoveredCol: number, hoveredRow: number) => {
-  const cells = tableGrid.querySelectorAll('.table-grid-cell');
-  cells.forEach((cell) => {
-    const cellCol = parseInt((cell as HTMLElement).dataset.col ?? '', 10);
-    const cellRow = parseInt((cell as HTMLElement).dataset.row ?? '', 10);
-    cell.classList.toggle('is-highlighted', cellCol <= hoveredCol && cellRow <= hoveredRow);
-  });
-  tableSizeLabel.textContent = `${hoveredCol} x ${hoveredRow}`;
-  selectedTableCols = hoveredCol;
-  selectedTableRows = hoveredRow;
+    const cells = tableGrid.querySelectorAll(".table-grid-cell");
+    cells.forEach((cell) => {
+        const cellCol = parseInt((cell as HTMLElement).dataset.col ?? "", 10);
+        const cellRow = parseInt((cell as HTMLElement).dataset.row ?? "", 10);
+        cell.classList.toggle("is-highlighted", cellCol <= hoveredCol && cellRow <= hoveredRow);
+    });
+    tableSizeLabel.textContent = `${hoveredCol} x ${hoveredRow}`;
+    selectedTableCols = hoveredCol;
+    selectedTableRows = hoveredRow;
 };
 
-tableGrid.addEventListener('mouseover', (event) => {
-  const cell = (event.target as Element).closest('.table-grid-cell') as HTMLElement | null;
-  if (!cell) return;
-  const col = parseInt(cell.dataset.col ?? '', 10);
-  const row = parseInt(cell.dataset.row ?? '', 10);
-  updateTableGridHighlight(col, row);
+tableGrid.addEventListener("mouseover", (event) => {
+    const cell = (event.target as Element).closest(".table-grid-cell") as HTMLElement | null;
+    if (!cell) return;
+    const col = parseInt(cell.dataset.col ?? "", 10);
+    const row = parseInt(cell.dataset.row ?? "", 10);
+    updateTableGridHighlight(col, row);
 });
 
-tableGrid.addEventListener('mouseleave', () => {
-  updateTableGridHighlight(1, 1);
+tableGrid.addEventListener("mouseleave", () => {
+    updateTableGridHighlight(1, 1);
 });
 
-tableGrid.addEventListener('click', (event) => {
-  const cell = (event.target as Element).closest('.table-grid-cell') as HTMLElement | null;
-  if (!cell || !editor) return;
-  editor.insertFormat('table', { cols: selectedTableCols, rows: selectedTableRows });
-  editor.focus();
+tableGrid.addEventListener("click", (event) => {
+    const cell = (event.target as Element).closest(".table-grid-cell") as HTMLElement | null;
+    if (!cell || !editor) return;
+    editor.insertFormat("table", { cols: selectedTableCols, rows: selectedTableRows });
+    editor.focus();
 });
 
 formatGroup.append(headingWrapper, bulletListBtn, numberedListBtn, taskBtn, separator, tableWrapper, codeBlockBtn, linkBtn, wikiLinkBtn, imageBtn, quoteBtn, hrBtn);
 
-const rightGroup = document.createElement('div');
-rightGroup.className = 'right-group';
+const rightGroup = document.createElement("div");
+rightGroup.className = "right-group";
 
-const findToggleBtn = document.createElement('button');
-findToggleBtn.type = 'button';
-findToggleBtn.className = 'format-button toggle-button';
-findToggleBtn.dataset.action = 'find';
-findToggleBtn.title = 'Find and Replace';
+const findToggleBtn = document.createElement("button");
+findToggleBtn.type = "button";
+findToggleBtn.className = "format-button toggle-button";
+findToggleBtn.dataset.action = "find";
+findToggleBtn.title = "Find and Replace";
 findToggleBtn.appendChild(createElement(Search, { width: 18, height: 18 }));
 
-const exportBtn = document.createElement('button');
-exportBtn.type = 'button';
-exportBtn.className = 'format-button export-button';
-exportBtn.dataset.action = 'export';
-exportBtn.title = 'Export';
-exportBtn.setAttribute('aria-label', 'Export');
+const exportBtn = document.createElement("button");
+exportBtn.type = "button";
+exportBtn.className = "format-button export-button";
+exportBtn.dataset.action = "export";
+exportBtn.title = "Export";
+exportBtn.setAttribute("aria-label", "Export");
 exportBtn.appendChild(createElement(Share, { width: 18, height: 18 }));
 
-const exportDropdown = document.createElement('div');
-exportDropdown.className = 'export-dropdown';
-exportDropdown.setAttribute('role', 'menu');
-exportDropdown.setAttribute('aria-label', 'Export formats');
+const exportDropdown = document.createElement("div");
+exportDropdown.className = "export-dropdown";
+exportDropdown.setAttribute("role", "menu");
+exportDropdown.setAttribute("aria-label", "Export formats");
 
-const exportDropdownWrapper = document.createElement('div');
-exportDropdownWrapper.className = 'export-dropdown-wrapper';
+const exportDropdownWrapper = document.createElement("div");
+exportDropdownWrapper.className = "export-dropdown-wrapper";
 
-const exportHtmlOption = document.createElement('button');
-exportHtmlOption.type = 'button';
-exportHtmlOption.className = 'export-dropdown-option';
-exportHtmlOption.dataset.format = 'html';
-exportHtmlOption.title = 'Export as HTML';
-exportHtmlOption.textContent = 'HTML';
+const exportHtmlOption = document.createElement("button");
+exportHtmlOption.type = "button";
+exportHtmlOption.className = "export-dropdown-option";
+exportHtmlOption.dataset.format = "html";
+exportHtmlOption.title = "Export as HTML";
+exportHtmlOption.textContent = "HTML";
 
-const exportPdfOption = document.createElement('button');
-exportPdfOption.type = 'button';
-exportPdfOption.className = 'export-dropdown-option';
-exportPdfOption.dataset.format = 'pdf';
-exportPdfOption.title = 'Export as PDF';
-exportPdfOption.textContent = 'PDF';
+const exportPdfOption = document.createElement("button");
+exportPdfOption.type = "button";
+exportPdfOption.className = "export-dropdown-option";
+exportPdfOption.dataset.format = "pdf";
+exportPdfOption.title = "Export as PDF";
+exportPdfOption.textContent = "PDF";
 
 exportDropdown.append(exportHtmlOption, exportPdfOption);
 exportDropdownWrapper.appendChild(exportDropdown);
 
-const exportWrapper = document.createElement('div');
-exportWrapper.className = 'export-wrapper';
+const exportWrapper = document.createElement("div");
+exportWrapper.className = "export-wrapper";
 exportWrapper.append(exportBtn, exportDropdownWrapper);
 
 rightGroup.append(outlineBtn, findToggleBtn, lineNumbersBtn, gitChangesGutterBtn, exportWrapper);
 
-const modeGroup = document.createElement('div');
-modeGroup.className = 'mode-group';
-modeGroup.setAttribute('role', 'tablist');
-modeGroup.setAttribute('aria-label', 'Markdown mode');
+const modeGroup = document.createElement("div");
+modeGroup.className = "mode-group";
+modeGroup.setAttribute("role", "tablist");
+modeGroup.setAttribute("aria-label", "Markdown mode");
 
-const liveButton = document.createElement('button');
-liveButton.type = 'button';
-liveButton.className = 'mode-button';
-liveButton.dataset.mode = 'live';
-liveButton.textContent = 'Live';
-liveButton.setAttribute('role', 'tab');
-liveButton.title = 'Live';
+const liveButton = document.createElement("button");
+liveButton.type = "button";
+liveButton.className = "mode-button";
+liveButton.dataset.mode = "live";
+liveButton.textContent = "Live";
+liveButton.setAttribute("role", "tab");
+liveButton.title = "Live";
 
-const sourceButton = document.createElement('button');
-sourceButton.type = 'button';
-sourceButton.className = 'mode-button';
-sourceButton.dataset.mode = 'source';
-sourceButton.textContent = 'Source';
-sourceButton.setAttribute('role', 'tab');
-sourceButton.title = 'Source';
+const sourceButton = document.createElement("button");
+sourceButton.type = "button";
+sourceButton.className = "mode-button";
+sourceButton.dataset.mode = "source";
+sourceButton.textContent = "Source";
+sourceButton.setAttribute("role", "tab");
+sourceButton.title = "Source";
 
 modeGroup.append(liveButton, sourceButton);
 
@@ -446,30 +445,30 @@ const findPanelController = createFindPanelController(findPanelElements, () => e
 const selectionMenuElements = createSelectionMenu();
 const selectionMenuController = createSelectionMenuController(selectionMenuElements, () => editor);
 
-const editorNoticeBanner = document.createElement('div');
-editorNoticeBanner.className = 'editor-notice';
-editorNoticeBanner.setAttribute('role', 'status');
-editorNoticeBanner.setAttribute('aria-live', 'polite');
+const editorNoticeBanner = document.createElement("div");
+editorNoticeBanner.className = "editor-notice";
+editorNoticeBanner.setAttribute("role", "status");
+editorNoticeBanner.setAttribute("aria-live", "polite");
 editorNoticeBanner.hidden = true;
 
 toolbar.replaceChildren(formatGroup, rightGroup, modeGroup, findPanelElements.panel, editorNoticeBanner);
 
-const existingEditorWrapper = root.querySelector('.editor-wrapper');
-const editorWrapper = existingEditorWrapper instanceof HTMLElement ? existingEditorWrapper : document.createElement('div');
-editorWrapper.className = 'editor-wrapper';
-editorWrapper.classList.remove('meo-preload-editor-shell');
-editorWrapper.removeAttribute('aria-hidden');
+const existingEditorWrapper = root.querySelector(".editor-wrapper");
+const editorWrapper = existingEditorWrapper instanceof HTMLElement ? existingEditorWrapper : document.createElement("div");
+editorWrapper.className = "editor-wrapper";
+editorWrapper.classList.remove("meo-preload-editor-shell");
+editorWrapper.removeAttribute("aria-hidden");
 
-const existingEditorHost = editorWrapper.querySelector('.editor-host');
-const editorHost = existingEditorHost instanceof HTMLElement ? existingEditorHost : document.createElement('div');
-editorHost.className = 'editor-host';
+const existingEditorHost = editorWrapper.querySelector(".editor-host");
+const editorHost = existingEditorHost instanceof HTMLElement ? existingEditorHost : document.createElement("div");
+editorHost.className = "editor-host";
 
 let editor: any = null;
 const outlineController = createOutlineController({
-  root,
-  editorWrapper,
-  outlineButton: outlineBtn,
-  getEditor: () => editor
+    root,
+    editorWrapper,
+    outlineButton: outlineBtn,
+    getEditor: () => editor,
 });
 
 editorWrapper.replaceChildren(editorHost, outlineController.sidebar, selectionMenuElements.menu);
@@ -478,11 +477,11 @@ root.replaceChildren(toolbar, editorWrapper);
 let documentVersion = 0;
 let pendingDebounce: number | null = null;
 let pendingText: string | null = null;
-let syncedText = '';
+let syncedText = "";
 let inFlight = false;
 let inFlightText: string | null = null;
 let saveAfterSync = false;
-let currentMode: 'live' | 'source' = 'live';
+let currentMode: "live" | "source" = "live";
 let hasLocalModePreference = false;
 let pendingInitialText: string | null = null;
 let initialEditorMountQueued = false;
@@ -505,76 +504,76 @@ let createEditorFactoryPromise: Promise<CreateEditorFactory> | null = null;
 const VIEW_POSITION_DEBOUNCE_MS = 250;
 const INITIAL_EDITOR_MOUNT_FALLBACK_MS = 120;
 
-const setEditorNotice = (message: string, kind = 'info') => {
-  const normalizedMessage = `${message ?? ''}`.trim();
-  if (!normalizedMessage) {
-    clearEditorNotice();
-    return;
-  }
-  editorNoticeBanner.textContent = normalizedMessage;
-  editorNoticeBanner.dataset.kind = kind;
-  editorNoticeBanner.hidden = false;
-  editorNoticeBanner.classList.add('is-visible');
+const setEditorNotice = (message: string, kind = "info") => {
+    const normalizedMessage = `${message ?? ""}`.trim();
+    if (!normalizedMessage) {
+        clearEditorNotice();
+        return;
+    }
+    editorNoticeBanner.textContent = normalizedMessage;
+    editorNoticeBanner.dataset.kind = kind;
+    editorNoticeBanner.hidden = false;
+    editorNoticeBanner.classList.add("is-visible");
 };
 
 const clearEditorNotice = () => {
-  editorNoticeBanner.textContent = '';
-  delete editorNoticeBanner.dataset.kind;
-  editorNoticeBanner.hidden = true;
-  editorNoticeBanner.classList.remove('is-visible');
+    editorNoticeBanner.textContent = "";
+    delete editorNoticeBanner.dataset.kind;
+    editorNoticeBanner.hidden = true;
+    editorNoticeBanner.classList.remove("is-visible");
 };
 
 const editorNotice: EditorNotice = {
-  setEditorNotice,
-  clearEditorNotice
+    setEditorNotice,
+    clearEditorNotice,
 };
 
 const failureNotice = createFailureNoticeManager(editorNotice);
 
 const clearGitBlameCache = ({ hideTooltip = true } = {}) => {
-  gitClient?.clearBlameCache({ hideTooltip });
+    gitClient?.clearBlameCache({ hideTooltip });
 };
 
 const bumpLocalEditGeneration = () => {
-  gitClient?.bumpLocalEditGeneration();
+    gitClient?.bumpLocalEditGeneration();
 };
 
 const loadCreateEditorFactory = async (): Promise<CreateEditorFactory> => {
-  if (!createEditorFactoryPromise) {
-    createEditorFactoryPromise = import('./editor')
-      .then((mod) => mod.createEditor)
-      .catch((error) => {
-        createEditorFactoryPromise = null;
-        throw error;
-      });
-  }
+    if (!createEditorFactoryPromise) {
+        createEditorFactoryPromise = import("./editor")
+            .then((mod) => mod.createEditor)
+            .catch((error) => {
+                createEditorFactoryPromise = null;
+                throw error;
+            });
+    }
 
-  return createEditorFactoryPromise;
+    return createEditorFactoryPromise;
 };
 
 let editorBundleWarmupScheduled = false;
 
 const scheduleEditorBundleWarmupAfterReady = () => {
-  if (editorBundleWarmupScheduled) {
-    return;
-  }
-  editorBundleWarmupScheduled = true;
+    if (editorBundleWarmupScheduled) {
+        return;
+    }
+    editorBundleWarmupScheduled = true;
 
-  const warm = () => {
-    // Wait one frame after full document readiness before warming the heavy editor bundle.
-    window.requestAnimationFrame(() => {
-      void loadCreateEditorFactory().catch((error) => {
-        logWebviewRenderError('warmEditorBundleAfterReady', error);
-      });
-    });
-  };
+    const warm = () => {
+        // Wait one frame after full document readiness before warming the heavy editor bundle.
+        window.requestAnimationFrame(() => {
+            void loadCreateEditorFactory().catch((error) => {
+                logWebviewRenderError("warmEditorBundleAfterReady", error);
+            });
+        });
+    };
 
-  if (document.readyState === 'complete') {
-    warm();
-    return;
-  }
+    if (document.readyState === "complete") {
+        warm();
+        return;
+    }
 
-  window.addEventListener('load', warm, { once: true });
+    window.addEventListener("load", warm, { once: true });
 };
 
 const READY_RETRY_DELAYS_MS = [120, 300, 700, 1300] as const;
@@ -582,1135 +581,1169 @@ let readyHandshakeAcknowledged = false;
 const readyRetryTimers = new Set<number>();
 
 const clearReadyRetryTimers = () => {
-  for (const timer of readyRetryTimers) {
-    window.clearTimeout(timer);
-  }
-  readyRetryTimers.clear();
+    for (const timer of readyRetryTimers) {
+        window.clearTimeout(timer);
+    }
+    readyRetryTimers.clear();
 };
 
 const postReadyMessage = () => {
-  if (readyHandshakeAcknowledged) {
-    return;
-  }
-  vscode.postMessage({ type: 'ready' });
+    if (readyHandshakeAcknowledged) {
+        return;
+    }
+    vscode.postMessage({ type: "ready" });
 };
 
 const scheduleReadyHandshake = () => {
-  postReadyMessage();
-  for (const delayMs of READY_RETRY_DELAYS_MS) {
-    const timer = window.setTimeout(() => {
-      readyRetryTimers.delete(timer);
-      postReadyMessage();
-    }, delayMs);
-    readyRetryTimers.add(timer);
-  }
+    postReadyMessage();
+    for (const delayMs of READY_RETRY_DELAYS_MS) {
+        const timer = window.setTimeout(() => {
+            readyRetryTimers.delete(timer);
+            postReadyMessage();
+        }, delayMs);
+        readyRetryTimers.add(timer);
+    }
 };
 
 const acknowledgeReadyHandshake = () => {
-  readyHandshakeAcknowledged = true;
-  clearReadyRetryTimers();
+    readyHandshakeAcknowledged = true;
+    clearReadyRetryTimers();
 };
 
 type WebviewUiState = {
-  mode?: 'live' | 'source';
+    mode?: "live" | "source";
 };
 
 const persistModeState = () => {
-  const state: WebviewUiState = {
-    mode: currentMode
-  };
-  vscode.setState(state);
+    const state: WebviewUiState = {
+        mode: currentMode,
+    };
+    vscode.setState(state);
 };
 
 const postFindOptions = () => {
-  vscode.postMessage({
-    type: 'setFindOptions',
-    findOptions: findPanelController.getSearchOptions()
-  });
+    vscode.postMessage({
+        type: "setFindOptions",
+        findOptions: findPanelController.getSearchOptions(),
+    });
 };
 
 const getCurrentEditorText = () => {
-  if (editor) {
-    return editor.getText();
-  }
-  if (typeof pendingText === 'string') {
-    return pendingText;
-  }
-  if (typeof pendingInitialText === 'string') {
-    return pendingInitialText;
-  }
-  return syncedText;
+    if (editor) {
+        return editor.getText();
+    }
+    if (typeof pendingText === "string") {
+        return pendingText;
+    }
+    if (typeof pendingInitialText === "string") {
+        return pendingInitialText;
+    }
+    return syncedText;
 };
 
 const syncPendingDraftState = () => {
-  const draftText = pendingText ?? inFlightText;
-  const nextDraftText =
-    draftText === null || (!inFlight && normalizeEol(draftText) === syncedText)
-      ? null
-      : draftText;
+    const draftText = pendingText ?? inFlightText;
+    const nextDraftText = draftText === null || (!inFlight && normalizeEol(draftText) === syncedText) ? null : draftText;
 
-  if (hasSentDraftText && nextDraftText === lastSentDraftText) {
-    return;
-  }
+    if (hasSentDraftText && nextDraftText === lastSentDraftText) {
+        return;
+    }
 
-  hasSentDraftText = true;
-  lastSentDraftText = nextDraftText;
-  vscode.postMessage({ type: 'draftChanged', text: nextDraftText });
+    hasSentDraftText = true;
+    lastSentDraftText = nextDraftText;
+    vscode.postMessage({ type: "draftChanged", text: nextDraftText });
 };
 
 const normalizeLineNumber = (value: unknown): number | null => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return null;
-  }
-  return Math.max(1, Math.floor(value));
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return null;
+    }
+    return Math.max(1, Math.floor(value));
 };
 
 const normalizeLineOffset = (value: unknown): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return 0;
-  }
-  return Math.max(0, Math.round(value * 100) / 100);
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return 0;
+    }
+    return Math.max(0, Math.round(value * 100) / 100);
 };
 
 const getTopVisiblePosition = (): { topLine: number; topLineOffset: number } | null => {
-  if (!editor) {
-    return null;
-  }
-  if (typeof editor.getTopVisiblePosition === 'function') {
-    const position = editor.getTopVisiblePosition();
-    const topLine = normalizeLineNumber(position?.line);
+    if (!editor) {
+        return null;
+    }
+    if (typeof editor.getTopVisiblePosition === "function") {
+        const position = editor.getTopVisiblePosition();
+        const topLine = normalizeLineNumber(position?.line);
+        if (topLine === null) {
+            return null;
+        }
+        return {
+            topLine,
+            topLineOffset: normalizeLineOffset(position?.lineOffset),
+        };
+    }
+    if (typeof editor.getTopVisibleLine !== "function") {
+        return null;
+    }
+    const topLine = normalizeLineNumber(editor.getTopVisibleLine());
     if (topLine === null) {
-      return null;
+        return null;
     }
     return {
-      topLine,
-      topLineOffset: normalizeLineOffset(position?.lineOffset)
+        topLine,
+        topLineOffset: 0,
     };
-  }
-  if (typeof editor.getTopVisibleLine !== 'function') {
-    return null;
-  }
-  const topLine = normalizeLineNumber(editor.getTopVisibleLine());
-  if (topLine === null) {
-    return null;
-  }
-  return {
-    topLine,
-    topLineOffset: 0
-  };
 };
 
 const postTopVisiblePositionIfChanged = (position: { topLine: number; topLineOffset: number } | null): void => {
-  if (!position) {
-    return;
-  }
-  if (position.topLine === lastSentTopLine && position.topLineOffset === lastSentTopLineOffset) {
-    return;
-  }
-  lastSentTopLine = position.topLine;
-  lastSentTopLineOffset = position.topLineOffset;
-  vscode.postMessage({
-    type: 'viewPositionChanged',
-    topLine: position.topLine,
-    topLineOffset: position.topLineOffset
-  });
+    if (!position) {
+        return;
+    }
+    if (position.topLine === lastSentTopLine && position.topLineOffset === lastSentTopLineOffset) {
+        return;
+    }
+    lastSentTopLine = position.topLine;
+    lastSentTopLineOffset = position.topLineOffset;
+    vscode.postMessage({
+        type: "viewPositionChanged",
+        topLine: position.topLine,
+        topLineOffset: position.topLineOffset,
+    });
 };
 
 const flushViewPositionNow = (): void => {
-  if (pendingViewPositionTimer !== null) {
-    window.clearTimeout(pendingViewPositionTimer);
-    pendingViewPositionTimer = null;
-  }
-  postTopVisiblePositionIfChanged(getTopVisiblePosition());
+    if (pendingViewPositionTimer !== null) {
+        window.clearTimeout(pendingViewPositionTimer);
+        pendingViewPositionTimer = null;
+    }
+    postTopVisiblePositionIfChanged(getTopVisiblePosition());
 };
 
 const scheduleViewPositionCapture = (): void => {
-  if (pendingViewPositionTimer !== null) {
-    window.clearTimeout(pendingViewPositionTimer);
-  }
-  pendingViewPositionTimer = window.setTimeout(() => {
-    pendingViewPositionTimer = null;
-    postTopVisiblePositionIfChanged(getTopVisiblePosition());
-  }, VIEW_POSITION_DEBOUNCE_MS);
+    if (pendingViewPositionTimer !== null) {
+        window.clearTimeout(pendingViewPositionTimer);
+    }
+    pendingViewPositionTimer = window.setTimeout(() => {
+        pendingViewPositionTimer = null;
+        postTopVisiblePositionIfChanged(getTopVisiblePosition());
+    }, VIEW_POSITION_DEBOUNCE_MS);
 };
 
 const applyPendingRestoreTopLine = (): void => {
-  if (!editor || pendingRestoreTopLine === null || pendingRevealSelection !== null) {
-    return;
-  }
-  if (typeof editor.restoreTopLine === 'function') {
-    editor.restoreTopLine(pendingRestoreTopLine, pendingRestoreTopLineOffset);
-    pendingRestoreTopLine = null;
-    pendingRestoreTopLineOffset = 0;
-  }
+    if (!editor || pendingRestoreTopLine === null || pendingRevealSelection !== null) {
+        return;
+    }
+    if (typeof editor.restoreTopLine === "function") {
+        editor.restoreTopLine(pendingRestoreTopLine, pendingRestoreTopLineOffset);
+        pendingRestoreTopLine = null;
+        pendingRestoreTopLineOffset = 0;
+    }
 };
 
 const refreshEditorSurface = (): void => {
-  if (!editor) {
-    return;
-  }
-  if (typeof editor.refreshLayout === 'function') {
-    editor.refreshLayout();
-  }
+    if (!editor) {
+        return;
+    }
+    if (typeof editor.refreshLayout === "function") {
+        editor.refreshLayout();
+    }
 };
 
 const runEditorSurfaceRecovery = (): void => {
-  pendingEditorSurfaceRecoveryRaf = null;
-  refreshEditorSurface();
-  applyPendingRestoreTopLine();
-  scheduleViewPositionCapture();
+    pendingEditorSurfaceRecoveryRaf = null;
+    refreshEditorSurface();
+    applyPendingRestoreTopLine();
+    scheduleViewPositionCapture();
 };
 
 const scheduleEditorSurfaceRecovery = (): void => {
-  if (pendingEditorSurfaceRecoveryRaf !== null) {
-    return;
-  }
-  pendingEditorSurfaceRecoveryRaf = window.requestAnimationFrame(runEditorSurfaceRecovery);
+    if (pendingEditorSurfaceRecoveryRaf !== null) {
+        return;
+    }
+    pendingEditorSurfaceRecoveryRaf = window.requestAnimationFrame(runEditorSurfaceRecovery);
 };
 
 const clampRevealOffset = (value: number, max: number): number => {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  return Math.max(0, Math.min(Math.floor(value), max));
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+    return Math.max(0, Math.min(Math.floor(value), max));
 };
 
 const applyRevealSelectionFromHost = (revealMessage: any) => {
-  if (!revealMessage || typeof revealMessage !== 'object') {
-    return;
-  }
+    if (!revealMessage || typeof revealMessage !== "object") {
+        return;
+    }
 
-  const { anchor, head, focus } = revealMessage;
-  if (typeof anchor !== 'number' || typeof head !== 'number') {
-    return;
-  }
+    const { anchor, head, focus } = revealMessage;
+    if (typeof anchor !== "number" || typeof head !== "number") {
+        return;
+    }
 
-  if (!editor) {
-    pendingRevealSelection = { anchor, head, focus };
-    return;
-  }
+    if (!editor) {
+        pendingRevealSelection = { anchor, head, focus };
+        return;
+    }
 
-  const max = editor.getText().length;
-  const clampedAnchor = clampRevealOffset(anchor, max);
-  const clampedHead = clampRevealOffset(head, max);
-  pendingRestoreTopLine = null;
-  pendingRestoreTopLineOffset = 0;
-  editor.revealSelection(clampedAnchor, clampedHead, {
-    focusEditor: focus !== false,
-    align: 'center'
-  });
-  pendingRevealSelection = null;
-  scheduleViewPositionCapture();
+    const max = editor.getText().length;
+    const clampedAnchor = clampRevealOffset(anchor, max);
+    const clampedHead = clampRevealOffset(head, max);
+    pendingRestoreTopLine = null;
+    pendingRestoreTopLineOffset = 0;
+    editor.revealSelection(clampedAnchor, clampedHead, {
+        focusEditor: focus !== false,
+        align: "center",
+    });
+    pendingRevealSelection = null;
+    scheduleViewPositionCapture();
 };
 
 const focusEditorFromHost = () => {
-  if (!editor) {
-    pendingEditorFocus = true;
-    return;
-  }
+    if (!editor) {
+        pendingEditorFocus = true;
+        return;
+    }
 
-  scheduleEditorSurfaceRecovery();
-  editor.focus();
-  pendingEditorFocus = false;
+    scheduleEditorSurfaceRecovery();
+    editor.focus();
+    pendingEditorFocus = false;
 };
 
 gitClient = createGitClient({
-  vscode,
-  getCurrentEditorText: () => getCurrentEditorText(),
-  getSyncedText: () => syncedText,
-  clearTransientUi: () => editor?.clearGitUiTransientState?.()
+    vscode,
+    getCurrentEditorText: () => getCurrentEditorText(),
+    getSyncedText: () => syncedText,
+    clearTransientUi: () => editor?.clearGitUiTransientState?.(),
 });
 
 const requestGitBlameForLine = ({ lineNumber }: { lineNumber: number }) => {
-  if (!gitClient) {
-    return Promise.resolve({ kind: 'unavailable', reason: 'error' });
-  }
-  return gitClient.requestBlameForLine({ lineNumber });
+    if (!gitClient) {
+        return Promise.resolve({ kind: "unavailable", reason: "error" });
+    }
+    return gitClient.requestBlameForLine({ lineNumber });
 };
 
 const openGitRevisionForLine = ({ lineNumber }: { lineNumber: number }) => {
-  gitClient?.openRevisionForLine({ lineNumber });
+    gitClient?.openRevisionForLine({ lineNumber });
 };
 
 const openGitWorktreeForLine = ({ lineNumber }: { lineNumber: number }) => {
-  gitClient?.openWorktreeForLine({ lineNumber });
+    gitClient?.openWorktreeForLine({ lineNumber });
 };
 
 const flushChanges = () => {
-  if (!editor || inFlight || pendingText === null || normalizeEol(pendingText) === syncedText) {
-    return;
-  }
+    if (!editor || inFlight || pendingText === null || normalizeEol(pendingText) === syncedText) {
+        return;
+    }
 
-  const nextText = pendingText;
-  const message: WebviewMessage = {
-    type: 'applyChanges',
-    baseVersion: documentVersion,
-    changes: [
-      {
-        from: 0,
-        to: syncedText.length,
-        insert: nextText
-      }
-    ]
-  };
+    const nextText = pendingText;
+    const message: WebviewMessage = {
+        type: "applyChanges",
+        baseVersion: documentVersion,
+        changes: [
+            {
+                from: 0,
+                to: syncedText.length,
+                insert: nextText,
+            },
+        ],
+    };
 
-  inFlight = true;
-  inFlightText = nextText;
-  syncedText = normalizeEol(nextText);
-  documentVersion++;
-  syncPendingDraftState();
-  vscode.postMessage(message);
+    inFlight = true;
+    inFlightText = nextText;
+    syncedText = normalizeEol(nextText);
+    documentVersion++;
+    syncPendingDraftState();
+    vscode.postMessage(message);
 };
 
 const flushPendingChangesNow = () => {
-  if (pendingDebounce !== null) {
-    window.clearTimeout(pendingDebounce);
-    pendingDebounce = null;
-  }
+    if (pendingDebounce !== null) {
+        window.clearTimeout(pendingDebounce);
+        pendingDebounce = null;
+    }
 
-  flushChanges();
+    flushChanges();
 };
 
 const maybeSaveAfterSync = () => {
-  if (!saveAfterSync) {
-    return;
-  }
+    if (!saveAfterSync) {
+        return;
+    }
 
-  if (inFlight) {
-    return;
-  }
+    if (inFlight) {
+        return;
+    }
 
-  if (pendingText !== null && normalizeEol(pendingText) !== syncedText) {
-    flushChanges();
-    return;
-  }
+    if (pendingText !== null && normalizeEol(pendingText) !== syncedText) {
+        flushChanges();
+        return;
+    }
 
-  saveAfterSync = false;
-  vscode.postMessage({ type: 'saveDocument' });
+    saveAfterSync = false;
+    vscode.postMessage({ type: "saveDocument" });
 };
 
 const requestSave = async () => {
-  saveAfterSync = true;
-  flushPendingChangesNow();
+    saveAfterSync = true;
+    flushPendingChangesNow();
 
-  let retries = 0;
-  while (inFlight && retries < 50) {
-    await new Promise(resolve => window.setTimeout(resolve, 20));
-    retries++;
-  }
+    let retries = 0;
+    while (inFlight && retries < 50) {
+        await new Promise((resolve) => window.setTimeout(resolve, 20));
+        retries++;
+    }
 
-  maybeSaveAfterSync();
+    maybeSaveAfterSync();
 };
 
 const setEditorTextSafely = (text: string, context: string): boolean => {
-  if (!editor) {
-    return false;
-  }
-
-  try {
-    editor.setText(text);
-    return true;
-  } catch (error) {
-    logWebviewRenderError('setText', error, { context });
-
-    if (currentMode === 'live') {
-      try {
-        editor.setText(text);
-        failureNotice.clearFailureNotice();
-        return true;
-      } catch (retryInLiveError) {
-        logWebviewRenderError('setText.retryInLive', retryInLiveError, { context });
-        if (!shouldAutoFallbackToSourceForLiveError(retryInLiveError)) {
-          failureNotice.setFailureNotice('Live mode hit a transient render error while updating. Try again.', 'warning');
-          return false;
-        }
-      }
-
-      failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, 'warning');
-      applyMode('source', { post: true, persist: false, reason: 'render-failure' });
-      if (!editor) {
+    if (!editor) {
         return false;
-      }
-      try {
-        editor.setText(text);
-        return true;
-      } catch (retryError) {
-        logWebviewRenderError('setText.retryInSource', retryError, { context });
-        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
-        return false;
-      }
     }
 
-    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
-    return false;
-  }
+    try {
+        editor.setText(text);
+        return true;
+    } catch (error) {
+        logWebviewRenderError("setText", error, { context });
+
+        if (currentMode === "live") {
+            try {
+                editor.setText(text);
+                failureNotice.clearFailureNotice();
+                return true;
+            } catch (retryInLiveError) {
+                logWebviewRenderError("setText.retryInLive", retryInLiveError, { context });
+                if (!shouldAutoFallbackToSourceForLiveError(retryInLiveError)) {
+                    failureNotice.setFailureNotice("Live mode hit a transient render error while updating. Try again.", "warning");
+                    return false;
+                }
+            }
+
+            failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, "warning");
+            applyMode("source", { post: true, persist: false, reason: "render-failure" });
+            if (!editor) {
+                return false;
+            }
+            try {
+                editor.setText(text);
+                return true;
+            } catch (retryError) {
+                logWebviewRenderError("setText.retryInSource", retryError, { context });
+                failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
+                return false;
+            }
+        }
+
+        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
+        return false;
+    }
 };
 
 const shortcutHandlerContext: ShortcutHandlerContext = {
-  get editor() { return editor; },
-  get currentMode() { return currentMode; },
-  get vimModeEnabled() { return vimModeEnabled; },
-  get pendingText() { return pendingText; },
-  get syncedText() { return syncedText; },
-  requestSave,
-  openFindPanel: (target) => findPanelController.open(target),
-  applyMode: (mode, options) => applyMode(mode, options),
-  flushPendingChangesNow
+    get editor() {
+        return editor;
+    },
+    get currentMode() {
+        return currentMode;
+    },
+    get vimModeEnabled() {
+        return vimModeEnabled;
+    },
+    get pendingText() {
+        return pendingText;
+    },
+    get syncedText() {
+        return syncedText;
+    },
+    requestSave,
+    openFindPanel: (target) => findPanelController.open(target),
+    applyMode: (mode, options) => applyMode(mode, options),
+    flushPendingChangesNow,
 };
 
 const queueChanges = (nextText: string) => {
-  bumpLocalEditGeneration();
-  pendingText = nextText;
-  syncPendingDraftState();
+    bumpLocalEditGeneration();
+    pendingText = nextText;
+    syncPendingDraftState();
 
-  if (pendingDebounce !== null) {
-    window.clearTimeout(pendingDebounce);
-  }
+    if (pendingDebounce !== null) {
+        window.clearTimeout(pendingDebounce);
+    }
 
-  pendingDebounce = window.setTimeout(() => {
-    pendingDebounce = null;
-    flushChanges();
-  }, 100);
+    pendingDebounce = window.setTimeout(() => {
+        pendingDebounce = null;
+        flushChanges();
+    }, 100);
 
-  if (outlineController.isVisible()) {
-    outlineController.refresh();
-  }
-  scheduleWikiLinkStatusRefresh(nextText);
-  scheduleLocalLinkStatusRefresh(nextText);
-  findPanelController.updateFindStatusSummary();
+    if (outlineController.isVisible()) {
+        outlineController.refresh();
+    }
+    scheduleWikiLinkStatusRefresh(nextText);
+    scheduleLocalLinkStatusRefresh(nextText);
+    findPanelController.updateFindStatusSummary();
 };
 
 const updateModeUI = () => {
-  root.dataset.mode = currentMode;
-  const buttons = [liveButton, sourceButton];
-  for (const button of buttons) {
-    const selected = button.dataset.mode === currentMode;
-    button.classList.toggle('is-active', selected);
-    button.setAttribute('aria-selected', selected ? 'true' : 'false');
-    button.tabIndex = selected ? 0 : -1;
-  }
+    root.dataset.mode = currentMode;
+    const buttons = [liveButton, sourceButton];
+    for (const button of buttons) {
+        const selected = button.dataset.mode === currentMode;
+        button.classList.toggle("is-active", selected);
+        button.setAttribute("aria-selected", selected ? "true" : "false");
+        button.tabIndex = selected ? 0 : -1;
+    }
 };
 
-const applyMode = (mode: 'live' | 'source', { post = true, persist = true, userTriggered = false, reason = 'user' } = {}): boolean => {
-  if (mode !== 'live' && mode !== 'source') {
-    return false;
-  }
-
-  const previousMode = currentMode;
-  const shouldRestoreEditorFocus = modeToggleShouldRestoreEditorFocus;
-  modeToggleShouldRestoreEditorFocus = false;
-  currentMode = mode;
-  clearGitBlameCache();
-  if (userTriggered) {
-    hasLocalModePreference = true;
-  }
-  updateModeUI();
-
-  if (editor) {
-    try {
-      editor.setMode(mode);
-      syncGitDiffLineHighlights();
-      if (shouldRestoreEditorFocus) {
-        editor.focus();
-      }
-      if (mode === 'live') {
-        failureNotice.clearFailureNotice();
-      }
-    } catch (error) {
-      logWebviewRenderError('applyMode', error, { requestedMode: mode, reason });
-
-      if (mode === 'live') {
-        if (!shouldAutoFallbackToSourceForLiveError(error)) {
-          failureNotice.setFailureNotice('Live mode hit a transient render error. Staying in current mode; try again.', 'warning');
-          currentMode = previousMode;
-          updateModeUI();
-          failureNotice.updateEditorNotice();
-          return false;
-        }
-
-        failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, 'warning');
-
-        try {
-          editor.setMode('source');
-          currentMode = 'source';
-          updateModeUI();
-          failureNotice.updateEditorNotice();
-          if (shouldRestoreEditorFocus) {
-            editor.focus();
-          }
-          if (post) {
-            vscode.postMessage({ type: 'setMode', mode: 'source' });
-          }
-          return false;
-        } catch (fallbackError) {
-          logWebviewRenderError('applyMode.fallbackSource', fallbackError, { requestedMode: mode, reason });
-          failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
-        }
-      }
-
-      currentMode = previousMode;
-      updateModeUI();
-      failureNotice.updateEditorNotice();
-      return false;
+const applyMode = (mode: "live" | "source", { post = true, persist = true, userTriggered = false, reason = "user" } = {}): boolean => {
+    if (mode !== "live" && mode !== "source") {
+        return false;
     }
-  }
 
-  if (persist) {
-    persistModeState();
-  }
+    const previousMode = currentMode;
+    const shouldRestoreEditorFocus = modeToggleShouldRestoreEditorFocus;
+    modeToggleShouldRestoreEditorFocus = false;
+    currentMode = mode;
+    clearGitBlameCache();
+    if (userTriggered) {
+        hasLocalModePreference = true;
+    }
+    updateModeUI();
 
-  if (post) {
-    vscode.postMessage({ type: 'setMode', mode });
-  }
+    if (editor) {
+        try {
+            editor.setMode(mode);
+            syncGitDiffLineHighlights();
+            if (shouldRestoreEditorFocus) {
+                editor.focus();
+            }
+            if (mode === "live") {
+                failureNotice.clearFailureNotice();
+            }
+        } catch (error) {
+            logWebviewRenderError("applyMode", error, { requestedMode: mode, reason });
 
-  failureNotice.updateEditorNotice();
-  return true;
+            if (mode === "live") {
+                if (!shouldAutoFallbackToSourceForLiveError(error)) {
+                    failureNotice.setFailureNotice("Live mode hit a transient render error. Staying in current mode; try again.", "warning");
+                    currentMode = previousMode;
+                    updateModeUI();
+                    failureNotice.updateEditorNotice();
+                    return false;
+                }
+
+                failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, "warning");
+
+                try {
+                    editor.setMode("source");
+                    currentMode = "source";
+                    updateModeUI();
+                    failureNotice.updateEditorNotice();
+                    if (shouldRestoreEditorFocus) {
+                        editor.focus();
+                    }
+                    if (post) {
+                        vscode.postMessage({ type: "setMode", mode: "source" });
+                    }
+                    return false;
+                } catch (fallbackError) {
+                    logWebviewRenderError("applyMode.fallbackSource", fallbackError, { requestedMode: mode, reason });
+                    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
+                }
+            }
+
+            currentMode = previousMode;
+            updateModeUI();
+            failureNotice.updateEditorNotice();
+            return false;
+        }
+    }
+
+    if (persist) {
+        persistModeState();
+    }
+
+    if (post) {
+        vscode.postMessage({ type: "setMode", mode });
+    }
+
+    failureNotice.updateEditorNotice();
+    return true;
 };
 
 const mountInitialEditor = async () => {
-  if (editor || pendingInitialText === null || initialEditorMountInFlight) {
-    return;
-  }
-  initialEditorMountInFlight = true;
-  try {
-    const createEditor = await loadCreateEditorFactory();
-    const initialText = pendingInitialText;
-    const initialTopLine = pendingRevealSelection === null ? pendingRestoreTopLine : null;
-    const initialTopLineOffset = pendingRevealSelection === null ? pendingRestoreTopLineOffset : 0;
-    if (editor || initialText === null) {
-      return;
+    if (editor || pendingInitialText === null || initialEditorMountInFlight) {
+        return;
     }
-    editor = createEditor({
-      parent: editorHost,
-      text: initialText,
-      initialMode: currentMode,
-      initialTopLine,
-      initialTopLineOffset,
-      initialLineNumbers: lineNumbersVisible,
-      initialGitGutter: gitChangesGutterVisible,
-      initialVimMode: vimModeEnabled,
-      onApplyChanges: queueChanges,
-      onOpenLink: (href: string) => {
-        vscode.postMessage({ type: 'openLink', href });
-      },
-      onSelectionChange: (state: any) => selectionMenuController.update(state),
-      onViewportChange: () => scheduleViewPositionCapture(),
-      onRequestGitBlame: requestGitBlameForLine,
-      onOpenGitRevisionForLine: openGitRevisionForLine,
-      onOpenGitWorktreeForLine: openGitWorktreeForLine
-    });
-    gitClient?.applyBaselineToEditor(editor);
-    syncGitDiffLineHighlights();
-    if (initialTopLine !== null) {
-      pendingRestoreTopLine = null;
-      pendingRestoreTopLineOffset = 0;
-    }
-    editor.focus();
-    pendingInitialText = null;
-    initialMountRecoveryAttempted = false;
-    if (currentMode === 'live') {
-      failureNotice.clearFailureNotice();
-    }
-    requestWikiLinkStatuses(initialText);
-    requestLocalLinkStatuses(initialText);
-    if (pendingRevealSelection) {
-      applyRevealSelectionFromHost(pendingRevealSelection);
-    }
-    if (pendingEditorFocus) {
-      focusEditorFromHost();
-    }
-    if (outlineController.isVisible()) {
-      outlineController.refresh();
-    }
-    failureNotice.updateEditorNotice();
-    
-    setWikiLinkRefreshContext({
-      refreshDecorations: () => editor?.refreshDecorations?.()
-    });
-    setLocalLinkRefreshContext({
-      refreshDecorations: () => editor?.refreshDecorations?.()
-    });
-    scheduleEditorSurfaceRecovery();
-  } catch (error) {
-    logWebviewRenderError('mountInitialEditor', error);
-
-    if (currentMode === 'live') {
-      if (!shouldAutoFallbackToSourceForLiveError(error)) {
-        if (!initialMountRecoveryAttempted) {
-          initialMountRecoveryAttempted = true;
-          failureNotice.setFailureNotice('Live mode hit a transient render error while loading. Retrying...', 'warning');
-          scheduleInitialEditorMount();
-          return;
+    initialEditorMountInFlight = true;
+    try {
+        const createEditor = await loadCreateEditorFactory();
+        const initialText = pendingInitialText;
+        const initialTopLine = pendingRevealSelection === null ? pendingRestoreTopLine : null;
+        const initialTopLineOffset = pendingRevealSelection === null ? pendingRestoreTopLineOffset : 0;
+        if (editor || initialText === null) {
+            return;
         }
-        failureNotice.setFailureNotice('Live mode hit a transient render error while loading. Try reopening or switching modes.', 'warning');
-        return;
-      }
+        editor = createEditor({
+            parent: editorHost,
+            text: initialText,
+            initialMode: currentMode,
+            initialTopLine,
+            initialTopLineOffset,
+            initialLineNumbers: lineNumbersVisible,
+            initialGitGutter: gitChangesGutterVisible,
+            initialVimMode: vimModeEnabled,
+            initialVimKeybindings: vimKeybindingsState,
+            initialVimLeader: vimLeaderState,
+            onApplyChanges: queueChanges,
+            onOpenLink: (href: string) => {
+                vscode.postMessage({ type: "openLink", href });
+            },
+            onSelectionChange: (state: any) => selectionMenuController.update(state),
+            onViewportChange: () => scheduleViewPositionCapture(),
+            onRequestGitBlame: requestGitBlameForLine,
+            onOpenGitRevisionForLine: openGitRevisionForLine,
+            onOpenGitWorktreeForLine: openGitWorktreeForLine,
+        });
+        gitClient?.applyBaselineToEditor(editor);
+        syncGitDiffLineHighlights();
+        if (initialTopLine !== null) {
+            pendingRestoreTopLine = null;
+            pendingRestoreTopLineOffset = 0;
+        }
+        editor.focus();
+        pendingInitialText = null;
+        initialMountRecoveryAttempted = false;
+        if (currentMode === "live") {
+            failureNotice.clearFailureNotice();
+        }
+        requestWikiLinkStatuses(initialText);
+        requestLocalLinkStatuses(initialText);
+        if (pendingRevealSelection) {
+            applyRevealSelectionFromHost(pendingRevealSelection);
+        }
+        if (pendingEditorFocus) {
+            focusEditorFromHost();
+        }
+        if (outlineController.isVisible()) {
+            outlineController.refresh();
+        }
+        failureNotice.updateEditorNotice();
 
-      if (!initialMountRecoveryAttempted) {
-        initialMountRecoveryAttempted = true;
-        failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, 'warning');
-        applyMode('source', { post: true, persist: false, reason: 'render-failure' });
-        scheduleInitialEditorMount();
-        return;
-      }
+        setWikiLinkRefreshContext({
+            refreshDecorations: () => editor?.refreshDecorations?.(),
+        });
+        setLocalLinkRefreshContext({
+            refreshDecorations: () => editor?.refreshDecorations?.(),
+        });
+        scheduleEditorSurfaceRecovery();
+    } catch (error) {
+        logWebviewRenderError("mountInitialEditor", error);
+
+        if (currentMode === "live") {
+            if (!shouldAutoFallbackToSourceForLiveError(error)) {
+                if (!initialMountRecoveryAttempted) {
+                    initialMountRecoveryAttempted = true;
+                    failureNotice.setFailureNotice("Live mode hit a transient render error while loading. Retrying...", "warning");
+                    scheduleInitialEditorMount();
+                    return;
+                }
+                failureNotice.setFailureNotice("Live mode hit a transient render error while loading. Try reopening or switching modes.", "warning");
+                return;
+            }
+
+            if (!initialMountRecoveryAttempted) {
+                initialMountRecoveryAttempted = true;
+                failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, "warning");
+                applyMode("source", { post: true, persist: false, reason: "render-failure" });
+                scheduleInitialEditorMount();
+                return;
+            }
+        }
+
+        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
+    } finally {
+        initialEditorMountInFlight = false;
     }
-
-    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
-  } finally {
-    initialEditorMountInFlight = false;
-  }
 };
 
 const scheduleInitialEditorMount = () => {
-  if (editor || initialEditorMountQueued) {
-    return;
-  }
-
-  const runScheduledMount = () => {
-    if (!initialEditorMountQueued) {
-      return;
+    if (editor || initialEditorMountQueued) {
+        return;
     }
-    initialEditorMountQueued = false;
-    if (initialEditorMountFallbackTimer !== null) {
-      window.clearTimeout(initialEditorMountFallbackTimer);
-      initialEditorMountFallbackTimer = null;
-    }
-    void mountInitialEditor();
-    findPanelController.updateFindStatusSummary();
-  };
 
-  initialEditorMountQueued = true;
-  window.requestAnimationFrame(runScheduledMount);
-  initialEditorMountFallbackTimer = window.setTimeout(
-    runScheduledMount,
-    INITIAL_EDITOR_MOUNT_FALLBACK_MS
-  );
+    const runScheduledMount = () => {
+        if (!initialEditorMountQueued) {
+            return;
+        }
+        initialEditorMountQueued = false;
+        if (initialEditorMountFallbackTimer !== null) {
+            window.clearTimeout(initialEditorMountFallbackTimer);
+            initialEditorMountFallbackTimer = null;
+        }
+        void mountInitialEditor();
+        findPanelController.updateFindStatusSummary();
+    };
+
+    initialEditorMountQueued = true;
+    window.requestAnimationFrame(runScheduledMount);
+    initialEditorMountFallbackTimer = window.setTimeout(runScheduledMount, INITIAL_EDITOR_MOUNT_FALLBACK_MS);
 };
 
 const handleInit = (message: any) => {
-  pendingRestoreTopLine = normalizeLineNumber(message.restoreTopLine);
-  pendingRestoreTopLineOffset = normalizeLineOffset(message.restoreTopLineOffset);
-  lastSentTopLine = null;
-  lastSentTopLineOffset = null;
-  if (!editor) {
-    pendingInitialText = message.text;
-    scheduleInitialEditorMount();
-  } else {
-    setEditorTextSafely(message.text, 'init');
-  }
-  if (typeof message.lineNumbers === 'boolean') {
-    setLineNumbersVisible(message.lineNumbers, { post: false });
-  }
-  if (typeof message.gitChangesGutter === 'boolean') {
-    setGitChangesGutterVisible(message.gitChangesGutter, { post: false });
-  }
-  if (typeof message.gitDiffLineHighlights === 'boolean') {
-    gitDiffLineHighlightsEnabled = message.gitDiffLineHighlights;
-    syncGitDiffLineHighlights();
-  }
-  if (typeof message.vimMode === 'boolean') {
-    setVimModeEnabled(message.vimMode);
-  }
-  if (message.findOptions && typeof message.findOptions === 'object') {
-    findPanelController.setSearchOptions(message.findOptions);
-  }
-  outlineController.setPosition(message.outlinePosition);
-  if (typeof message.outlineVisible === 'boolean') {
-    setOutlineVisible(message.outlineVisible, { post: false });
-  }
-  if (editor && outlineController.isVisible()) {
-    outlineController.refresh();
-  }
-  scheduleEditorSurfaceRecovery();
-  scheduleWikiLinkStatusRefresh(message.text);
-  scheduleLocalLinkStatusRefresh(message.text);
-  findPanelController.updateFindStatusSummary();
+    pendingRestoreTopLine = normalizeLineNumber(message.restoreTopLine);
+    pendingRestoreTopLineOffset = normalizeLineOffset(message.restoreTopLineOffset);
+    lastSentTopLine = null;
+    lastSentTopLineOffset = null;
+    if (!editor) {
+        pendingInitialText = message.text;
+        scheduleInitialEditorMount();
+    } else {
+        setEditorTextSafely(message.text, "init");
+    }
+    if (typeof message.lineNumbers === "boolean") {
+        setLineNumbersVisible(message.lineNumbers, { post: false });
+    }
+    if (typeof message.gitChangesGutter === "boolean") {
+        setGitChangesGutterVisible(message.gitChangesGutter, { post: false });
+    }
+    if (typeof message.gitDiffLineHighlights === "boolean") {
+        gitDiffLineHighlightsEnabled = message.gitDiffLineHighlights;
+        syncGitDiffLineHighlights();
+    }
+    if (typeof message.vimMode === "boolean") {
+        setVimModeEnabled(message.vimMode);
+    }
+    if (Array.isArray(message.vimKeybindings)) {
+        vimKeybindingsState = message.vimKeybindings;
+        vimLeaderState = typeof message.vimLeader === "string" ? message.vimLeader : "\\";
+        editor?.setVimKeybindings(vimKeybindingsState, vimLeaderState);
+    }
+    if (message.findOptions && typeof message.findOptions === "object") {
+        findPanelController.setSearchOptions(message.findOptions);
+    }
+    outlineController.setPosition(message.outlinePosition);
+    if (typeof message.outlineVisible === "boolean") {
+        setOutlineVisible(message.outlineVisible, { post: false });
+    }
+    if (editor && outlineController.isVisible()) {
+        outlineController.refresh();
+    }
+    scheduleEditorSurfaceRecovery();
+    scheduleWikiLinkStatusRefresh(message.text);
+    scheduleLocalLinkStatusRefresh(message.text);
+    findPanelController.updateFindStatusSummary();
 };
 
 const exportHandlerContext: ExportHandlerContext = {
-  vscode,
-  getEditor: () => editor,
-  get pendingText() { return pendingText; },
-  get pendingInitialText() { return pendingInitialText; },
-  get syncedText() { return syncedText; },
-  get pendingDebounce() { return pendingDebounce; },
-  get inFlight() { return inFlight; },
-  flushChanges,
-  normalizeEol,
-  setPendingDebounce: (value) => { pendingDebounce = value; }
+    vscode,
+    getEditor: () => editor,
+    get pendingText() {
+        return pendingText;
+    },
+    get pendingInitialText() {
+        return pendingInitialText;
+    },
+    get syncedText() {
+        return syncedText;
+    },
+    get pendingDebounce() {
+        return pendingDebounce;
+    },
+    get inFlight() {
+        return inFlight;
+    },
+    flushChanges,
+    normalizeEol,
+    setPendingDebounce: (value) => {
+        pendingDebounce = value;
+    },
 };
 
 const exportHandler = createExportHandler(exportHandlerContext);
 
 const withMessageErrorBoundary = (context: string, action: () => void): void => {
-  try {
-    action();
-  } catch (error) {
-    console.error(`[MEO webview] ${context}`, error);
-  }
+    try {
+        action();
+    } catch (error) {
+        console.error(`[MEO webview] ${context}`, error);
+    }
 };
 
-window.addEventListener('message', (event) => {
-  const message = event.data;
+window.addEventListener("message", (event) => {
+    const message = event.data;
 
-  if (!message || typeof message !== 'object') {
-    return;
-  }
+    if (!message || typeof message !== "object") {
+        return;
+    }
 
-  if (message.type === 'init') {
-    acknowledgeReadyHandshake();
-    withMessageErrorBoundary('init handler', () => {
-      applyThemeSettings(message.theme);
-      initialMountRecoveryAttempted = false;
-      failureNotice.clearFailureNotice();
-      gitClient?.resetForInit({ hideTooltip: false });
-      const nextMode = hasLocalModePreference ? currentMode : message.mode;
-      documentVersion = message.version;
-      syncedText = normalizeEol(message.text);
-      pendingText = null;
-      inFlight = false;
-      inFlightText = null;
-      saveAfterSync = false;
-      syncPendingDraftState();
+    if (message.type === "init") {
+        acknowledgeReadyHandshake();
+        withMessageErrorBoundary("init handler", () => {
+            applyThemeSettings(message.theme);
+            initialMountRecoveryAttempted = false;
+            failureNotice.clearFailureNotice();
+            gitClient?.resetForInit({ hideTooltip: false });
+            const nextMode = hasLocalModePreference ? currentMode : message.mode;
+            documentVersion = message.version;
+            syncedText = normalizeEol(message.text);
+            pendingText = null;
+            inFlight = false;
+            inFlightText = null;
+            saveAfterSync = false;
+            syncPendingDraftState();
 
-      handleInit(message);
-      if (hasLocalModePreference) {
-        applyMode(nextMode, {
-          post: true,
-          persist: true,
-          reason: 'init'
+            handleInit(message);
+            if (hasLocalModePreference) {
+                applyMode(nextMode, {
+                    post: true,
+                    persist: true,
+                    reason: "init",
+                });
+            } else {
+                applyMode(nextMode, {
+                    post: false,
+                    persist: false,
+                    reason: "init",
+                });
+            }
+            failureNotice.updateEditorNotice();
         });
-      } else {
-        applyMode(nextMode, {
-          post: false,
-          persist: false,
-          reason: 'init'
+        return;
+    }
+
+    if (message.type === "themeChanged") {
+        withMessageErrorBoundary("themeChanged handler", () => {
+            applyThemeSettings(message.theme);
         });
-      }
-      failureNotice.updateEditorNotice();
-    });
-    return;
-  }
+        return;
+    }
 
-  if (message.type === 'themeChanged') {
-    withMessageErrorBoundary('themeChanged handler', () => {
-      applyThemeSettings(message.theme);
-    });
-    return;
-  }
+    if (message.type === "revealSelection") {
+        applyRevealSelectionFromHost(message);
+        return;
+    }
 
-  if (message.type === 'revealSelection') {
-    applyRevealSelectionFromHost(message);
-    return;
-  }
+    if (message.type === "focusEditor") {
+        focusEditorFromHost();
+        return;
+    }
 
-  if (message.type === 'focusEditor') {
-    focusEditorFromHost();
-    return;
-  }
+    if (message.type === "toggleMode") {
+        applyMode(currentMode === "live" ? "source" : "live", { userTriggered: true, reason: "command" });
+        return;
+    }
 
-  if (message.type === 'toggleMode') {
-    applyMode(currentMode === 'live' ? 'source' : 'live', { userTriggered: true, reason: 'command' });
-    return;
-  }
+    if (message.type === "docChanged" && !editor && pendingInitialText !== null) {
+        clearGitBlameCache({ hideTooltip: false });
+        documentVersion = message.version;
+        syncedText = normalizeEol(message.text);
+        pendingInitialText = message.text;
+        return;
+    }
 
-  if (message.type === 'docChanged' && !editor && pendingInitialText !== null) {
-    clearGitBlameCache({ hideTooltip: false });
-    documentVersion = message.version;
-    syncedText = normalizeEol(message.text);
-    pendingInitialText = message.text;
-    return;
-  }
+    if (message.type === "docChanged" && editor) {
+        clearGitBlameCache();
+        const incomingText = normalizeEol(message.text);
+        const currentText = normalizeEol(editor.getText());
+        const pendingNormalized = pendingText === null ? null : normalizeEol(pendingText);
+        const inFlightNormalized = inFlightText === null ? null : normalizeEol(inFlightText);
 
-  if (message.type === 'docChanged' && editor) {
-    clearGitBlameCache();
-    const incomingText = normalizeEol(message.text);
-    const currentText = normalizeEol(editor.getText());
-    const pendingNormalized = pendingText === null ? null : normalizeEol(pendingText);
-    const inFlightNormalized = inFlightText === null ? null : normalizeEol(inFlightText);
+        documentVersion = message.version;
 
-    documentVersion = message.version;
+        if (incomingText === currentText) {
+            syncedText = currentText;
 
-    if (incomingText === currentText) {
-      syncedText = currentText;
+            if (pendingNormalized === incomingText) {
+                pendingText = null;
+            }
 
-      if (pendingNormalized === incomingText) {
+            if (inFlight && inFlightNormalized === incomingText) {
+                inFlight = false;
+                inFlightText = null;
+            }
+
+            flushChanges();
+            maybeSaveAfterSync();
+            syncPendingDraftState();
+            return;
+        }
+
+        if (inFlight && inFlightNormalized === incomingText) {
+            syncedText = incomingText;
+            inFlight = false;
+            inFlightText = null;
+            flushChanges();
+            maybeSaveAfterSync();
+            syncPendingDraftState();
+            return;
+        }
+
+        if (pendingNormalized === incomingText) {
+            syncedText = incomingText;
+            pendingText = null;
+            inFlight = false;
+            inFlightText = null;
+            flushChanges();
+            maybeSaveAfterSync();
+            syncPendingDraftState();
+            return;
+        }
+
+        syncedText = incomingText;
         pendingText = null;
-      }
-
-      if (inFlight && inFlightNormalized === incomingText) {
         inFlight = false;
         inFlightText = null;
-      }
+        saveAfterSync = false;
 
-      flushChanges();
-      maybeSaveAfterSync();
-      syncPendingDraftState();
-      return;
+        if (pendingDebounce !== null) {
+            window.clearTimeout(pendingDebounce);
+            pendingDebounce = null;
+        }
+
+        syncPendingDraftState();
+        if (!setEditorTextSafely(message.text, "docChanged")) {
+            return;
+        }
+        scheduleWikiLinkStatusRefresh(message.text);
+        scheduleLocalLinkStatusRefresh(message.text);
+        findPanelController.updateFindStatusSummary();
+        return;
     }
 
-    if (inFlight && inFlightNormalized === incomingText) {
-      syncedText = incomingText;
-      inFlight = false;
-      inFlightText = null;
-      flushChanges();
-      maybeSaveAfterSync();
-      syncPendingDraftState();
-      return;
+    if (message.type === "applied") {
+        documentVersion = message.version;
+        if (inFlightText !== null) {
+            syncedText = normalizeEol(inFlightText);
+        }
+        inFlight = false;
+        inFlightText = null;
+        flushChanges();
+        maybeSaveAfterSync();
+        syncPendingDraftState();
+        return;
     }
 
-    if (pendingNormalized === incomingText) {
-      syncedText = incomingText;
-      pendingText = null;
-      inFlight = false;
-      inFlightText = null;
-      flushChanges();
-      maybeSaveAfterSync();
-      syncPendingDraftState();
-      return;
+    if (message.type === "lineNumbersChanged") {
+        setLineNumbersVisible(message.enabled, { post: false });
+        return;
     }
 
-    syncedText = incomingText;
-    pendingText = null;
-    inFlight = false;
-    inFlightText = null;
-    saveAfterSync = false;
-
-    if (pendingDebounce !== null) {
-      window.clearTimeout(pendingDebounce);
-      pendingDebounce = null;
+    if (message.type === "gitChangesGutterChanged") {
+        setGitChangesGutterVisible(message.enabled, { post: false });
+        return;
     }
 
-    syncPendingDraftState();
-    if (!setEditorTextSafely(message.text, 'docChanged')) {
-      return;
+    if (message.type === "gitDiffLineHighlightsChanged") {
+        gitDiffLineHighlightsEnabled = message.enabled;
+        syncGitDiffLineHighlights();
+        return;
     }
-    scheduleWikiLinkStatusRefresh(message.text);
-    scheduleLocalLinkStatusRefresh(message.text);
-    findPanelController.updateFindStatusSummary();
-    return;
-  }
 
-  if (message.type === 'applied') {
-    documentVersion = message.version;
-    if (inFlightText !== null) {
-      syncedText = normalizeEol(inFlightText);
+    if (message.type === "vimModeChanged") {
+        setVimModeEnabled(message.enabled);
+        return;
     }
-    inFlight = false;
-    inFlightText = null;
-    flushChanges();
-    maybeSaveAfterSync();
-    syncPendingDraftState();
-    return;
-  }
 
-  if (message.type === 'lineNumbersChanged') {
-    setLineNumbersVisible(message.enabled, { post: false });
-    return;
-  }
-
-  if (message.type === 'gitChangesGutterChanged') {
-    setGitChangesGutterVisible(message.enabled, { post: false });
-    return;
-  }
-
-  if (message.type === 'gitDiffLineHighlightsChanged') {
-    gitDiffLineHighlightsEnabled = message.enabled;
-    syncGitDiffLineHighlights();
-    return;
-  }
-
-  if (message.type === 'vimModeChanged') {
-    setVimModeEnabled(message.enabled);
-    return;
-  }
-
-  if (message.type === 'findOptionsChanged') {
-    if (message.findOptions && typeof message.findOptions === 'object') {
-      findPanelController.setSearchOptions(message.findOptions);
-      findPanelController.updateFindStatusSummary();
+    if (message.type === "vimKeybindingsChanged") {
+        vimKeybindingsState = message.keybindings;
+        vimLeaderState = message.leaderKey;
+        editor?.setVimKeybindings(vimKeybindingsState, vimLeaderState);
+        return;
     }
-    return;
-  }
 
-  if (message.type === 'outlineVisibilityChanged') {
-    setOutlineVisible(message.visible, { post: false });
-    return;
-  }
-
-  if (message.type === 'gitBaselineChanged') {
-    if (typeof message.version === 'number' && message.version < documentVersion) {
-      return;
+    if (message.type === "findOptionsChanged") {
+        if (message.findOptions && typeof message.findOptions === "object") {
+            findPanelController.setSearchOptions(message.findOptions);
+            findPanelController.updateFindStatusSummary();
+        }
+        return;
     }
-    gitClient?.handleMessage(message, { editor });
-    return;
-  }
 
-  if (message.type === 'gitBlameResult') {
-    gitClient?.handleMessage(message, { editor });
-    return;
-  }
-
-  if (message.type === 'outlinePositionChanged') {
-    outlineController.setPosition(message.position);
-    return;
-  }
-
-  if (message.type === 'resolvedImageSrc') {
-    settleImageSrcRequest(message.requestId, message.resolvedUrl);
-    return;
-  }
-
-  if (message.type === 'resolvedWikiLinks') {
-    if (handleResolvedWikiLinks(message)) {
-      editor?.refreshDecorations();
+    if (message.type === "outlineVisibilityChanged") {
+        setOutlineVisible(message.visible, { post: false });
+        return;
     }
-    return;
-  }
 
-  if (message.type === 'resolvedLocalLinks') {
-    if (handleResolvedLocalLinks(message)) {
-      editor?.refreshDecorations();
+    if (message.type === "gitBaselineChanged") {
+        if (typeof message.version === "number" && message.version < documentVersion) {
+            return;
+        }
+        gitClient?.handleMessage(message, { editor });
+        return;
     }
-    return;
-  }
 
-  if (message.type === 'savedImagePath') {
-    handleSavedImagePath(message);
-    return;
-  }
-
-  if (message.type === 'requestExportSnapshot') {
-    if (typeof message.requestId !== 'string' || !message.requestId) {
-      return;
+    if (message.type === "gitBlameResult") {
+        gitClient?.handleMessage(message, { editor });
+        return;
     }
-    void exportHandler.handleExportSnapshotRequest(message.requestId);
-  }
+
+    if (message.type === "outlinePositionChanged") {
+        outlineController.setPosition(message.position);
+        return;
+    }
+
+    if (message.type === "resolvedImageSrc") {
+        settleImageSrcRequest(message.requestId, message.resolvedUrl);
+        return;
+    }
+
+    if (message.type === "resolvedWikiLinks") {
+        if (handleResolvedWikiLinks(message)) {
+            editor?.refreshDecorations();
+        }
+        return;
+    }
+
+    if (message.type === "resolvedLocalLinks") {
+        if (handleResolvedLocalLinks(message)) {
+            editor?.refreshDecorations();
+        }
+        return;
+    }
+
+    if (message.type === "savedImagePath") {
+        handleSavedImagePath(message);
+        return;
+    }
+
+    if (message.type === "requestExportSnapshot") {
+        if (typeof message.requestId !== "string" || !message.requestId) {
+            return;
+        }
+        void exportHandler.handleExportSnapshotRequest(message.requestId);
+    }
 });
 
-window.addEventListener('keydown', (event) => {
-  handleEditorShortcut(event, shortcutHandlerContext);
-}, { capture: true });
+window.addEventListener(
+    "keydown",
+    (event) => {
+        handleEditorShortcut(event, shortcutHandlerContext);
+    },
+    { capture: true },
+);
 
-window.addEventListener('paste', async (event) => {
-  if (!editor) {
-    return;
-  }
-
-  const stateAtPaste = editor.view.state;
-  const selectionAtPaste = stateAtPaste.selection.main;
-  const lineAtPaste = stateAtPaste.doc.lineAt(selectionAtPaste.head);
-  const lineNumberAtPaste = lineAtPaste.number;
-  const lineOffsetAtPaste = selectionAtPaste.head - lineAtPaste.from;
-
-  await handleImagePaste(event, editor, {
-    lineNumber: lineNumberAtPaste,
-    lineOffset: lineOffsetAtPaste
-  });
-});
-
-window.addEventListener('blur', () => {
-  flushPendingChangesNow();
-  flushViewPositionNow();
-});
-
-window.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'hidden') {
-    if (pendingEditorSurfaceRecoveryRaf !== null) {
-      window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
-      pendingEditorSurfaceRecoveryRaf = null;
+window.addEventListener("paste", async (event) => {
+    if (!editor) {
+        return;
     }
-    forceFlushChanges();
-    return;
-  }
-  scheduleEditorSurfaceRecovery();
+
+    const stateAtPaste = editor.view.state;
+    const selectionAtPaste = stateAtPaste.selection.main;
+    const lineAtPaste = stateAtPaste.doc.lineAt(selectionAtPaste.head);
+    const lineNumberAtPaste = lineAtPaste.number;
+    const lineOffsetAtPaste = selectionAtPaste.head - lineAtPaste.from;
+
+    await handleImagePaste(event, editor, {
+        lineNumber: lineNumberAtPaste,
+        lineOffset: lineOffsetAtPaste,
+    });
 });
 
-window.addEventListener('focus', () => {
-  scheduleEditorSurfaceRecovery();
+window.addEventListener("blur", () => {
+    flushPendingChangesNow();
+    flushViewPositionNow();
+});
+
+window.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+        if (pendingEditorSurfaceRecoveryRaf !== null) {
+            window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
+            pendingEditorSurfaceRecoveryRaf = null;
+        }
+        forceFlushChanges();
+        return;
+    }
+    scheduleEditorSurfaceRecovery();
+});
+
+window.addEventListener("focus", () => {
+    scheduleEditorSurfaceRecovery();
 });
 
 const forceFlushChanges = () => {
-  flushChanges();
-  flushViewPositionNow();
+    flushChanges();
+    flushViewPositionNow();
 };
 
-window.addEventListener('beforeunload', () => {
-  clearReadyRetryTimers();
-  cancelPendingWikiStatusRefresh();
-  cancelPendingLocalLinkStatusRefresh();
-  clearGitBlameCache({ hideTooltip: false });
+window.addEventListener("beforeunload", () => {
+    clearReadyRetryTimers();
+    cancelPendingWikiStatusRefresh();
+    cancelPendingLocalLinkStatusRefresh();
+    clearGitBlameCache({ hideTooltip: false });
 
-  if (initialEditorMountFallbackTimer !== null) {
-    window.clearTimeout(initialEditorMountFallbackTimer);
-    initialEditorMountFallbackTimer = null;
-  }
-  if (pendingEditorSurfaceRecoveryRaf !== null) {
-    window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
-    pendingEditorSurfaceRecoveryRaf = null;
-  }
+    if (initialEditorMountFallbackTimer !== null) {
+        window.clearTimeout(initialEditorMountFallbackTimer);
+        initialEditorMountFallbackTimer = null;
+    }
+    if (pendingEditorSurfaceRecoveryRaf !== null) {
+        window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
+        pendingEditorSurfaceRecoveryRaf = null;
+    }
 
-  if (pendingDebounce !== null) {
-    window.clearTimeout(pendingDebounce);
-    pendingDebounce = null;
-  }
+    if (pendingDebounce !== null) {
+        window.clearTimeout(pendingDebounce);
+        pendingDebounce = null;
+    }
 
-  forceFlushChanges();
+    forceFlushChanges();
 });
 
-window.addEventListener('resize', () => {
-  findPanelController.updateAnchor();
-  if (editor) {
-    editor.refreshSelectionOverlay();
-  }
+window.addEventListener("resize", () => {
+    findPanelController.updateAnchor();
+    if (editor) {
+        editor.refreshSelectionOverlay();
+    }
 });
 
 const state = vscode.getState() as WebviewUiState | undefined;
-if (state && (state.mode === 'live' || state.mode === 'source')) {
-  applyMode(state.mode, { post: false, persist: false });
-  hasLocalModePreference = true;
+if (state && (state.mode === "live" || state.mode === "source")) {
+    applyMode(state.mode, { post: false, persist: false });
+    hasLocalModePreference = true;
 } else {
-  updateModeUI();
+    updateModeUI();
 }
-outlineController.setPosition('right');
+outlineController.setPosition("right");
 updateLineNumbersUI();
 updateGitChangesGutterUI();
 
-liveButton.addEventListener('click', () => {
-  applyMode('live', { userTriggered: true });
+liveButton.addEventListener("click", () => {
+    applyMode("live", { userTriggered: true });
 });
 
-sourceButton.addEventListener('click', () => {
-  applyMode('source', { userTriggered: true });
+sourceButton.addEventListener("click", () => {
+    applyMode("source", { userTriggered: true });
 });
 
 const preserveEditorFocusOnModePointerToggle = (event: PointerEvent) => {
-  const target = event.target;
-  if (!(target instanceof Element) || !target.closest('.mode-button')) {
-    return;
-  }
-  if (!editor || !editor.hasFocus()) {
-    modeToggleShouldRestoreEditorFocus = false;
-    return;
-  }
-  modeToggleShouldRestoreEditorFocus = true;
-  event.preventDefault();
+    const target = event.target;
+    if (!(target instanceof Element) || !target.closest(".mode-button")) {
+        return;
+    }
+    if (!editor || !editor.hasFocus()) {
+        modeToggleShouldRestoreEditorFocus = false;
+        return;
+    }
+    modeToggleShouldRestoreEditorFocus = true;
+    event.preventDefault();
 };
 
-modeGroup.addEventListener('pointerdown', preserveEditorFocusOnModePointerToggle);
+modeGroup.addEventListener("pointerdown", preserveEditorFocusOnModePointerToggle);
 
 const handleFormatAction = (action: string) => {
-  if (!editor) return;
-  editor.insertFormat(action);
-  editor.focus();
+    if (!editor) return;
+    editor.insertFormat(action);
+    editor.focus();
 };
 
-findPanelElements.findInput.addEventListener('input', () => {
-  findPanelController.updateFindStatusSummary();
+findPanelElements.findInput.addEventListener("input", () => {
+    findPanelController.updateFindStatusSummary();
 });
 
-findPanelElements.wholeWordBtn.addEventListener('click', () => {
-  findPanelController.toggleWholeWord();
-  postFindOptions();
+findPanelElements.wholeWordBtn.addEventListener("click", () => {
+    findPanelController.toggleWholeWord();
+    postFindOptions();
 });
 
-findPanelElements.caseSensitiveBtn.addEventListener('click', () => {
-  findPanelController.toggleCaseSensitive();
-  postFindOptions();
+findPanelElements.caseSensitiveBtn.addEventListener("click", () => {
+    findPanelController.toggleCaseSensitive();
+    postFindOptions();
 });
 
-findPanelElements.panel.addEventListener('keydown', (event) => {
-  if (event.key !== 'Escape' || !findPanelController.isVisible()) {
-    return;
-  }
+findPanelElements.panel.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || !findPanelController.isVisible()) {
+        return;
+    }
 
-  event.preventDefault();
-  event.stopPropagation();
-  findPanelController.close();
-});
-
-findPanelElements.findInput.addEventListener('keydown', (event) => {
-  if (event.key === 'Enter') {
     event.preventDefault();
-    findPanelController.runFind(event.shiftKey, { focusEditor: false });
-    return;
-  }
-});
-
-findPanelElements.replaceInput.addEventListener('keydown', (event) => {
-  if (event.key === 'Enter') {
-    event.preventDefault();
-    findPanelController.runReplace();
-    return;
-  }
-});
-
-findPanelElements.findPrevBtn.addEventListener('click', () => {
-  findPanelController.runFind(true);
-});
-
-findPanelElements.findNextBtn.addEventListener('click', () => {
-  findPanelController.runFind(false);
-});
-
-findPanelElements.replaceBtn.addEventListener('click', () => {
-  findPanelController.runReplace();
-});
-
-findPanelElements.replaceAllBtn.addEventListener('click', () => {
-  findPanelController.runReplaceAll();
-});
-
-findToggleBtn.addEventListener('click', () => {
-  if (findPanelController.isVisible()) {
+    event.stopPropagation();
     findPanelController.close();
-    return;
-  }
-  findPanelController.open('find');
 });
 
-selectionMenuElements.menu.addEventListener('pointerdown', (event) => {
-  event.preventDefault();
+findPanelElements.findInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+        event.preventDefault();
+        findPanelController.runFind(event.shiftKey, { focusEditor: false });
+        return;
+    }
 });
 
-selectionMenuElements.menu.addEventListener('click', (event) => {
-  const button = (event.target as Element).closest('.selection-inline-button') as HTMLElement | null;
-  if (!button) return;
-  const { action } = button.dataset;
-  if (!action) return;
-  selectionMenuController.handleAction(action);
+findPanelElements.replaceInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+        event.preventDefault();
+        findPanelController.runReplace();
+        return;
+    }
 });
 
-headingDropdown.addEventListener('click', (event) => {
-  const option = (event.target as Element).closest('.heading-dropdown-option') as HTMLElement | null;
-  if (!option || !editor) return;
-  const level = parseInt(option.dataset.level ?? '', 10);
-  editor.insertFormat('heading', level);
-  editor.focus();
+findPanelElements.findPrevBtn.addEventListener("click", () => {
+    findPanelController.runFind(true);
 });
 
-bulletListBtn.addEventListener('click', () => handleFormatAction('bulletList'));
-numberedListBtn.addEventListener('click', () => handleFormatAction('numberedList'));
-taskBtn.addEventListener('click', () => handleFormatAction('task'));
-codeBlockBtn.addEventListener('click', () => handleFormatAction('codeBlock'));
-quoteBtn.addEventListener('click', () => handleFormatAction('quote'));
-hrBtn.addEventListener('click', () => handleFormatAction('hr'));
-linkBtn.addEventListener('click', () => handleFormatAction('link'));
-wikiLinkBtn.addEventListener('click', () => handleFormatAction('wikiLink'));
-imageBtn.addEventListener('click', () => handleFormatAction('image'));
-exportHtmlOption.addEventListener('click', () => {
-  exportHandler.requestExport('html');
+findPanelElements.findNextBtn.addEventListener("click", () => {
+    findPanelController.runFind(false);
 });
-exportPdfOption.addEventListener('click', () => {
-  exportHandler.requestExport('pdf');
+
+findPanelElements.replaceBtn.addEventListener("click", () => {
+    findPanelController.runReplace();
 });
-outlineBtn.addEventListener('click', () => {
-  setOutlineVisible(!outlineController.isVisible());
+
+findPanelElements.replaceAllBtn.addEventListener("click", () => {
+    findPanelController.runReplaceAll();
 });
-lineNumbersBtn.addEventListener('click', toggleLineNumbers);
-gitChangesGutterBtn.addEventListener('click', toggleGitChangesGutter);
+
+findToggleBtn.addEventListener("click", () => {
+    if (findPanelController.isVisible()) {
+        findPanelController.close();
+        return;
+    }
+    findPanelController.open("find");
+});
+
+selectionMenuElements.menu.addEventListener("pointerdown", (event) => {
+    event.preventDefault();
+});
+
+selectionMenuElements.menu.addEventListener("click", (event) => {
+    const button = (event.target as Element).closest(".selection-inline-button") as HTMLElement | null;
+    if (!button) return;
+    const { action } = button.dataset;
+    if (!action) return;
+    selectionMenuController.handleAction(action);
+});
+
+headingDropdown.addEventListener("click", (event) => {
+    const option = (event.target as Element).closest(".heading-dropdown-option") as HTMLElement | null;
+    if (!option || !editor) return;
+    const level = parseInt(option.dataset.level ?? "", 10);
+    editor.insertFormat("heading", level);
+    editor.focus();
+});
+
+bulletListBtn.addEventListener("click", () => handleFormatAction("bulletList"));
+numberedListBtn.addEventListener("click", () => handleFormatAction("numberedList"));
+taskBtn.addEventListener("click", () => handleFormatAction("task"));
+codeBlockBtn.addEventListener("click", () => handleFormatAction("codeBlock"));
+quoteBtn.addEventListener("click", () => handleFormatAction("quote"));
+hrBtn.addEventListener("click", () => handleFormatAction("hr"));
+linkBtn.addEventListener("click", () => handleFormatAction("link"));
+wikiLinkBtn.addEventListener("click", () => handleFormatAction("wikiLink"));
+imageBtn.addEventListener("click", () => handleFormatAction("image"));
+exportHtmlOption.addEventListener("click", () => {
+    exportHandler.requestExport("html");
+});
+exportPdfOption.addEventListener("click", () => {
+    exportHandler.requestExport("pdf");
+});
+outlineBtn.addEventListener("click", () => {
+    setOutlineVisible(!outlineController.isVisible());
+});
+lineNumbersBtn.addEventListener("click", toggleLineNumbers);
+gitChangesGutterBtn.addEventListener("click", toggleGitChangesGutter);
 
 persistModeState();
-vscode.postMessage({ type: 'setMode', mode: currentMode });
+vscode.postMessage({ type: "setMode", mode: currentMode });
 scheduleReadyHandshake();
 scheduleEditorBundleWarmupAfterReady();

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -1,63 +1,63 @@
-import { createElement, Heading, Heading1, Heading2, Heading3, Heading4, Heading5, Heading6, List, ListOrdered, ListTodo, ListTree, Hash, Code, Terminal, Quote, Minus, Table2, Link, Brackets, Image, Bold, Italic, Strikethrough, Search, Share, GitCompare } from "lucide";
-import { setImageSrcResolver, initializeImageHandling, resolveImageSrc, settleImageSrcRequest, handleSavedImagePath, handleImagePaste } from "./helpers/images";
-import { createGitClient } from "./helpers/gitClient";
-import { createOutlineController } from "./helpers/outline";
-import { normalizeWikiTarget, replaceWikiLinkStatuses, initializeWikiLinkHandling, collectWikiLinkTargets, requestWikiLinkStatuses, scheduleWikiLinkStatusRefresh, setWikiLinkRefreshContext, cancelPendingWikiStatusRefresh, handleResolvedWikiLinks } from "./helpers/wikiLinks";
-import { initializeLocalLinkHandling, requestLocalLinkStatuses, scheduleLocalLinkStatusRefresh, setLocalLinkRefreshContext, cancelPendingLocalLinkStatusRefresh, handleResolvedLocalLinks } from "./helpers/localLinks";
-import { setGitDiffLineHighlightsEnabled } from "./helpers/gitDiffLineHighlights";
-import { applyThemeSettings } from "./helpers/theme";
-import { createFailureNoticeManager, getErrorMessage, isTransientMermaidRuntimeError, shouldAutoFallbackToSourceForLiveError, logWebviewRenderError, type EditorNotice, type FailureNoticeManager } from "./helpers/errors";
-import { isPrimaryModifier, isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from "./helpers/shortcuts";
-import { createFindPanel, createFindPanelController, type FindPanelController } from "./helpers/findPanel";
-import { createSelectionMenu, createSelectionMenuController, type SelectionMenuController } from "./helpers/selectionMenu";
-import { createExportHandler, type ExportHandlerContext } from "./helpers/export";
+import { createElement, Heading, Heading1, Heading2, Heading3, Heading4, Heading5, Heading6, List, ListOrdered, ListTodo, ListTree, Hash, Code, Terminal, Quote, Minus, Table2, Link, Brackets, Image, Bold, Italic, Strikethrough, Search, Share, GitCompare } from 'lucide';
+import { setImageSrcResolver, initializeImageHandling, resolveImageSrc, settleImageSrcRequest, handleSavedImagePath, handleImagePaste } from './helpers/images';
+import { createGitClient } from './helpers/gitClient';
+import { createOutlineController } from './helpers/outline';
+import { normalizeWikiTarget, replaceWikiLinkStatuses, initializeWikiLinkHandling, collectWikiLinkTargets, requestWikiLinkStatuses, scheduleWikiLinkStatusRefresh, setWikiLinkRefreshContext, cancelPendingWikiStatusRefresh, handleResolvedWikiLinks } from './helpers/wikiLinks';
+import { initializeLocalLinkHandling, requestLocalLinkStatuses, scheduleLocalLinkStatusRefresh, setLocalLinkRefreshContext, cancelPendingLocalLinkStatusRefresh, handleResolvedLocalLinks } from './helpers/localLinks';
+import { setGitDiffLineHighlightsEnabled } from './helpers/gitDiffLineHighlights';
+import { applyThemeSettings } from './helpers/theme';
+import { createFailureNoticeManager, getErrorMessage, isTransientMermaidRuntimeError, shouldAutoFallbackToSourceForLiveError, logWebviewRenderError, type EditorNotice, type FailureNoticeManager } from './helpers/errors';
+import { isPrimaryModifier, isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from './helpers/shortcuts';
+import { createFindPanel, createFindPanelController, type FindPanelController } from './helpers/findPanel';
+import { createSelectionMenu, createSelectionMenuController, type SelectionMenuController } from './helpers/selectionMenu';
+import { createExportHandler, type ExportHandlerContext } from './helpers/export';
 
-type CreateEditorFactory = (typeof import("./editor"))["createEditor"];
+type CreateEditorFactory = (typeof import('./editor'))['createEditor'];
 
 type CompatibleVsCodeWebviewApi = {
-    postMessage: (message: WebviewMessage) => void;
-    getState: () => unknown;
-    setState: (state: unknown) => void;
+  postMessage: (message: WebviewMessage) => void;
+  getState: () => unknown;
+  setState: (state: unknown) => void;
 };
 
 function createCompatibleVsCodeApi(): CompatibleVsCodeWebviewApi {
-    const hostApi = acquireVsCodeApi();
-    let fallbackState: unknown;
+  const hostApi = acquireVsCodeApi();
+  let fallbackState: unknown;
 
-    const getState = (): unknown => {
-        if (typeof hostApi.getState !== "function") {
-            return fallbackState;
-        }
+  const getState = (): unknown => {
+    if (typeof hostApi.getState !== 'function') {
+      return fallbackState;
+    }
 
-        try {
-            const hostState = hostApi.getState();
-            if (hostState !== undefined) {
-                fallbackState = hostState;
-            }
-            return hostState;
-        } catch {
-            return fallbackState;
-        }
-    };
+    try {
+      const hostState = hostApi.getState();
+      if (hostState !== undefined) {
+        fallbackState = hostState;
+      }
+      return hostState;
+    } catch {
+      return fallbackState;
+    }
+  };
 
-    const setState = (state: unknown): void => {
-        fallbackState = state;
-        if (typeof hostApi.setState !== "function") {
-            return;
-        }
+  const setState = (state: unknown): void => {
+    fallbackState = state;
+    if (typeof hostApi.setState !== 'function') {
+      return;
+    }
 
-        try {
-            hostApi.setState(state);
-        } catch {
-            // Keep session-local fallback state when host persistence is unavailable.
-        }
-    };
+    try {
+      hostApi.setState(state);
+    } catch {
+      // Keep session-local fallback state when host persistence is unavailable.
+    }
+  };
 
-    return {
-        postMessage: (message: WebviewMessage) => hostApi.postMessage(message),
-        getState,
-        setState,
-    };
+  return {
+    postMessage: (message: WebviewMessage) => hostApi.postMessage(message),
+    getState,
+    setState
+  };
 }
 
 const vscode = createCompatibleVsCodeApi();
@@ -68,374 +68,377 @@ initializeLocalLinkHandling(vscode);
 applyThemeSettings();
 setImageSrcResolver(resolveImageSrc);
 
-const root = document.getElementById("app");
+const root = document.getElementById('app');
 
 if (!root) {
-    throw new Error("Webview root element not found");
+  throw new Error('Webview root element not found');
 }
 
-root.classList.add("editor-root");
+root.classList.add('editor-root');
 
-const existingToolbar = root.querySelector(".mode-toolbar");
-const toolbar = existingToolbar instanceof HTMLElement ? existingToolbar : document.createElement("div");
-toolbar.className = "mode-toolbar";
-toolbar.classList.remove("meo-preload-toolbar");
-toolbar.removeAttribute("aria-hidden");
-toolbar.setAttribute("role", "toolbar");
-toolbar.setAttribute("aria-label", "Editor toolbar");
+const existingToolbar = root.querySelector('.mode-toolbar');
+const toolbar = existingToolbar instanceof HTMLElement ? existingToolbar : document.createElement('div');
+toolbar.className = 'mode-toolbar';
+toolbar.classList.remove('meo-preload-toolbar');
+toolbar.removeAttribute('aria-hidden');
+toolbar.setAttribute('role', 'toolbar');
+toolbar.setAttribute('aria-label', 'Editor toolbar');
 
-const formatGroup = document.createElement("div");
-formatGroup.className = "format-group";
-formatGroup.setAttribute("role", "group");
-formatGroup.setAttribute("aria-label", "Formatting");
+const formatGroup = document.createElement('div');
+formatGroup.className = 'format-group';
+formatGroup.setAttribute('role', 'group');
+formatGroup.setAttribute('aria-label', 'Formatting');
 
-const headingBtn = document.createElement("button");
-headingBtn.type = "button";
-headingBtn.className = "format-button";
-headingBtn.dataset.action = "heading";
-headingBtn.title = "Heading";
+const headingBtn = document.createElement('button');
+headingBtn.type = 'button';
+headingBtn.className = 'format-button';
+headingBtn.dataset.action = 'heading';
+headingBtn.title = 'Heading';
 headingBtn.appendChild(createElement(Heading, { width: 18, height: 18 }));
 
-const headingDropdown = document.createElement("div");
-headingDropdown.className = "heading-dropdown";
-headingDropdown.setAttribute("role", "menu");
-headingDropdown.setAttribute("aria-label", "Heading levels");
+const headingDropdown = document.createElement('div');
+headingDropdown.className = 'heading-dropdown';
+headingDropdown.setAttribute('role', 'menu');
+headingDropdown.setAttribute('aria-label', 'Heading levels');
 
-const headingDropdownWrapper = document.createElement("div");
-headingDropdownWrapper.className = "heading-dropdown-wrapper";
+const headingDropdownWrapper = document.createElement('div');
+headingDropdownWrapper.className = 'heading-dropdown-wrapper';
 
 const headingIcons = [Heading1, Heading2, Heading3, Heading4, Heading5, Heading6];
 
 for (let level = 1; level <= 6; level++) {
-    const option = document.createElement("button");
-    option.type = "button";
-    option.className = "heading-dropdown-option";
-    option.dataset.level = String(level);
-    option.title = `Heading ${level}`;
-    option.appendChild(createElement(headingIcons[level - 1], { width: 18, height: 18 }));
-    headingDropdown.appendChild(option);
+  const option = document.createElement('button');
+  option.type = 'button';
+  option.className = 'heading-dropdown-option';
+  option.dataset.level = String(level);
+  option.title = `Heading ${level}`;
+  option.appendChild(createElement(headingIcons[level - 1], { width: 18, height: 18 }));
+  headingDropdown.appendChild(option);
 }
 
 headingDropdownWrapper.appendChild(headingDropdown);
 
-const headingWrapper = document.createElement("div");
-headingWrapper.className = "heading-wrapper";
+const headingWrapper = document.createElement('div');
+headingWrapper.className = 'heading-wrapper';
 headingWrapper.append(headingBtn, headingDropdownWrapper);
 
-const bulletListBtn = document.createElement("button");
-bulletListBtn.type = "button";
-bulletListBtn.className = "format-button";
-bulletListBtn.dataset.action = "bulletList";
-bulletListBtn.title = "Bullet List";
+const bulletListBtn = document.createElement('button');
+bulletListBtn.type = 'button';
+bulletListBtn.className = 'format-button';
+bulletListBtn.dataset.action = 'bulletList';
+bulletListBtn.title = 'Bullet List';
 bulletListBtn.appendChild(createElement(List, { width: 18, height: 18 }));
 
-const numberedListBtn = document.createElement("button");
-numberedListBtn.type = "button";
-numberedListBtn.className = "format-button";
-numberedListBtn.dataset.action = "numberedList";
-numberedListBtn.title = "Numbered List";
+const numberedListBtn = document.createElement('button');
+numberedListBtn.type = 'button';
+numberedListBtn.className = 'format-button';
+numberedListBtn.dataset.action = 'numberedList';
+numberedListBtn.title = 'Numbered List';
 numberedListBtn.appendChild(createElement(ListOrdered, { width: 18, height: 18 }));
 
-const taskBtn = document.createElement("button");
-taskBtn.type = "button";
-taskBtn.className = "format-button";
-taskBtn.dataset.action = "task";
-taskBtn.title = "Task";
+const taskBtn = document.createElement('button');
+taskBtn.type = 'button';
+taskBtn.className = 'format-button';
+taskBtn.dataset.action = 'task';
+taskBtn.title = 'Task';
 taskBtn.appendChild(createElement(ListTodo, { width: 18, height: 18 }));
 
 let vimModeEnabled = false;
 let vimKeybindingsState: VimKeybinding[] = [];
-let vimLeaderState = "\\";
+let vimLeaderState = '\\';
 
 let lineNumbersVisible = true;
 let gitChangesGutterVisible = true;
 let gitDiffLineHighlightsEnabled = true;
 
-const outlineBtn = document.createElement("button");
-outlineBtn.type = "button";
-outlineBtn.className = "format-button toggle-button";
-outlineBtn.dataset.action = "outline";
-outlineBtn.title = "Toggle Outline";
+const outlineBtn = document.createElement('button');
+outlineBtn.type = 'button';
+outlineBtn.className = 'format-button toggle-button';
+outlineBtn.dataset.action = 'outline';
+outlineBtn.title = 'Toggle Outline';
 outlineBtn.appendChild(createElement(ListTree, { width: 18, height: 18 }));
 
-const lineNumbersBtn = document.createElement("button");
-lineNumbersBtn.type = "button";
-lineNumbersBtn.className = "format-button toggle-button is-active";
-lineNumbersBtn.dataset.action = "lineNumbers";
-lineNumbersBtn.title = "Hide Line Numbers";
+const lineNumbersBtn = document.createElement('button');
+lineNumbersBtn.type = 'button';
+lineNumbersBtn.className = 'format-button toggle-button is-active';
+lineNumbersBtn.dataset.action = 'lineNumbers';
+lineNumbersBtn.title = 'Hide Line Numbers';
 lineNumbersBtn.appendChild(createElement(Hash, { width: 18, height: 18 }));
 
-const gitChangesGutterBtn = document.createElement("button");
-gitChangesGutterBtn.type = "button";
-gitChangesGutterBtn.className = "format-button toggle-button is-active";
-gitChangesGutterBtn.dataset.action = "gitChangesGutter";
-gitChangesGutterBtn.title = "Hide Git Changes Gutter";
+const gitChangesGutterBtn = document.createElement('button');
+gitChangesGutterBtn.type = 'button';
+gitChangesGutterBtn.className = 'format-button toggle-button is-active';
+gitChangesGutterBtn.dataset.action = 'gitChangesGutter';
+gitChangesGutterBtn.title = 'Hide Git Changes Gutter';
 gitChangesGutterBtn.appendChild(createElement(GitCompare, { width: 18, height: 18 }));
 
 const updateLineNumbersUI = () => {
-    lineNumbersBtn.classList.toggle("is-active", lineNumbersVisible);
-    lineNumbersBtn.setAttribute("aria-pressed", lineNumbersVisible ? "true" : "false");
-    lineNumbersBtn.title = lineNumbersVisible ? "Hide Line Numbers" : "Show Line Numbers";
+  lineNumbersBtn.classList.toggle('is-active', lineNumbersVisible);
+  lineNumbersBtn.setAttribute('aria-pressed', lineNumbersVisible ? 'true' : 'false');
+  lineNumbersBtn.title = lineNumbersVisible ? 'Hide Line Numbers' : 'Show Line Numbers';
 };
 
 const updateGitChangesGutterUI = () => {
-    gitChangesGutterBtn.classList.toggle("is-active", gitChangesGutterVisible);
-    gitChangesGutterBtn.setAttribute("aria-pressed", gitChangesGutterVisible ? "true" : "false");
-    gitChangesGutterBtn.title = gitChangesGutterVisible ? "Hide Git Changes" : "Show Git Changes";
+  gitChangesGutterBtn.classList.toggle('is-active', gitChangesGutterVisible);
+  gitChangesGutterBtn.setAttribute('aria-pressed', gitChangesGutterVisible ? 'true' : 'false');
+  gitChangesGutterBtn.title = gitChangesGutterVisible ? 'Hide Git Changes' : 'Show Git Changes';
 };
 
 const syncGitDiffLineHighlights = () => {
-    if (!editor) {
-        return;
-    }
-    setGitDiffLineHighlightsEnabled(editor, currentMode === "source" && gitChangesGutterVisible && gitDiffLineHighlightsEnabled);
+  if (!editor) {
+    return;
+  }
+  setGitDiffLineHighlightsEnabled(
+    editor,
+    currentMode === 'source' && gitChangesGutterVisible && gitDiffLineHighlightsEnabled
+  );
 };
 
 const setLineNumbersVisible = (visible, { post = true } = {}) => {
-    const nextVisible = visible !== false;
-    const changed = nextVisible !== lineNumbersVisible;
-    if (changed) {
-        lineNumbersVisible = nextVisible;
-        editor?.setLineNumbers(lineNumbersVisible);
-    }
-    updateLineNumbersUI();
-    if (post && changed) {
-        vscode.postMessage({ type: "setLineNumbers", visible: lineNumbersVisible });
-    }
+  const nextVisible = visible !== false;
+  const changed = nextVisible !== lineNumbersVisible;
+  if (changed) {
+    lineNumbersVisible = nextVisible;
+    editor?.setLineNumbers(lineNumbersVisible);
+  }
+  updateLineNumbersUI();
+  if (post && changed) {
+    vscode.postMessage({ type: 'setLineNumbers', visible: lineNumbersVisible });
+  }
 };
 
 const setGitChangesGutterVisible = (visible, { post = true } = {}) => {
-    const nextVisible = visible !== false;
-    const changed = nextVisible !== gitChangesGutterVisible;
-    if (changed) {
-        gitChangesGutterVisible = nextVisible;
-        editor?.setGitGutterVisible(gitChangesGutterVisible);
-        syncGitDiffLineHighlights();
-    }
-    updateGitChangesGutterUI();
-    if (post && changed) {
-        vscode.postMessage({ type: "setGitChangesGutter", visible: gitChangesGutterVisible });
-    }
+  const nextVisible = visible !== false;
+  const changed = nextVisible !== gitChangesGutterVisible;
+  if (changed) {
+    gitChangesGutterVisible = nextVisible;
+    editor?.setGitGutterVisible(gitChangesGutterVisible);
+    syncGitDiffLineHighlights();
+  }
+  updateGitChangesGutterUI();
+  if (post && changed) {
+    vscode.postMessage({ type: 'setGitChangesGutter', visible: gitChangesGutterVisible });
+  }
 };
 
 const setOutlineVisible = (visible, { post = true } = {}) => {
-    const nextVisible = visible === true;
-    const changed = nextVisible !== outlineController.isVisible();
-    outlineController.setVisible(nextVisible);
-    if (post && changed) {
-        vscode.postMessage({ type: "setOutlineVisible", visible: nextVisible });
-    }
+  const nextVisible = visible === true;
+  const changed = nextVisible !== outlineController.isVisible();
+  outlineController.setVisible(nextVisible);
+  if (post && changed) {
+    vscode.postMessage({ type: 'setOutlineVisible', visible: nextVisible });
+  }
 };
 
 const setVimModeEnabled = (enabled) => {
-    const nextEnabled = enabled === true;
-    if (nextEnabled === vimModeEnabled) {
-        return;
-    }
-    vimModeEnabled = nextEnabled;
-    editor?.setVimMode(vimModeEnabled);
+  const nextEnabled = enabled === true;
+  if (nextEnabled === vimModeEnabled) {
+    return;
+  }
+  vimModeEnabled = nextEnabled;
+  editor?.setVimMode(vimModeEnabled);
 };
 
 const toggleLineNumbers = () => {
-    setLineNumbersVisible(!lineNumbersVisible);
+  setLineNumbersVisible(!lineNumbersVisible);
 };
 
 const toggleGitChangesGutter = () => {
-    setGitChangesGutterVisible(!gitChangesGutterVisible);
+  setGitChangesGutterVisible(!gitChangesGutterVisible);
 };
 
-const separator = document.createElement("div");
-separator.className = "format-separator";
-separator.setAttribute("role", "separator");
+const separator = document.createElement('div');
+separator.className = 'format-separator';
+separator.setAttribute('role', 'separator');
 
-const codeBlockBtn = document.createElement("button");
-codeBlockBtn.type = "button";
-codeBlockBtn.className = "format-button";
-codeBlockBtn.dataset.action = "codeBlock";
-codeBlockBtn.title = "Code Block";
+const codeBlockBtn = document.createElement('button');
+codeBlockBtn.type = 'button';
+codeBlockBtn.className = 'format-button';
+codeBlockBtn.dataset.action = 'codeBlock';
+codeBlockBtn.title = 'Code Block';
 codeBlockBtn.appendChild(createElement(Code, { width: 18, height: 18 }));
 
-const quoteBtn = document.createElement("button");
-quoteBtn.type = "button";
-quoteBtn.className = "format-button";
-quoteBtn.dataset.action = "quote";
-quoteBtn.title = "Quote";
+const quoteBtn = document.createElement('button');
+quoteBtn.type = 'button';
+quoteBtn.className = 'format-button';
+quoteBtn.dataset.action = 'quote';
+quoteBtn.title = 'Quote';
 quoteBtn.appendChild(createElement(Quote, { width: 18, height: 18 }));
 
-const hrBtn = document.createElement("button");
-hrBtn.type = "button";
-hrBtn.className = "format-button";
-hrBtn.dataset.action = "hr";
-hrBtn.title = "Horizontal Rule";
+const hrBtn = document.createElement('button');
+hrBtn.type = 'button';
+hrBtn.className = 'format-button';
+hrBtn.dataset.action = 'hr';
+hrBtn.title = 'Horizontal Rule';
 hrBtn.appendChild(createElement(Minus, { width: 18, height: 18 }));
 
-const linkBtn = document.createElement("button");
-linkBtn.type = "button";
-linkBtn.className = "format-button";
-linkBtn.dataset.action = "link";
-linkBtn.title = "Link";
+const linkBtn = document.createElement('button');
+linkBtn.type = 'button';
+linkBtn.className = 'format-button';
+linkBtn.dataset.action = 'link';
+linkBtn.title = 'Link';
 linkBtn.appendChild(createElement(Link, { width: 18, height: 18 }));
 
-const wikiLinkBtn = document.createElement("button");
-wikiLinkBtn.type = "button";
-wikiLinkBtn.className = "format-button";
-wikiLinkBtn.dataset.action = "wikiLink";
-wikiLinkBtn.title = "Wiki Link";
+const wikiLinkBtn = document.createElement('button');
+wikiLinkBtn.type = 'button';
+wikiLinkBtn.className = 'format-button';
+wikiLinkBtn.dataset.action = 'wikiLink';
+wikiLinkBtn.title = 'Wiki Link';
 wikiLinkBtn.appendChild(createElement(Brackets, { width: 18, height: 18 }));
 
-const imageBtn = document.createElement("button");
-imageBtn.type = "button";
-imageBtn.className = "format-button";
-imageBtn.dataset.action = "image";
-imageBtn.title = "Image";
+const imageBtn = document.createElement('button');
+imageBtn.type = 'button';
+imageBtn.className = 'format-button';
+imageBtn.dataset.action = 'image';
+imageBtn.title = 'Image';
 imageBtn.appendChild(createElement(Image, { width: 18, height: 18 }));
 
-const tableBtn = document.createElement("button");
-tableBtn.type = "button";
-tableBtn.className = "format-button";
-tableBtn.dataset.action = "table";
-tableBtn.title = "Table";
+const tableBtn = document.createElement('button');
+tableBtn.type = 'button';
+tableBtn.className = 'format-button';
+tableBtn.dataset.action = 'table';
+tableBtn.title = 'Table';
 tableBtn.appendChild(createElement(Table2, { width: 18, height: 18 }));
 
-const tableDropdown = document.createElement("div");
-tableDropdown.className = "table-dropdown";
+const tableDropdown = document.createElement('div');
+tableDropdown.className = 'table-dropdown';
 
-const tableDropdownWrapper = document.createElement("div");
-tableDropdownWrapper.className = "table-dropdown-wrapper";
+const tableDropdownWrapper = document.createElement('div');
+tableDropdownWrapper.className = 'table-dropdown-wrapper';
 
-const tableGrid = document.createElement("div");
-tableGrid.className = "table-grid";
+const tableGrid = document.createElement('div');
+tableGrid.className = 'table-grid';
 
 const gridSize = 5;
 for (let row = 0; row < gridSize; row++) {
-    for (let col = 0; col < gridSize; col++) {
-        const cell = document.createElement("div");
-        cell.className = "table-grid-cell";
-        cell.dataset.row = String(row + 1);
-        cell.dataset.col = String(col + 1);
-        if (row === 0 && col === 0) {
-            cell.classList.add("is-highlighted");
-        }
-        tableGrid.appendChild(cell);
+  for (let col = 0; col < gridSize; col++) {
+    const cell = document.createElement('div');
+    cell.className = 'table-grid-cell';
+    cell.dataset.row = String(row + 1);
+    cell.dataset.col = String(col + 1);
+    if (row === 0 && col === 0) {
+      cell.classList.add('is-highlighted');
     }
+    tableGrid.appendChild(cell);
+  }
 }
 
-const tableSizeLabel = document.createElement("div");
-tableSizeLabel.className = "table-size-label";
-tableSizeLabel.textContent = "1 x 1";
+const tableSizeLabel = document.createElement('div');
+tableSizeLabel.className = 'table-size-label';
+tableSizeLabel.textContent = '1 x 1';
 
 tableDropdown.append(tableGrid, tableSizeLabel);
 tableDropdownWrapper.appendChild(tableDropdown);
 
-const tableWrapper = document.createElement("div");
-tableWrapper.className = "table-wrapper";
+const tableWrapper = document.createElement('div');
+tableWrapper.className = 'table-wrapper';
 tableWrapper.append(tableBtn, tableDropdownWrapper);
 
 let selectedTableCols = 1;
 let selectedTableRows = 1;
 
 const updateTableGridHighlight = (hoveredCol: number, hoveredRow: number) => {
-    const cells = tableGrid.querySelectorAll(".table-grid-cell");
-    cells.forEach((cell) => {
-        const cellCol = parseInt((cell as HTMLElement).dataset.col ?? "", 10);
-        const cellRow = parseInt((cell as HTMLElement).dataset.row ?? "", 10);
-        cell.classList.toggle("is-highlighted", cellCol <= hoveredCol && cellRow <= hoveredRow);
-    });
-    tableSizeLabel.textContent = `${hoveredCol} x ${hoveredRow}`;
-    selectedTableCols = hoveredCol;
-    selectedTableRows = hoveredRow;
+  const cells = tableGrid.querySelectorAll('.table-grid-cell');
+  cells.forEach((cell) => {
+    const cellCol = parseInt((cell as HTMLElement).dataset.col ?? '', 10);
+    const cellRow = parseInt((cell as HTMLElement).dataset.row ?? '', 10);
+    cell.classList.toggle('is-highlighted', cellCol <= hoveredCol && cellRow <= hoveredRow);
+  });
+  tableSizeLabel.textContent = `${hoveredCol} x ${hoveredRow}`;
+  selectedTableCols = hoveredCol;
+  selectedTableRows = hoveredRow;
 };
 
-tableGrid.addEventListener("mouseover", (event) => {
-    const cell = (event.target as Element).closest(".table-grid-cell") as HTMLElement | null;
-    if (!cell) return;
-    const col = parseInt(cell.dataset.col ?? "", 10);
-    const row = parseInt(cell.dataset.row ?? "", 10);
-    updateTableGridHighlight(col, row);
+tableGrid.addEventListener('mouseover', (event) => {
+  const cell = (event.target as Element).closest('.table-grid-cell') as HTMLElement | null;
+  if (!cell) return;
+  const col = parseInt(cell.dataset.col ?? '', 10);
+  const row = parseInt(cell.dataset.row ?? '', 10);
+  updateTableGridHighlight(col, row);
 });
 
-tableGrid.addEventListener("mouseleave", () => {
-    updateTableGridHighlight(1, 1);
+tableGrid.addEventListener('mouseleave', () => {
+  updateTableGridHighlight(1, 1);
 });
 
-tableGrid.addEventListener("click", (event) => {
-    const cell = (event.target as Element).closest(".table-grid-cell") as HTMLElement | null;
-    if (!cell || !editor) return;
-    editor.insertFormat("table", { cols: selectedTableCols, rows: selectedTableRows });
-    editor.focus();
+tableGrid.addEventListener('click', (event) => {
+  const cell = (event.target as Element).closest('.table-grid-cell') as HTMLElement | null;
+  if (!cell || !editor) return;
+  editor.insertFormat('table', { cols: selectedTableCols, rows: selectedTableRows });
+  editor.focus();
 });
 
 formatGroup.append(headingWrapper, bulletListBtn, numberedListBtn, taskBtn, separator, tableWrapper, codeBlockBtn, linkBtn, wikiLinkBtn, imageBtn, quoteBtn, hrBtn);
 
-const rightGroup = document.createElement("div");
-rightGroup.className = "right-group";
+const rightGroup = document.createElement('div');
+rightGroup.className = 'right-group';
 
-const findToggleBtn = document.createElement("button");
-findToggleBtn.type = "button";
-findToggleBtn.className = "format-button toggle-button";
-findToggleBtn.dataset.action = "find";
-findToggleBtn.title = "Find and Replace";
+const findToggleBtn = document.createElement('button');
+findToggleBtn.type = 'button';
+findToggleBtn.className = 'format-button toggle-button';
+findToggleBtn.dataset.action = 'find';
+findToggleBtn.title = 'Find and Replace';
 findToggleBtn.appendChild(createElement(Search, { width: 18, height: 18 }));
 
-const exportBtn = document.createElement("button");
-exportBtn.type = "button";
-exportBtn.className = "format-button export-button";
-exportBtn.dataset.action = "export";
-exportBtn.title = "Export";
-exportBtn.setAttribute("aria-label", "Export");
+const exportBtn = document.createElement('button');
+exportBtn.type = 'button';
+exportBtn.className = 'format-button export-button';
+exportBtn.dataset.action = 'export';
+exportBtn.title = 'Export';
+exportBtn.setAttribute('aria-label', 'Export');
 exportBtn.appendChild(createElement(Share, { width: 18, height: 18 }));
 
-const exportDropdown = document.createElement("div");
-exportDropdown.className = "export-dropdown";
-exportDropdown.setAttribute("role", "menu");
-exportDropdown.setAttribute("aria-label", "Export formats");
+const exportDropdown = document.createElement('div');
+exportDropdown.className = 'export-dropdown';
+exportDropdown.setAttribute('role', 'menu');
+exportDropdown.setAttribute('aria-label', 'Export formats');
 
-const exportDropdownWrapper = document.createElement("div");
-exportDropdownWrapper.className = "export-dropdown-wrapper";
+const exportDropdownWrapper = document.createElement('div');
+exportDropdownWrapper.className = 'export-dropdown-wrapper';
 
-const exportHtmlOption = document.createElement("button");
-exportHtmlOption.type = "button";
-exportHtmlOption.className = "export-dropdown-option";
-exportHtmlOption.dataset.format = "html";
-exportHtmlOption.title = "Export as HTML";
-exportHtmlOption.textContent = "HTML";
+const exportHtmlOption = document.createElement('button');
+exportHtmlOption.type = 'button';
+exportHtmlOption.className = 'export-dropdown-option';
+exportHtmlOption.dataset.format = 'html';
+exportHtmlOption.title = 'Export as HTML';
+exportHtmlOption.textContent = 'HTML';
 
-const exportPdfOption = document.createElement("button");
-exportPdfOption.type = "button";
-exportPdfOption.className = "export-dropdown-option";
-exportPdfOption.dataset.format = "pdf";
-exportPdfOption.title = "Export as PDF";
-exportPdfOption.textContent = "PDF";
+const exportPdfOption = document.createElement('button');
+exportPdfOption.type = 'button';
+exportPdfOption.className = 'export-dropdown-option';
+exportPdfOption.dataset.format = 'pdf';
+exportPdfOption.title = 'Export as PDF';
+exportPdfOption.textContent = 'PDF';
 
 exportDropdown.append(exportHtmlOption, exportPdfOption);
 exportDropdownWrapper.appendChild(exportDropdown);
 
-const exportWrapper = document.createElement("div");
-exportWrapper.className = "export-wrapper";
+const exportWrapper = document.createElement('div');
+exportWrapper.className = 'export-wrapper';
 exportWrapper.append(exportBtn, exportDropdownWrapper);
 
 rightGroup.append(outlineBtn, findToggleBtn, lineNumbersBtn, gitChangesGutterBtn, exportWrapper);
 
-const modeGroup = document.createElement("div");
-modeGroup.className = "mode-group";
-modeGroup.setAttribute("role", "tablist");
-modeGroup.setAttribute("aria-label", "Markdown mode");
+const modeGroup = document.createElement('div');
+modeGroup.className = 'mode-group';
+modeGroup.setAttribute('role', 'tablist');
+modeGroup.setAttribute('aria-label', 'Markdown mode');
 
-const liveButton = document.createElement("button");
-liveButton.type = "button";
-liveButton.className = "mode-button";
-liveButton.dataset.mode = "live";
-liveButton.textContent = "Live";
-liveButton.setAttribute("role", "tab");
-liveButton.title = "Live";
+const liveButton = document.createElement('button');
+liveButton.type = 'button';
+liveButton.className = 'mode-button';
+liveButton.dataset.mode = 'live';
+liveButton.textContent = 'Live';
+liveButton.setAttribute('role', 'tab');
+liveButton.title = 'Live';
 
-const sourceButton = document.createElement("button");
-sourceButton.type = "button";
-sourceButton.className = "mode-button";
-sourceButton.dataset.mode = "source";
-sourceButton.textContent = "Source";
-sourceButton.setAttribute("role", "tab");
-sourceButton.title = "Source";
+const sourceButton = document.createElement('button');
+sourceButton.type = 'button';
+sourceButton.className = 'mode-button';
+sourceButton.dataset.mode = 'source';
+sourceButton.textContent = 'Source';
+sourceButton.setAttribute('role', 'tab');
+sourceButton.title = 'Source';
 
 modeGroup.append(liveButton, sourceButton);
 
@@ -445,30 +448,30 @@ const findPanelController = createFindPanelController(findPanelElements, () => e
 const selectionMenuElements = createSelectionMenu();
 const selectionMenuController = createSelectionMenuController(selectionMenuElements, () => editor);
 
-const editorNoticeBanner = document.createElement("div");
-editorNoticeBanner.className = "editor-notice";
-editorNoticeBanner.setAttribute("role", "status");
-editorNoticeBanner.setAttribute("aria-live", "polite");
+const editorNoticeBanner = document.createElement('div');
+editorNoticeBanner.className = 'editor-notice';
+editorNoticeBanner.setAttribute('role', 'status');
+editorNoticeBanner.setAttribute('aria-live', 'polite');
 editorNoticeBanner.hidden = true;
 
 toolbar.replaceChildren(formatGroup, rightGroup, modeGroup, findPanelElements.panel, editorNoticeBanner);
 
-const existingEditorWrapper = root.querySelector(".editor-wrapper");
-const editorWrapper = existingEditorWrapper instanceof HTMLElement ? existingEditorWrapper : document.createElement("div");
-editorWrapper.className = "editor-wrapper";
-editorWrapper.classList.remove("meo-preload-editor-shell");
-editorWrapper.removeAttribute("aria-hidden");
+const existingEditorWrapper = root.querySelector('.editor-wrapper');
+const editorWrapper = existingEditorWrapper instanceof HTMLElement ? existingEditorWrapper : document.createElement('div');
+editorWrapper.className = 'editor-wrapper';
+editorWrapper.classList.remove('meo-preload-editor-shell');
+editorWrapper.removeAttribute('aria-hidden');
 
-const existingEditorHost = editorWrapper.querySelector(".editor-host");
-const editorHost = existingEditorHost instanceof HTMLElement ? existingEditorHost : document.createElement("div");
-editorHost.className = "editor-host";
+const existingEditorHost = editorWrapper.querySelector('.editor-host');
+const editorHost = existingEditorHost instanceof HTMLElement ? existingEditorHost : document.createElement('div');
+editorHost.className = 'editor-host';
 
 let editor: any = null;
 const outlineController = createOutlineController({
-    root,
-    editorWrapper,
-    outlineButton: outlineBtn,
-    getEditor: () => editor,
+  root,
+  editorWrapper,
+  outlineButton: outlineBtn,
+  getEditor: () => editor
 });
 
 editorWrapper.replaceChildren(editorHost, outlineController.sidebar, selectionMenuElements.menu);
@@ -477,11 +480,11 @@ root.replaceChildren(toolbar, editorWrapper);
 let documentVersion = 0;
 let pendingDebounce: number | null = null;
 let pendingText: string | null = null;
-let syncedText = "";
+let syncedText = '';
 let inFlight = false;
 let inFlightText: string | null = null;
 let saveAfterSync = false;
-let currentMode: "live" | "source" = "live";
+let currentMode: 'live' | 'source' = 'live';
 let hasLocalModePreference = false;
 let pendingInitialText: string | null = null;
 let initialEditorMountQueued = false;
@@ -504,76 +507,76 @@ let createEditorFactoryPromise: Promise<CreateEditorFactory> | null = null;
 const VIEW_POSITION_DEBOUNCE_MS = 250;
 const INITIAL_EDITOR_MOUNT_FALLBACK_MS = 120;
 
-const setEditorNotice = (message: string, kind = "info") => {
-    const normalizedMessage = `${message ?? ""}`.trim();
-    if (!normalizedMessage) {
-        clearEditorNotice();
-        return;
-    }
-    editorNoticeBanner.textContent = normalizedMessage;
-    editorNoticeBanner.dataset.kind = kind;
-    editorNoticeBanner.hidden = false;
-    editorNoticeBanner.classList.add("is-visible");
+const setEditorNotice = (message: string, kind = 'info') => {
+  const normalizedMessage = `${message ?? ''}`.trim();
+  if (!normalizedMessage) {
+    clearEditorNotice();
+    return;
+  }
+  editorNoticeBanner.textContent = normalizedMessage;
+  editorNoticeBanner.dataset.kind = kind;
+  editorNoticeBanner.hidden = false;
+  editorNoticeBanner.classList.add('is-visible');
 };
 
 const clearEditorNotice = () => {
-    editorNoticeBanner.textContent = "";
-    delete editorNoticeBanner.dataset.kind;
-    editorNoticeBanner.hidden = true;
-    editorNoticeBanner.classList.remove("is-visible");
+  editorNoticeBanner.textContent = '';
+  delete editorNoticeBanner.dataset.kind;
+  editorNoticeBanner.hidden = true;
+  editorNoticeBanner.classList.remove('is-visible');
 };
 
 const editorNotice: EditorNotice = {
-    setEditorNotice,
-    clearEditorNotice,
+  setEditorNotice,
+  clearEditorNotice
 };
 
 const failureNotice = createFailureNoticeManager(editorNotice);
 
 const clearGitBlameCache = ({ hideTooltip = true } = {}) => {
-    gitClient?.clearBlameCache({ hideTooltip });
+  gitClient?.clearBlameCache({ hideTooltip });
 };
 
 const bumpLocalEditGeneration = () => {
-    gitClient?.bumpLocalEditGeneration();
+  gitClient?.bumpLocalEditGeneration();
 };
 
 const loadCreateEditorFactory = async (): Promise<CreateEditorFactory> => {
-    if (!createEditorFactoryPromise) {
-        createEditorFactoryPromise = import("./editor")
-            .then((mod) => mod.createEditor)
-            .catch((error) => {
-                createEditorFactoryPromise = null;
-                throw error;
-            });
-    }
+  if (!createEditorFactoryPromise) {
+    createEditorFactoryPromise = import('./editor')
+      .then((mod) => mod.createEditor)
+      .catch((error) => {
+        createEditorFactoryPromise = null;
+        throw error;
+      });
+  }
 
-    return createEditorFactoryPromise;
+  return createEditorFactoryPromise;
 };
 
 let editorBundleWarmupScheduled = false;
 
 const scheduleEditorBundleWarmupAfterReady = () => {
-    if (editorBundleWarmupScheduled) {
-        return;
-    }
-    editorBundleWarmupScheduled = true;
+  if (editorBundleWarmupScheduled) {
+    return;
+  }
+  editorBundleWarmupScheduled = true;
 
-    const warm = () => {
-        // Wait one frame after full document readiness before warming the heavy editor bundle.
-        window.requestAnimationFrame(() => {
-            void loadCreateEditorFactory().catch((error) => {
-                logWebviewRenderError("warmEditorBundleAfterReady", error);
-            });
-        });
-    };
+  const warm = () => {
+    // Wait one frame after full document readiness before warming the heavy editor bundle.
+    window.requestAnimationFrame(() => {
+      void loadCreateEditorFactory().catch((error) => {
+        logWebviewRenderError('warmEditorBundleAfterReady', error);
+      });
+    });
+  };
 
-    if (document.readyState === "complete") {
-        warm();
-        return;
-    }
+  if (document.readyState === 'complete') {
+    warm();
+    return;
+  }
 
-    window.addEventListener("load", warm, { once: true });
+  window.addEventListener('load', warm, { once: true });
 };
 
 const READY_RETRY_DELAYS_MS = [120, 300, 700, 1300] as const;
@@ -581,1169 +584,1149 @@ let readyHandshakeAcknowledged = false;
 const readyRetryTimers = new Set<number>();
 
 const clearReadyRetryTimers = () => {
-    for (const timer of readyRetryTimers) {
-        window.clearTimeout(timer);
-    }
-    readyRetryTimers.clear();
+  for (const timer of readyRetryTimers) {
+    window.clearTimeout(timer);
+  }
+  readyRetryTimers.clear();
 };
 
 const postReadyMessage = () => {
-    if (readyHandshakeAcknowledged) {
-        return;
-    }
-    vscode.postMessage({ type: "ready" });
+  if (readyHandshakeAcknowledged) {
+    return;
+  }
+  vscode.postMessage({ type: 'ready' });
 };
 
 const scheduleReadyHandshake = () => {
-    postReadyMessage();
-    for (const delayMs of READY_RETRY_DELAYS_MS) {
-        const timer = window.setTimeout(() => {
-            readyRetryTimers.delete(timer);
-            postReadyMessage();
-        }, delayMs);
-        readyRetryTimers.add(timer);
-    }
+  postReadyMessage();
+  for (const delayMs of READY_RETRY_DELAYS_MS) {
+    const timer = window.setTimeout(() => {
+      readyRetryTimers.delete(timer);
+      postReadyMessage();
+    }, delayMs);
+    readyRetryTimers.add(timer);
+  }
 };
 
 const acknowledgeReadyHandshake = () => {
-    readyHandshakeAcknowledged = true;
-    clearReadyRetryTimers();
+  readyHandshakeAcknowledged = true;
+  clearReadyRetryTimers();
 };
 
 type WebviewUiState = {
-    mode?: "live" | "source";
+  mode?: 'live' | 'source';
 };
 
 const persistModeState = () => {
-    const state: WebviewUiState = {
-        mode: currentMode,
-    };
-    vscode.setState(state);
+  const state: WebviewUiState = {
+    mode: currentMode
+  };
+  vscode.setState(state);
 };
 
 const postFindOptions = () => {
-    vscode.postMessage({
-        type: "setFindOptions",
-        findOptions: findPanelController.getSearchOptions(),
-    });
+  vscode.postMessage({
+    type: 'setFindOptions',
+    findOptions: findPanelController.getSearchOptions()
+  });
 };
 
 const getCurrentEditorText = () => {
-    if (editor) {
-        return editor.getText();
-    }
-    if (typeof pendingText === "string") {
-        return pendingText;
-    }
-    if (typeof pendingInitialText === "string") {
-        return pendingInitialText;
-    }
-    return syncedText;
+  if (editor) {
+    return editor.getText();
+  }
+  if (typeof pendingText === 'string') {
+    return pendingText;
+  }
+  if (typeof pendingInitialText === 'string') {
+    return pendingInitialText;
+  }
+  return syncedText;
 };
 
 const syncPendingDraftState = () => {
-    const draftText = pendingText ?? inFlightText;
-    const nextDraftText = draftText === null || (!inFlight && normalizeEol(draftText) === syncedText) ? null : draftText;
+  const draftText = pendingText ?? inFlightText;
+  const nextDraftText =
+    draftText === null || (!inFlight && normalizeEol(draftText) === syncedText)
+      ? null
+      : draftText;
 
-    if (hasSentDraftText && nextDraftText === lastSentDraftText) {
-        return;
-    }
+  if (hasSentDraftText && nextDraftText === lastSentDraftText) {
+    return;
+  }
 
-    hasSentDraftText = true;
-    lastSentDraftText = nextDraftText;
-    vscode.postMessage({ type: "draftChanged", text: nextDraftText });
+  hasSentDraftText = true;
+  lastSentDraftText = nextDraftText;
+  vscode.postMessage({ type: 'draftChanged', text: nextDraftText });
 };
 
 const normalizeLineNumber = (value: unknown): number | null => {
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-        return null;
-    }
-    return Math.max(1, Math.floor(value));
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(1, Math.floor(value));
 };
 
 const normalizeLineOffset = (value: unknown): number => {
-    if (typeof value !== "number" || !Number.isFinite(value)) {
-        return 0;
-    }
-    return Math.max(0, Math.round(value * 100) / 100);
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.round(value * 100) / 100);
 };
 
 const getTopVisiblePosition = (): { topLine: number; topLineOffset: number } | null => {
-    if (!editor) {
-        return null;
-    }
-    if (typeof editor.getTopVisiblePosition === "function") {
-        const position = editor.getTopVisiblePosition();
-        const topLine = normalizeLineNumber(position?.line);
-        if (topLine === null) {
-            return null;
-        }
-        return {
-            topLine,
-            topLineOffset: normalizeLineOffset(position?.lineOffset),
-        };
-    }
-    if (typeof editor.getTopVisibleLine !== "function") {
-        return null;
-    }
-    const topLine = normalizeLineNumber(editor.getTopVisibleLine());
+  if (!editor) {
+    return null;
+  }
+  if (typeof editor.getTopVisiblePosition === 'function') {
+    const position = editor.getTopVisiblePosition();
+    const topLine = normalizeLineNumber(position?.line);
     if (topLine === null) {
-        return null;
+      return null;
     }
     return {
-        topLine,
-        topLineOffset: 0,
+      topLine,
+      topLineOffset: normalizeLineOffset(position?.lineOffset)
     };
+  }
+  if (typeof editor.getTopVisibleLine !== 'function') {
+    return null;
+  }
+  const topLine = normalizeLineNumber(editor.getTopVisibleLine());
+  if (topLine === null) {
+    return null;
+  }
+  return {
+    topLine,
+    topLineOffset: 0
+  };
 };
 
 const postTopVisiblePositionIfChanged = (position: { topLine: number; topLineOffset: number } | null): void => {
-    if (!position) {
-        return;
-    }
-    if (position.topLine === lastSentTopLine && position.topLineOffset === lastSentTopLineOffset) {
-        return;
-    }
-    lastSentTopLine = position.topLine;
-    lastSentTopLineOffset = position.topLineOffset;
-    vscode.postMessage({
-        type: "viewPositionChanged",
-        topLine: position.topLine,
-        topLineOffset: position.topLineOffset,
-    });
+  if (!position) {
+    return;
+  }
+  if (position.topLine === lastSentTopLine && position.topLineOffset === lastSentTopLineOffset) {
+    return;
+  }
+  lastSentTopLine = position.topLine;
+  lastSentTopLineOffset = position.topLineOffset;
+  vscode.postMessage({
+    type: 'viewPositionChanged',
+    topLine: position.topLine,
+    topLineOffset: position.topLineOffset
+  });
 };
 
 const flushViewPositionNow = (): void => {
-    if (pendingViewPositionTimer !== null) {
-        window.clearTimeout(pendingViewPositionTimer);
-        pendingViewPositionTimer = null;
-    }
-    postTopVisiblePositionIfChanged(getTopVisiblePosition());
+  if (pendingViewPositionTimer !== null) {
+    window.clearTimeout(pendingViewPositionTimer);
+    pendingViewPositionTimer = null;
+  }
+  postTopVisiblePositionIfChanged(getTopVisiblePosition());
 };
 
 const scheduleViewPositionCapture = (): void => {
-    if (pendingViewPositionTimer !== null) {
-        window.clearTimeout(pendingViewPositionTimer);
-    }
-    pendingViewPositionTimer = window.setTimeout(() => {
-        pendingViewPositionTimer = null;
-        postTopVisiblePositionIfChanged(getTopVisiblePosition());
-    }, VIEW_POSITION_DEBOUNCE_MS);
+  if (pendingViewPositionTimer !== null) {
+    window.clearTimeout(pendingViewPositionTimer);
+  }
+  pendingViewPositionTimer = window.setTimeout(() => {
+    pendingViewPositionTimer = null;
+    postTopVisiblePositionIfChanged(getTopVisiblePosition());
+  }, VIEW_POSITION_DEBOUNCE_MS);
 };
 
 const applyPendingRestoreTopLine = (): void => {
-    if (!editor || pendingRestoreTopLine === null || pendingRevealSelection !== null) {
-        return;
-    }
-    if (typeof editor.restoreTopLine === "function") {
-        editor.restoreTopLine(pendingRestoreTopLine, pendingRestoreTopLineOffset);
-        pendingRestoreTopLine = null;
-        pendingRestoreTopLineOffset = 0;
-    }
+  if (!editor || pendingRestoreTopLine === null || pendingRevealSelection !== null) {
+    return;
+  }
+  if (typeof editor.restoreTopLine === 'function') {
+    editor.restoreTopLine(pendingRestoreTopLine, pendingRestoreTopLineOffset);
+    pendingRestoreTopLine = null;
+    pendingRestoreTopLineOffset = 0;
+  }
 };
 
 const refreshEditorSurface = (): void => {
-    if (!editor) {
-        return;
-    }
-    if (typeof editor.refreshLayout === "function") {
-        editor.refreshLayout();
-    }
+  if (!editor) {
+    return;
+  }
+  if (typeof editor.refreshLayout === 'function') {
+    editor.refreshLayout();
+  }
 };
 
 const runEditorSurfaceRecovery = (): void => {
-    pendingEditorSurfaceRecoveryRaf = null;
-    refreshEditorSurface();
-    applyPendingRestoreTopLine();
-    scheduleViewPositionCapture();
+  pendingEditorSurfaceRecoveryRaf = null;
+  refreshEditorSurface();
+  applyPendingRestoreTopLine();
+  scheduleViewPositionCapture();
 };
 
 const scheduleEditorSurfaceRecovery = (): void => {
-    if (pendingEditorSurfaceRecoveryRaf !== null) {
-        return;
-    }
-    pendingEditorSurfaceRecoveryRaf = window.requestAnimationFrame(runEditorSurfaceRecovery);
+  if (pendingEditorSurfaceRecoveryRaf !== null) {
+    return;
+  }
+  pendingEditorSurfaceRecoveryRaf = window.requestAnimationFrame(runEditorSurfaceRecovery);
 };
 
 const clampRevealOffset = (value: number, max: number): number => {
-    if (!Number.isFinite(value)) {
-        return 0;
-    }
-    return Math.max(0, Math.min(Math.floor(value), max));
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(Math.floor(value), max));
 };
 
 const applyRevealSelectionFromHost = (revealMessage: any) => {
-    if (!revealMessage || typeof revealMessage !== "object") {
-        return;
-    }
+  if (!revealMessage || typeof revealMessage !== 'object') {
+    return;
+  }
 
-    const { anchor, head, focus } = revealMessage;
-    if (typeof anchor !== "number" || typeof head !== "number") {
-        return;
-    }
+  const { anchor, head, focus } = revealMessage;
+  if (typeof anchor !== 'number' || typeof head !== 'number') {
+    return;
+  }
 
-    if (!editor) {
-        pendingRevealSelection = { anchor, head, focus };
-        return;
-    }
+  if (!editor) {
+    pendingRevealSelection = { anchor, head, focus };
+    return;
+  }
 
-    const max = editor.getText().length;
-    const clampedAnchor = clampRevealOffset(anchor, max);
-    const clampedHead = clampRevealOffset(head, max);
-    pendingRestoreTopLine = null;
-    pendingRestoreTopLineOffset = 0;
-    editor.revealSelection(clampedAnchor, clampedHead, {
-        focusEditor: focus !== false,
-        align: "center",
-    });
-    pendingRevealSelection = null;
-    scheduleViewPositionCapture();
+  const max = editor.getText().length;
+  const clampedAnchor = clampRevealOffset(anchor, max);
+  const clampedHead = clampRevealOffset(head, max);
+  pendingRestoreTopLine = null;
+  pendingRestoreTopLineOffset = 0;
+  editor.revealSelection(clampedAnchor, clampedHead, {
+    focusEditor: focus !== false,
+    align: 'center'
+  });
+  pendingRevealSelection = null;
+  scheduleViewPositionCapture();
 };
 
 const focusEditorFromHost = () => {
-    if (!editor) {
-        pendingEditorFocus = true;
-        return;
-    }
+  if (!editor) {
+    pendingEditorFocus = true;
+    return;
+  }
 
-    scheduleEditorSurfaceRecovery();
-    editor.focus();
-    pendingEditorFocus = false;
+  scheduleEditorSurfaceRecovery();
+  editor.focus();
+  pendingEditorFocus = false;
 };
 
 gitClient = createGitClient({
-    vscode,
-    getCurrentEditorText: () => getCurrentEditorText(),
-    getSyncedText: () => syncedText,
-    clearTransientUi: () => editor?.clearGitUiTransientState?.(),
+  vscode,
+  getCurrentEditorText: () => getCurrentEditorText(),
+  getSyncedText: () => syncedText,
+  clearTransientUi: () => editor?.clearGitUiTransientState?.()
 });
 
 const requestGitBlameForLine = ({ lineNumber }: { lineNumber: number }) => {
-    if (!gitClient) {
-        return Promise.resolve({ kind: "unavailable", reason: "error" });
-    }
-    return gitClient.requestBlameForLine({ lineNumber });
+  if (!gitClient) {
+    return Promise.resolve({ kind: 'unavailable', reason: 'error' });
+  }
+  return gitClient.requestBlameForLine({ lineNumber });
 };
 
 const openGitRevisionForLine = ({ lineNumber }: { lineNumber: number }) => {
-    gitClient?.openRevisionForLine({ lineNumber });
+  gitClient?.openRevisionForLine({ lineNumber });
 };
 
 const openGitWorktreeForLine = ({ lineNumber }: { lineNumber: number }) => {
-    gitClient?.openWorktreeForLine({ lineNumber });
+  gitClient?.openWorktreeForLine({ lineNumber });
 };
 
 const flushChanges = () => {
-    if (!editor || inFlight || pendingText === null || normalizeEol(pendingText) === syncedText) {
-        return;
-    }
+  if (!editor || inFlight || pendingText === null || normalizeEol(pendingText) === syncedText) {
+    return;
+  }
 
-    const nextText = pendingText;
-    const message: WebviewMessage = {
-        type: "applyChanges",
-        baseVersion: documentVersion,
-        changes: [
-            {
-                from: 0,
-                to: syncedText.length,
-                insert: nextText,
-            },
-        ],
-    };
+  const nextText = pendingText;
+  const message: WebviewMessage = {
+    type: 'applyChanges',
+    baseVersion: documentVersion,
+    changes: [
+      {
+        from: 0,
+        to: syncedText.length,
+        insert: nextText
+      }
+    ]
+  };
 
-    inFlight = true;
-    inFlightText = nextText;
-    syncedText = normalizeEol(nextText);
-    documentVersion++;
-    syncPendingDraftState();
-    vscode.postMessage(message);
+  inFlight = true;
+  inFlightText = nextText;
+  syncedText = normalizeEol(nextText);
+  documentVersion++;
+  syncPendingDraftState();
+  vscode.postMessage(message);
 };
 
 const flushPendingChangesNow = () => {
-    if (pendingDebounce !== null) {
-        window.clearTimeout(pendingDebounce);
-        pendingDebounce = null;
-    }
+  if (pendingDebounce !== null) {
+    window.clearTimeout(pendingDebounce);
+    pendingDebounce = null;
+  }
 
-    flushChanges();
+  flushChanges();
 };
 
 const maybeSaveAfterSync = () => {
-    if (!saveAfterSync) {
-        return;
-    }
+  if (!saveAfterSync) {
+    return;
+  }
 
-    if (inFlight) {
-        return;
-    }
+  if (inFlight) {
+    return;
+  }
 
-    if (pendingText !== null && normalizeEol(pendingText) !== syncedText) {
-        flushChanges();
-        return;
-    }
+  if (pendingText !== null && normalizeEol(pendingText) !== syncedText) {
+    flushChanges();
+    return;
+  }
 
-    saveAfterSync = false;
-    vscode.postMessage({ type: "saveDocument" });
+  saveAfterSync = false;
+  vscode.postMessage({ type: 'saveDocument' });
 };
 
 const requestSave = async () => {
-    saveAfterSync = true;
-    flushPendingChangesNow();
+  saveAfterSync = true;
+  flushPendingChangesNow();
 
-    let retries = 0;
-    while (inFlight && retries < 50) {
-        await new Promise((resolve) => window.setTimeout(resolve, 20));
-        retries++;
-    }
+  let retries = 0;
+  while (inFlight && retries < 50) {
+    await new Promise(resolve => window.setTimeout(resolve, 20));
+    retries++;
+  }
 
-    maybeSaveAfterSync();
+  maybeSaveAfterSync();
 };
 
 const setEditorTextSafely = (text: string, context: string): boolean => {
-    if (!editor) {
-        return false;
-    }
+  if (!editor) {
+    return false;
+  }
 
-    try {
+  try {
+    editor.setText(text);
+    return true;
+  } catch (error) {
+    logWebviewRenderError('setText', error, { context });
+
+    if (currentMode === 'live') {
+      try {
+        editor.setText(text);
+        failureNotice.clearFailureNotice();
+        return true;
+      } catch (retryInLiveError) {
+        logWebviewRenderError('setText.retryInLive', retryInLiveError, { context });
+        if (!shouldAutoFallbackToSourceForLiveError(retryInLiveError)) {
+          failureNotice.setFailureNotice('Live mode hit a transient render error while updating. Try again.', 'warning');
+          return false;
+        }
+      }
+
+      failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, 'warning');
+      applyMode('source', { post: true, persist: false, reason: 'render-failure' });
+      if (!editor) {
+        return false;
+      }
+      try {
         editor.setText(text);
         return true;
-    } catch (error) {
-        logWebviewRenderError("setText", error, { context });
-
-        if (currentMode === "live") {
-            try {
-                editor.setText(text);
-                failureNotice.clearFailureNotice();
-                return true;
-            } catch (retryInLiveError) {
-                logWebviewRenderError("setText.retryInLive", retryInLiveError, { context });
-                if (!shouldAutoFallbackToSourceForLiveError(retryInLiveError)) {
-                    failureNotice.setFailureNotice("Live mode hit a transient render error while updating. Try again.", "warning");
-                    return false;
-                }
-            }
-
-            failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, "warning");
-            applyMode("source", { post: true, persist: false, reason: "render-failure" });
-            if (!editor) {
-                return false;
-            }
-            try {
-                editor.setText(text);
-                return true;
-            } catch (retryError) {
-                logWebviewRenderError("setText.retryInSource", retryError, { context });
-                failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
-                return false;
-            }
-        }
-
-        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
+      } catch (retryError) {
+        logWebviewRenderError('setText.retryInSource', retryError, { context });
+        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
         return false;
+      }
     }
+
+    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
+    return false;
+  }
 };
 
 const shortcutHandlerContext: ShortcutHandlerContext = {
-    get editor() {
-        return editor;
-    },
-    get currentMode() {
-        return currentMode;
-    },
-    get vimModeEnabled() {
-        return vimModeEnabled;
-    },
-    get pendingText() {
-        return pendingText;
-    },
-    get syncedText() {
-        return syncedText;
-    },
-    requestSave,
-    openFindPanel: (target) => findPanelController.open(target),
-    applyMode: (mode, options) => applyMode(mode, options),
-    flushPendingChangesNow,
+  get editor() { return editor; },
+  get currentMode() { return currentMode; },
+  get vimModeEnabled() { return vimModeEnabled; },
+  get pendingText() { return pendingText; },
+  get syncedText() { return syncedText; },
+  requestSave,
+  openFindPanel: (target) => findPanelController.open(target),
+  applyMode: (mode, options) => applyMode(mode, options),
+  flushPendingChangesNow
 };
 
 const queueChanges = (nextText: string) => {
-    bumpLocalEditGeneration();
-    pendingText = nextText;
-    syncPendingDraftState();
+  bumpLocalEditGeneration();
+  pendingText = nextText;
+  syncPendingDraftState();
 
-    if (pendingDebounce !== null) {
-        window.clearTimeout(pendingDebounce);
-    }
+  if (pendingDebounce !== null) {
+    window.clearTimeout(pendingDebounce);
+  }
 
-    pendingDebounce = window.setTimeout(() => {
-        pendingDebounce = null;
-        flushChanges();
-    }, 100);
+  pendingDebounce = window.setTimeout(() => {
+    pendingDebounce = null;
+    flushChanges();
+  }, 100);
 
-    if (outlineController.isVisible()) {
-        outlineController.refresh();
-    }
-    scheduleWikiLinkStatusRefresh(nextText);
-    scheduleLocalLinkStatusRefresh(nextText);
-    findPanelController.updateFindStatusSummary();
+  if (outlineController.isVisible()) {
+    outlineController.refresh();
+  }
+  scheduleWikiLinkStatusRefresh(nextText);
+  scheduleLocalLinkStatusRefresh(nextText);
+  findPanelController.updateFindStatusSummary();
 };
 
 const updateModeUI = () => {
-    root.dataset.mode = currentMode;
-    const buttons = [liveButton, sourceButton];
-    for (const button of buttons) {
-        const selected = button.dataset.mode === currentMode;
-        button.classList.toggle("is-active", selected);
-        button.setAttribute("aria-selected", selected ? "true" : "false");
-        button.tabIndex = selected ? 0 : -1;
-    }
+  root.dataset.mode = currentMode;
+  const buttons = [liveButton, sourceButton];
+  for (const button of buttons) {
+    const selected = button.dataset.mode === currentMode;
+    button.classList.toggle('is-active', selected);
+    button.setAttribute('aria-selected', selected ? 'true' : 'false');
+    button.tabIndex = selected ? 0 : -1;
+  }
 };
 
-const applyMode = (mode: "live" | "source", { post = true, persist = true, userTriggered = false, reason = "user" } = {}): boolean => {
-    if (mode !== "live" && mode !== "source") {
-        return false;
-    }
+const applyMode = (mode: 'live' | 'source', { post = true, persist = true, userTriggered = false, reason = 'user' } = {}): boolean => {
+  if (mode !== 'live' && mode !== 'source') {
+    return false;
+  }
 
-    const previousMode = currentMode;
-    const shouldRestoreEditorFocus = modeToggleShouldRestoreEditorFocus;
-    modeToggleShouldRestoreEditorFocus = false;
-    currentMode = mode;
-    clearGitBlameCache();
-    if (userTriggered) {
-        hasLocalModePreference = true;
-    }
-    updateModeUI();
+  const previousMode = currentMode;
+  const shouldRestoreEditorFocus = modeToggleShouldRestoreEditorFocus;
+  modeToggleShouldRestoreEditorFocus = false;
+  currentMode = mode;
+  clearGitBlameCache();
+  if (userTriggered) {
+    hasLocalModePreference = true;
+  }
+  updateModeUI();
 
-    if (editor) {
-        try {
-            editor.setMode(mode);
-            syncGitDiffLineHighlights();
-            if (shouldRestoreEditorFocus) {
-                editor.focus();
-            }
-            if (mode === "live") {
-                failureNotice.clearFailureNotice();
-            }
-        } catch (error) {
-            logWebviewRenderError("applyMode", error, { requestedMode: mode, reason });
+  if (editor) {
+    try {
+      editor.setMode(mode);
+      syncGitDiffLineHighlights();
+      if (shouldRestoreEditorFocus) {
+        editor.focus();
+      }
+      if (mode === 'live') {
+        failureNotice.clearFailureNotice();
+      }
+    } catch (error) {
+      logWebviewRenderError('applyMode', error, { requestedMode: mode, reason });
 
-            if (mode === "live") {
-                if (!shouldAutoFallbackToSourceForLiveError(error)) {
-                    failureNotice.setFailureNotice("Live mode hit a transient render error. Staying in current mode; try again.", "warning");
-                    currentMode = previousMode;
-                    updateModeUI();
-                    failureNotice.updateEditorNotice();
-                    return false;
-                }
-
-                failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, "warning");
-
-                try {
-                    editor.setMode("source");
-                    currentMode = "source";
-                    updateModeUI();
-                    failureNotice.updateEditorNotice();
-                    if (shouldRestoreEditorFocus) {
-                        editor.focus();
-                    }
-                    if (post) {
-                        vscode.postMessage({ type: "setMode", mode: "source" });
-                    }
-                    return false;
-                } catch (fallbackError) {
-                    logWebviewRenderError("applyMode.fallbackSource", fallbackError, { requestedMode: mode, reason });
-                    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
-                }
-            }
-
-            currentMode = previousMode;
-            updateModeUI();
-            failureNotice.updateEditorNotice();
-            return false;
+      if (mode === 'live') {
+        if (!shouldAutoFallbackToSourceForLiveError(error)) {
+          failureNotice.setFailureNotice('Live mode hit a transient render error. Staying in current mode; try again.', 'warning');
+          currentMode = previousMode;
+          updateModeUI();
+          failureNotice.updateEditorNotice();
+          return false;
         }
-    }
 
-    if (persist) {
-        persistModeState();
-    }
+        failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, 'warning');
 
-    if (post) {
-        vscode.postMessage({ type: "setMode", mode });
-    }
+        try {
+          editor.setMode('source');
+          currentMode = 'source';
+          updateModeUI();
+          failureNotice.updateEditorNotice();
+          if (shouldRestoreEditorFocus) {
+            editor.focus();
+          }
+          if (post) {
+            vscode.postMessage({ type: 'setMode', mode: 'source' });
+          }
+          return false;
+        } catch (fallbackError) {
+          logWebviewRenderError('applyMode.fallbackSource', fallbackError, { requestedMode: mode, reason });
+          failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
+        }
+      }
 
-    failureNotice.updateEditorNotice();
-    return true;
+      currentMode = previousMode;
+      updateModeUI();
+      failureNotice.updateEditorNotice();
+      return false;
+    }
+  }
+
+  if (persist) {
+    persistModeState();
+  }
+
+  if (post) {
+    vscode.postMessage({ type: 'setMode', mode });
+  }
+
+  failureNotice.updateEditorNotice();
+  return true;
 };
 
 const mountInitialEditor = async () => {
-    if (editor || pendingInitialText === null || initialEditorMountInFlight) {
+  if (editor || pendingInitialText === null || initialEditorMountInFlight) {
+    return;
+  }
+  initialEditorMountInFlight = true;
+  try {
+    const createEditor = await loadCreateEditorFactory();
+    const initialText = pendingInitialText;
+    const initialTopLine = pendingRevealSelection === null ? pendingRestoreTopLine : null;
+    const initialTopLineOffset = pendingRevealSelection === null ? pendingRestoreTopLineOffset : 0;
+    if (editor || initialText === null) {
+      return;
+    }
+    editor = createEditor({
+      parent: editorHost,
+      text: initialText,
+      initialMode: currentMode,
+      initialTopLine,
+      initialTopLineOffset,
+      initialLineNumbers: lineNumbersVisible,
+      initialGitGutter: gitChangesGutterVisible,
+      initialVimMode: vimModeEnabled,
+      initialVimKeybindings: vimKeybindingsState,
+      initialVimLeader: vimLeaderState,
+      onApplyChanges: queueChanges,
+      onOpenLink: (href: string) => {
+        vscode.postMessage({ type: 'openLink', href });
+      },
+      onSelectionChange: (state: any) => selectionMenuController.update(state),
+      onViewportChange: () => scheduleViewPositionCapture(),
+      onRequestGitBlame: requestGitBlameForLine,
+      onOpenGitRevisionForLine: openGitRevisionForLine,
+      onOpenGitWorktreeForLine: openGitWorktreeForLine
+    });
+    gitClient?.applyBaselineToEditor(editor);
+    syncGitDiffLineHighlights();
+    if (initialTopLine !== null) {
+      pendingRestoreTopLine = null;
+      pendingRestoreTopLineOffset = 0;
+    }
+    editor.focus();
+    pendingInitialText = null;
+    initialMountRecoveryAttempted = false;
+    if (currentMode === 'live') {
+      failureNotice.clearFailureNotice();
+    }
+    requestWikiLinkStatuses(initialText);
+    requestLocalLinkStatuses(initialText);
+    if (pendingRevealSelection) {
+      applyRevealSelectionFromHost(pendingRevealSelection);
+    }
+    if (pendingEditorFocus) {
+      focusEditorFromHost();
+    }
+    if (outlineController.isVisible()) {
+      outlineController.refresh();
+    }
+    failureNotice.updateEditorNotice();
+
+    setWikiLinkRefreshContext({
+      refreshDecorations: () => editor?.refreshDecorations?.()
+    });
+    setLocalLinkRefreshContext({
+      refreshDecorations: () => editor?.refreshDecorations?.()
+    });
+    scheduleEditorSurfaceRecovery();
+  } catch (error) {
+    logWebviewRenderError('mountInitialEditor', error);
+
+    if (currentMode === 'live') {
+      if (!shouldAutoFallbackToSourceForLiveError(error)) {
+        if (!initialMountRecoveryAttempted) {
+          initialMountRecoveryAttempted = true;
+          failureNotice.setFailureNotice('Live mode hit a transient render error while loading. Retrying...', 'warning');
+          scheduleInitialEditorMount();
+          return;
+        }
+        failureNotice.setFailureNotice('Live mode hit a transient render error while loading. Try reopening or switching modes.', 'warning');
         return;
+      }
+
+      if (!initialMountRecoveryAttempted) {
+        initialMountRecoveryAttempted = true;
+        failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, 'warning');
+        applyMode('source', { post: true, persist: false, reason: 'render-failure' });
+        scheduleInitialEditorMount();
+        return;
+      }
     }
-    initialEditorMountInFlight = true;
-    try {
-        const createEditor = await loadCreateEditorFactory();
-        const initialText = pendingInitialText;
-        const initialTopLine = pendingRevealSelection === null ? pendingRestoreTopLine : null;
-        const initialTopLineOffset = pendingRevealSelection === null ? pendingRestoreTopLineOffset : 0;
-        if (editor || initialText === null) {
-            return;
-        }
-        editor = createEditor({
-            parent: editorHost,
-            text: initialText,
-            initialMode: currentMode,
-            initialTopLine,
-            initialTopLineOffset,
-            initialLineNumbers: lineNumbersVisible,
-            initialGitGutter: gitChangesGutterVisible,
-            initialVimMode: vimModeEnabled,
-            initialVimKeybindings: vimKeybindingsState,
-            initialVimLeader: vimLeaderState,
-            onApplyChanges: queueChanges,
-            onOpenLink: (href: string) => {
-                vscode.postMessage({ type: "openLink", href });
-            },
-            onSelectionChange: (state: any) => selectionMenuController.update(state),
-            onViewportChange: () => scheduleViewPositionCapture(),
-            onRequestGitBlame: requestGitBlameForLine,
-            onOpenGitRevisionForLine: openGitRevisionForLine,
-            onOpenGitWorktreeForLine: openGitWorktreeForLine,
-        });
-        gitClient?.applyBaselineToEditor(editor);
-        syncGitDiffLineHighlights();
-        if (initialTopLine !== null) {
-            pendingRestoreTopLine = null;
-            pendingRestoreTopLineOffset = 0;
-        }
-        editor.focus();
-        pendingInitialText = null;
-        initialMountRecoveryAttempted = false;
-        if (currentMode === "live") {
-            failureNotice.clearFailureNotice();
-        }
-        requestWikiLinkStatuses(initialText);
-        requestLocalLinkStatuses(initialText);
-        if (pendingRevealSelection) {
-            applyRevealSelectionFromHost(pendingRevealSelection);
-        }
-        if (pendingEditorFocus) {
-            focusEditorFromHost();
-        }
-        if (outlineController.isVisible()) {
-            outlineController.refresh();
-        }
-        failureNotice.updateEditorNotice();
 
-        setWikiLinkRefreshContext({
-            refreshDecorations: () => editor?.refreshDecorations?.(),
-        });
-        setLocalLinkRefreshContext({
-            refreshDecorations: () => editor?.refreshDecorations?.(),
-        });
-        scheduleEditorSurfaceRecovery();
-    } catch (error) {
-        logWebviewRenderError("mountInitialEditor", error);
-
-        if (currentMode === "live") {
-            if (!shouldAutoFallbackToSourceForLiveError(error)) {
-                if (!initialMountRecoveryAttempted) {
-                    initialMountRecoveryAttempted = true;
-                    failureNotice.setFailureNotice("Live mode hit a transient render error while loading. Retrying...", "warning");
-                    scheduleInitialEditorMount();
-                    return;
-                }
-                failureNotice.setFailureNotice("Live mode hit a transient render error while loading. Try reopening or switching modes.", "warning");
-                return;
-            }
-
-            if (!initialMountRecoveryAttempted) {
-                initialMountRecoveryAttempted = true;
-                failureNotice.setFailureNotice(failureNotice.liveModeFailureMessage, "warning");
-                applyMode("source", { post: true, persist: false, reason: "render-failure" });
-                scheduleInitialEditorMount();
-                return;
-            }
-        }
-
-        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, "error");
-    } finally {
-        initialEditorMountInFlight = false;
-    }
+    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
+  } finally {
+    initialEditorMountInFlight = false;
+  }
 };
 
 const scheduleInitialEditorMount = () => {
-    if (editor || initialEditorMountQueued) {
-        return;
+  if (editor || initialEditorMountQueued) {
+    return;
+  }
+
+  const runScheduledMount = () => {
+    if (!initialEditorMountQueued) {
+      return;
     }
+    initialEditorMountQueued = false;
+    if (initialEditorMountFallbackTimer !== null) {
+      window.clearTimeout(initialEditorMountFallbackTimer);
+      initialEditorMountFallbackTimer = null;
+    }
+    void mountInitialEditor();
+    findPanelController.updateFindStatusSummary();
+  };
 
-    const runScheduledMount = () => {
-        if (!initialEditorMountQueued) {
-            return;
-        }
-        initialEditorMountQueued = false;
-        if (initialEditorMountFallbackTimer !== null) {
-            window.clearTimeout(initialEditorMountFallbackTimer);
-            initialEditorMountFallbackTimer = null;
-        }
-        void mountInitialEditor();
-        findPanelController.updateFindStatusSummary();
-    };
-
-    initialEditorMountQueued = true;
-    window.requestAnimationFrame(runScheduledMount);
-    initialEditorMountFallbackTimer = window.setTimeout(runScheduledMount, INITIAL_EDITOR_MOUNT_FALLBACK_MS);
+  initialEditorMountQueued = true;
+  window.requestAnimationFrame(runScheduledMount);
+  initialEditorMountFallbackTimer = window.setTimeout(
+    runScheduledMount,
+    INITIAL_EDITOR_MOUNT_FALLBACK_MS
+  );
 };
 
 const handleInit = (message: any) => {
-    pendingRestoreTopLine = normalizeLineNumber(message.restoreTopLine);
-    pendingRestoreTopLineOffset = normalizeLineOffset(message.restoreTopLineOffset);
-    lastSentTopLine = null;
-    lastSentTopLineOffset = null;
-    if (!editor) {
-        pendingInitialText = message.text;
-        scheduleInitialEditorMount();
-    } else {
-        setEditorTextSafely(message.text, "init");
-    }
-    if (typeof message.lineNumbers === "boolean") {
-        setLineNumbersVisible(message.lineNumbers, { post: false });
-    }
-    if (typeof message.gitChangesGutter === "boolean") {
-        setGitChangesGutterVisible(message.gitChangesGutter, { post: false });
-    }
-    if (typeof message.gitDiffLineHighlights === "boolean") {
-        gitDiffLineHighlightsEnabled = message.gitDiffLineHighlights;
-        syncGitDiffLineHighlights();
-    }
-    if (typeof message.vimMode === "boolean") {
-        setVimModeEnabled(message.vimMode);
-    }
-    if (Array.isArray(message.vimKeybindings)) {
-        vimKeybindingsState = message.vimKeybindings;
-        vimLeaderState = typeof message.vimLeader === "string" ? message.vimLeader : "\\";
-        editor?.setVimKeybindings(vimKeybindingsState, vimLeaderState);
-    }
-    if (message.findOptions && typeof message.findOptions === "object") {
-        findPanelController.setSearchOptions(message.findOptions);
-    }
-    outlineController.setPosition(message.outlinePosition);
-    if (typeof message.outlineVisible === "boolean") {
-        setOutlineVisible(message.outlineVisible, { post: false });
-    }
-    if (editor && outlineController.isVisible()) {
-        outlineController.refresh();
-    }
-    scheduleEditorSurfaceRecovery();
-    scheduleWikiLinkStatusRefresh(message.text);
-    scheduleLocalLinkStatusRefresh(message.text);
-    findPanelController.updateFindStatusSummary();
+  pendingRestoreTopLine = normalizeLineNumber(message.restoreTopLine);
+  pendingRestoreTopLineOffset = normalizeLineOffset(message.restoreTopLineOffset);
+  lastSentTopLine = null;
+  lastSentTopLineOffset = null;
+  if (!editor) {
+    pendingInitialText = message.text;
+    scheduleInitialEditorMount();
+  } else {
+    setEditorTextSafely(message.text, 'init');
+  }
+  if (typeof message.lineNumbers === 'boolean') {
+    setLineNumbersVisible(message.lineNumbers, { post: false });
+  }
+  if (typeof message.gitChangesGutter === 'boolean') {
+    setGitChangesGutterVisible(message.gitChangesGutter, { post: false });
+  }
+  if (typeof message.gitDiffLineHighlights === 'boolean') {
+    gitDiffLineHighlightsEnabled = message.gitDiffLineHighlights;
+    syncGitDiffLineHighlights();
+  }
+  if (typeof message.vimMode === 'boolean') {
+    setVimModeEnabled(message.vimMode);
+  }
+  if (Array.isArray(message.vimKeybindings)) {
+    vimKeybindingsState = message.vimKeybindings;
+    vimLeaderState = typeof message.vimLeader === 'string' ? message.vimLeader : '\\';
+    editor?.setVimKeybindings(vimKeybindingsState, vimLeaderState);
+  }
+  if (message.findOptions && typeof message.findOptions === 'object') {
+    findPanelController.setSearchOptions(message.findOptions);
+  }
+  outlineController.setPosition(message.outlinePosition);
+  if (typeof message.outlineVisible === 'boolean') {
+    setOutlineVisible(message.outlineVisible, { post: false });
+  }
+  if (editor && outlineController.isVisible()) {
+    outlineController.refresh();
+  }
+  scheduleEditorSurfaceRecovery();
+  scheduleWikiLinkStatusRefresh(message.text);
+  scheduleLocalLinkStatusRefresh(message.text);
+  findPanelController.updateFindStatusSummary();
 };
 
 const exportHandlerContext: ExportHandlerContext = {
-    vscode,
-    getEditor: () => editor,
-    get pendingText() {
-        return pendingText;
-    },
-    get pendingInitialText() {
-        return pendingInitialText;
-    },
-    get syncedText() {
-        return syncedText;
-    },
-    get pendingDebounce() {
-        return pendingDebounce;
-    },
-    get inFlight() {
-        return inFlight;
-    },
-    flushChanges,
-    normalizeEol,
-    setPendingDebounce: (value) => {
-        pendingDebounce = value;
-    },
+  vscode,
+  getEditor: () => editor,
+  get pendingText() { return pendingText; },
+  get pendingInitialText() { return pendingInitialText; },
+  get syncedText() { return syncedText; },
+  get pendingDebounce() { return pendingDebounce; },
+  get inFlight() { return inFlight; },
+  flushChanges,
+  normalizeEol,
+  setPendingDebounce: (value) => { pendingDebounce = value; }
 };
 
 const exportHandler = createExportHandler(exportHandlerContext);
 
 const withMessageErrorBoundary = (context: string, action: () => void): void => {
-    try {
-        action();
-    } catch (error) {
-        console.error(`[MEO webview] ${context}`, error);
-    }
+  try {
+    action();
+  } catch (error) {
+    console.error(`[MEO webview] ${context}`, error);
+  }
 };
 
-window.addEventListener("message", (event) => {
-    const message = event.data;
+window.addEventListener('message', (event) => {
+  const message = event.data;
 
-    if (!message || typeof message !== "object") {
-        return;
-    }
+  if (!message || typeof message !== 'object') {
+    return;
+  }
 
-    if (message.type === "init") {
-        acknowledgeReadyHandshake();
-        withMessageErrorBoundary("init handler", () => {
-            applyThemeSettings(message.theme);
-            initialMountRecoveryAttempted = false;
-            failureNotice.clearFailureNotice();
-            gitClient?.resetForInit({ hideTooltip: false });
-            const nextMode = hasLocalModePreference ? currentMode : message.mode;
-            documentVersion = message.version;
-            syncedText = normalizeEol(message.text);
-            pendingText = null;
-            inFlight = false;
-            inFlightText = null;
-            saveAfterSync = false;
-            syncPendingDraftState();
+  if (message.type === 'init') {
+    acknowledgeReadyHandshake();
+    withMessageErrorBoundary('init handler', () => {
+      applyThemeSettings(message.theme);
+      initialMountRecoveryAttempted = false;
+      failureNotice.clearFailureNotice();
+      gitClient?.resetForInit({ hideTooltip: false });
+      const nextMode = hasLocalModePreference ? currentMode : message.mode;
+      documentVersion = message.version;
+      syncedText = normalizeEol(message.text);
+      pendingText = null;
+      inFlight = false;
+      inFlightText = null;
+      saveAfterSync = false;
+      syncPendingDraftState();
 
-            handleInit(message);
-            if (hasLocalModePreference) {
-                applyMode(nextMode, {
-                    post: true,
-                    persist: true,
-                    reason: "init",
-                });
-            } else {
-                applyMode(nextMode, {
-                    post: false,
-                    persist: false,
-                    reason: "init",
-                });
-            }
-            failureNotice.updateEditorNotice();
+      handleInit(message);
+      if (hasLocalModePreference) {
+        applyMode(nextMode, {
+          post: true,
+          persist: true,
+          reason: 'init'
         });
-        return;
-    }
-
-    if (message.type === "themeChanged") {
-        withMessageErrorBoundary("themeChanged handler", () => {
-            applyThemeSettings(message.theme);
+      } else {
+        applyMode(nextMode, {
+          post: false,
+          persist: false,
+          reason: 'init'
         });
-        return;
-    }
-
-    if (message.type === "revealSelection") {
-        applyRevealSelectionFromHost(message);
-        return;
-    }
-
-    if (message.type === "focusEditor") {
-        focusEditorFromHost();
-        return;
-    }
-
-    if (message.type === "toggleMode") {
-        applyMode(currentMode === "live" ? "source" : "live", { userTriggered: true, reason: "command" });
-        return;
-    }
-
-    if (message.type === "docChanged" && !editor && pendingInitialText !== null) {
-        clearGitBlameCache({ hideTooltip: false });
-        documentVersion = message.version;
-        syncedText = normalizeEol(message.text);
-        pendingInitialText = message.text;
-        return;
-    }
-
-    if (message.type === "docChanged" && editor) {
-        clearGitBlameCache();
-        const incomingText = normalizeEol(message.text);
-        const currentText = normalizeEol(editor.getText());
-        const pendingNormalized = pendingText === null ? null : normalizeEol(pendingText);
-        const inFlightNormalized = inFlightText === null ? null : normalizeEol(inFlightText);
-
-        documentVersion = message.version;
-
-        if (incomingText === currentText) {
-            syncedText = currentText;
-
-            if (pendingNormalized === incomingText) {
-                pendingText = null;
-            }
-
-            if (inFlight && inFlightNormalized === incomingText) {
-                inFlight = false;
-                inFlightText = null;
-            }
-
-            flushChanges();
-            maybeSaveAfterSync();
-            syncPendingDraftState();
-            return;
-        }
-
-        if (inFlight && inFlightNormalized === incomingText) {
-            syncedText = incomingText;
-            inFlight = false;
-            inFlightText = null;
-            flushChanges();
-            maybeSaveAfterSync();
-            syncPendingDraftState();
-            return;
-        }
-
-        if (pendingNormalized === incomingText) {
-            syncedText = incomingText;
-            pendingText = null;
-            inFlight = false;
-            inFlightText = null;
-            flushChanges();
-            maybeSaveAfterSync();
-            syncPendingDraftState();
-            return;
-        }
-
-        syncedText = incomingText;
-        pendingText = null;
-        inFlight = false;
-        inFlightText = null;
-        saveAfterSync = false;
-
-        if (pendingDebounce !== null) {
-            window.clearTimeout(pendingDebounce);
-            pendingDebounce = null;
-        }
-
-        syncPendingDraftState();
-        if (!setEditorTextSafely(message.text, "docChanged")) {
-            return;
-        }
-        scheduleWikiLinkStatusRefresh(message.text);
-        scheduleLocalLinkStatusRefresh(message.text);
-        findPanelController.updateFindStatusSummary();
-        return;
-    }
-
-    if (message.type === "applied") {
-        documentVersion = message.version;
-        if (inFlightText !== null) {
-            syncedText = normalizeEol(inFlightText);
-        }
-        inFlight = false;
-        inFlightText = null;
-        flushChanges();
-        maybeSaveAfterSync();
-        syncPendingDraftState();
-        return;
-    }
-
-    if (message.type === "lineNumbersChanged") {
-        setLineNumbersVisible(message.enabled, { post: false });
-        return;
-    }
-
-    if (message.type === "gitChangesGutterChanged") {
-        setGitChangesGutterVisible(message.enabled, { post: false });
-        return;
-    }
-
-    if (message.type === "gitDiffLineHighlightsChanged") {
-        gitDiffLineHighlightsEnabled = message.enabled;
-        syncGitDiffLineHighlights();
-        return;
-    }
-
-    if (message.type === "vimModeChanged") {
-        setVimModeEnabled(message.enabled);
-        return;
-    }
-
-    if (message.type === "vimKeybindingsChanged") {
-        vimKeybindingsState = message.keybindings;
-        vimLeaderState = message.leaderKey;
-        editor?.setVimKeybindings(vimKeybindingsState, vimLeaderState);
-        return;
-    }
-
-    if (message.type === "findOptionsChanged") {
-        if (message.findOptions && typeof message.findOptions === "object") {
-            findPanelController.setSearchOptions(message.findOptions);
-            findPanelController.updateFindStatusSummary();
-        }
-        return;
-    }
-
-    if (message.type === "outlineVisibilityChanged") {
-        setOutlineVisible(message.visible, { post: false });
-        return;
-    }
-
-    if (message.type === "gitBaselineChanged") {
-        if (typeof message.version === "number" && message.version < documentVersion) {
-            return;
-        }
-        gitClient?.handleMessage(message, { editor });
-        return;
-    }
-
-    if (message.type === "gitBlameResult") {
-        gitClient?.handleMessage(message, { editor });
-        return;
-    }
-
-    if (message.type === "outlinePositionChanged") {
-        outlineController.setPosition(message.position);
-        return;
-    }
-
-    if (message.type === "resolvedImageSrc") {
-        settleImageSrcRequest(message.requestId, message.resolvedUrl);
-        return;
-    }
-
-    if (message.type === "resolvedWikiLinks") {
-        if (handleResolvedWikiLinks(message)) {
-            editor?.refreshDecorations();
-        }
-        return;
-    }
-
-    if (message.type === "resolvedLocalLinks") {
-        if (handleResolvedLocalLinks(message)) {
-            editor?.refreshDecorations();
-        }
-        return;
-    }
-
-    if (message.type === "savedImagePath") {
-        handleSavedImagePath(message);
-        return;
-    }
-
-    if (message.type === "requestExportSnapshot") {
-        if (typeof message.requestId !== "string" || !message.requestId) {
-            return;
-        }
-        void exportHandler.handleExportSnapshotRequest(message.requestId);
-    }
-});
-
-window.addEventListener(
-    "keydown",
-    (event) => {
-        handleEditorShortcut(event, shortcutHandlerContext);
-    },
-    { capture: true },
-);
-
-window.addEventListener("paste", async (event) => {
-    if (!editor) {
-        return;
-    }
-
-    const stateAtPaste = editor.view.state;
-    const selectionAtPaste = stateAtPaste.selection.main;
-    const lineAtPaste = stateAtPaste.doc.lineAt(selectionAtPaste.head);
-    const lineNumberAtPaste = lineAtPaste.number;
-    const lineOffsetAtPaste = selectionAtPaste.head - lineAtPaste.from;
-
-    await handleImagePaste(event, editor, {
-        lineNumber: lineNumberAtPaste,
-        lineOffset: lineOffsetAtPaste,
+      }
+      failureNotice.updateEditorNotice();
     });
-});
+    return;
+  }
 
-window.addEventListener("blur", () => {
-    flushPendingChangesNow();
-    flushViewPositionNow();
-});
+  if (message.type === 'themeChanged') {
+    withMessageErrorBoundary('themeChanged handler', () => {
+      applyThemeSettings(message.theme);
+    });
+    return;
+  }
 
-window.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "hidden") {
-        if (pendingEditorSurfaceRecoveryRaf !== null) {
-            window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
-            pendingEditorSurfaceRecoveryRaf = null;
-        }
-        forceFlushChanges();
-        return;
+  if (message.type === 'revealSelection') {
+    applyRevealSelectionFromHost(message);
+    return;
+  }
+
+  if (message.type === 'focusEditor') {
+    focusEditorFromHost();
+    return;
+  }
+
+  if (message.type === 'toggleMode') {
+    applyMode(currentMode === 'live' ? 'source' : 'live', { userTriggered: true, reason: 'command' });
+    return;
+  }
+
+  if (message.type === 'docChanged' && !editor && pendingInitialText !== null) {
+    clearGitBlameCache({ hideTooltip: false });
+    documentVersion = message.version;
+    syncedText = normalizeEol(message.text);
+    pendingInitialText = message.text;
+    return;
+  }
+
+  if (message.type === 'docChanged' && editor) {
+    clearGitBlameCache();
+    const incomingText = normalizeEol(message.text);
+    const currentText = normalizeEol(editor.getText());
+    const pendingNormalized = pendingText === null ? null : normalizeEol(pendingText);
+    const inFlightNormalized = inFlightText === null ? null : normalizeEol(inFlightText);
+
+    documentVersion = message.version;
+
+    if (incomingText === currentText) {
+      syncedText = currentText;
+
+      if (pendingNormalized === incomingText) {
+        pendingText = null;
+      }
+
+      if (inFlight && inFlightNormalized === incomingText) {
+        inFlight = false;
+        inFlightText = null;
+      }
+
+      flushChanges();
+      maybeSaveAfterSync();
+      syncPendingDraftState();
+      return;
     }
-    scheduleEditorSurfaceRecovery();
+
+    if (inFlight && inFlightNormalized === incomingText) {
+      syncedText = incomingText;
+      inFlight = false;
+      inFlightText = null;
+      flushChanges();
+      maybeSaveAfterSync();
+      syncPendingDraftState();
+      return;
+    }
+
+    if (pendingNormalized === incomingText) {
+      syncedText = incomingText;
+      pendingText = null;
+      inFlight = false;
+      inFlightText = null;
+      flushChanges();
+      maybeSaveAfterSync();
+      syncPendingDraftState();
+      return;
+    }
+
+    syncedText = incomingText;
+    pendingText = null;
+    inFlight = false;
+    inFlightText = null;
+    saveAfterSync = false;
+
+    if (pendingDebounce !== null) {
+      window.clearTimeout(pendingDebounce);
+      pendingDebounce = null;
+    }
+
+    syncPendingDraftState();
+    if (!setEditorTextSafely(message.text, 'docChanged')) {
+      return;
+    }
+    scheduleWikiLinkStatusRefresh(message.text);
+    scheduleLocalLinkStatusRefresh(message.text);
+    findPanelController.updateFindStatusSummary();
+    return;
+  }
+
+  if (message.type === 'applied') {
+    documentVersion = message.version;
+    if (inFlightText !== null) {
+      syncedText = normalizeEol(inFlightText);
+    }
+    inFlight = false;
+    inFlightText = null;
+    flushChanges();
+    maybeSaveAfterSync();
+    syncPendingDraftState();
+    return;
+  }
+
+  if (message.type === 'lineNumbersChanged') {
+    setLineNumbersVisible(message.enabled, { post: false });
+    return;
+  }
+
+  if (message.type === 'gitChangesGutterChanged') {
+    setGitChangesGutterVisible(message.enabled, { post: false });
+    return;
+  }
+
+  if (message.type === 'gitDiffLineHighlightsChanged') {
+    gitDiffLineHighlightsEnabled = message.enabled;
+    syncGitDiffLineHighlights();
+    return;
+  }
+
+  if (message.type === 'vimModeChanged') {
+    setVimModeEnabled(message.enabled);
+    return;
+  }
+
+  if (message.type === 'vimKeybindingsChanged') {
+    vimKeybindingsState = message.keybindings;
+    vimLeaderState = message.leaderKey;
+    editor?.setVimKeybindings(vimKeybindingsState, vimLeaderState);
+    return;
+  }
+
+  if (message.type === 'findOptionsChanged') {
+    if (message.findOptions && typeof message.findOptions === 'object') {
+      findPanelController.setSearchOptions(message.findOptions);
+      findPanelController.updateFindStatusSummary();
+    }
+    return;
+  }
+
+  if (message.type === 'outlineVisibilityChanged') {
+    setOutlineVisible(message.visible, { post: false });
+    return;
+  }
+
+  if (message.type === 'gitBaselineChanged') {
+    if (typeof message.version === 'number' && message.version < documentVersion) {
+      return;
+    }
+    gitClient?.handleMessage(message, { editor });
+    return;
+  }
+
+  if (message.type === 'gitBlameResult') {
+    gitClient?.handleMessage(message, { editor });
+    return;
+  }
+
+  if (message.type === 'outlinePositionChanged') {
+    outlineController.setPosition(message.position);
+    return;
+  }
+
+  if (message.type === 'resolvedImageSrc') {
+    settleImageSrcRequest(message.requestId, message.resolvedUrl);
+    return;
+  }
+
+  if (message.type === 'resolvedWikiLinks') {
+    if (handleResolvedWikiLinks(message)) {
+      editor?.refreshDecorations();
+    }
+    return;
+  }
+
+  if (message.type === 'resolvedLocalLinks') {
+    if (handleResolvedLocalLinks(message)) {
+      editor?.refreshDecorations();
+    }
+    return;
+  }
+
+  if (message.type === 'savedImagePath') {
+    handleSavedImagePath(message);
+    return;
+  }
+
+  if (message.type === 'requestExportSnapshot') {
+    if (typeof message.requestId !== 'string' || !message.requestId) {
+      return;
+    }
+    void exportHandler.handleExportSnapshotRequest(message.requestId);
+  }
 });
 
-window.addEventListener("focus", () => {
-    scheduleEditorSurfaceRecovery();
+window.addEventListener('keydown', (event) => {
+  handleEditorShortcut(event, shortcutHandlerContext);
+}, { capture: true });
+
+window.addEventListener('paste', async (event) => {
+  if (!editor) {
+    return;
+  }
+
+  const stateAtPaste = editor.view.state;
+  const selectionAtPaste = stateAtPaste.selection.main;
+  const lineAtPaste = stateAtPaste.doc.lineAt(selectionAtPaste.head);
+  const lineNumberAtPaste = lineAtPaste.number;
+  const lineOffsetAtPaste = selectionAtPaste.head - lineAtPaste.from;
+
+  await handleImagePaste(event, editor, {
+    lineNumber: lineNumberAtPaste,
+    lineOffset: lineOffsetAtPaste
+  });
+});
+
+window.addEventListener('blur', () => {
+  flushPendingChangesNow();
+  flushViewPositionNow();
+});
+
+window.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    if (pendingEditorSurfaceRecoveryRaf !== null) {
+      window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
+      pendingEditorSurfaceRecoveryRaf = null;
+    }
+    forceFlushChanges();
+    return;
+  }
+  scheduleEditorSurfaceRecovery();
+});
+
+window.addEventListener('focus', () => {
+  scheduleEditorSurfaceRecovery();
 });
 
 const forceFlushChanges = () => {
-    flushChanges();
-    flushViewPositionNow();
+  flushChanges();
+  flushViewPositionNow();
 };
 
-window.addEventListener("beforeunload", () => {
-    clearReadyRetryTimers();
-    cancelPendingWikiStatusRefresh();
-    cancelPendingLocalLinkStatusRefresh();
-    clearGitBlameCache({ hideTooltip: false });
+window.addEventListener('beforeunload', () => {
+  clearReadyRetryTimers();
+  cancelPendingWikiStatusRefresh();
+  cancelPendingLocalLinkStatusRefresh();
+  clearGitBlameCache({ hideTooltip: false });
 
-    if (initialEditorMountFallbackTimer !== null) {
-        window.clearTimeout(initialEditorMountFallbackTimer);
-        initialEditorMountFallbackTimer = null;
-    }
-    if (pendingEditorSurfaceRecoveryRaf !== null) {
-        window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
-        pendingEditorSurfaceRecoveryRaf = null;
-    }
+  if (initialEditorMountFallbackTimer !== null) {
+    window.clearTimeout(initialEditorMountFallbackTimer);
+    initialEditorMountFallbackTimer = null;
+  }
+  if (pendingEditorSurfaceRecoveryRaf !== null) {
+    window.cancelAnimationFrame(pendingEditorSurfaceRecoveryRaf);
+    pendingEditorSurfaceRecoveryRaf = null;
+  }
 
-    if (pendingDebounce !== null) {
-        window.clearTimeout(pendingDebounce);
-        pendingDebounce = null;
-    }
+  if (pendingDebounce !== null) {
+    window.clearTimeout(pendingDebounce);
+    pendingDebounce = null;
+  }
 
-    forceFlushChanges();
+  forceFlushChanges();
 });
 
-window.addEventListener("resize", () => {
-    findPanelController.updateAnchor();
-    if (editor) {
-        editor.refreshSelectionOverlay();
-    }
+window.addEventListener('resize', () => {
+  findPanelController.updateAnchor();
+  if (editor) {
+    editor.refreshSelectionOverlay();
+  }
 });
 
 const state = vscode.getState() as WebviewUiState | undefined;
-if (state && (state.mode === "live" || state.mode === "source")) {
-    applyMode(state.mode, { post: false, persist: false });
-    hasLocalModePreference = true;
+if (state && (state.mode === 'live' || state.mode === 'source')) {
+  applyMode(state.mode, { post: false, persist: false });
+  hasLocalModePreference = true;
 } else {
-    updateModeUI();
+  updateModeUI();
 }
-outlineController.setPosition("right");
+outlineController.setPosition('right');
 updateLineNumbersUI();
 updateGitChangesGutterUI();
 
-liveButton.addEventListener("click", () => {
-    applyMode("live", { userTriggered: true });
+liveButton.addEventListener('click', () => {
+  applyMode('live', { userTriggered: true });
 });
 
-sourceButton.addEventListener("click", () => {
-    applyMode("source", { userTriggered: true });
+sourceButton.addEventListener('click', () => {
+  applyMode('source', { userTriggered: true });
 });
 
 const preserveEditorFocusOnModePointerToggle = (event: PointerEvent) => {
-    const target = event.target;
-    if (!(target instanceof Element) || !target.closest(".mode-button")) {
-        return;
-    }
-    if (!editor || !editor.hasFocus()) {
-        modeToggleShouldRestoreEditorFocus = false;
-        return;
-    }
-    modeToggleShouldRestoreEditorFocus = true;
-    event.preventDefault();
+  const target = event.target;
+  if (!(target instanceof Element) || !target.closest('.mode-button')) {
+    return;
+  }
+  if (!editor || !editor.hasFocus()) {
+    modeToggleShouldRestoreEditorFocus = false;
+    return;
+  }
+  modeToggleShouldRestoreEditorFocus = true;
+  event.preventDefault();
 };
 
-modeGroup.addEventListener("pointerdown", preserveEditorFocusOnModePointerToggle);
+modeGroup.addEventListener('pointerdown', preserveEditorFocusOnModePointerToggle);
 
 const handleFormatAction = (action: string) => {
-    if (!editor) return;
-    editor.insertFormat(action);
-    editor.focus();
+  if (!editor) return;
+  editor.insertFormat(action);
+  editor.focus();
 };
 
-findPanelElements.findInput.addEventListener("input", () => {
-    findPanelController.updateFindStatusSummary();
+findPanelElements.findInput.addEventListener('input', () => {
+  findPanelController.updateFindStatusSummary();
 });
 
-findPanelElements.wholeWordBtn.addEventListener("click", () => {
-    findPanelController.toggleWholeWord();
-    postFindOptions();
+findPanelElements.wholeWordBtn.addEventListener('click', () => {
+  findPanelController.toggleWholeWord();
+  postFindOptions();
 });
 
-findPanelElements.caseSensitiveBtn.addEventListener("click", () => {
-    findPanelController.toggleCaseSensitive();
-    postFindOptions();
+findPanelElements.caseSensitiveBtn.addEventListener('click', () => {
+  findPanelController.toggleCaseSensitive();
+  postFindOptions();
 });
 
-findPanelElements.panel.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape" || !findPanelController.isVisible()) {
-        return;
-    }
+findPanelElements.panel.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape' || !findPanelController.isVisible()) {
+    return;
+  }
 
+  event.preventDefault();
+  event.stopPropagation();
+  findPanelController.close();
+});
+
+findPanelElements.findInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
     event.preventDefault();
-    event.stopPropagation();
-    findPanelController.close();
+    findPanelController.runFind(event.shiftKey, { focusEditor: false });
+    return;
+  }
 });
 
-findPanelElements.findInput.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-        event.preventDefault();
-        findPanelController.runFind(event.shiftKey, { focusEditor: false });
-        return;
-    }
-});
-
-findPanelElements.replaceInput.addEventListener("keydown", (event) => {
-    if (event.key === "Enter") {
-        event.preventDefault();
-        findPanelController.runReplace();
-        return;
-    }
-});
-
-findPanelElements.findPrevBtn.addEventListener("click", () => {
-    findPanelController.runFind(true);
-});
-
-findPanelElements.findNextBtn.addEventListener("click", () => {
-    findPanelController.runFind(false);
-});
-
-findPanelElements.replaceBtn.addEventListener("click", () => {
+findPanelElements.replaceInput.addEventListener('keydown', (event) => {
+  if (event.key === 'Enter') {
+    event.preventDefault();
     findPanelController.runReplace();
+    return;
+  }
 });
 
-findPanelElements.replaceAllBtn.addEventListener("click", () => {
-    findPanelController.runReplaceAll();
+findPanelElements.findPrevBtn.addEventListener('click', () => {
+  findPanelController.runFind(true);
 });
 
-findToggleBtn.addEventListener("click", () => {
-    if (findPanelController.isVisible()) {
-        findPanelController.close();
-        return;
-    }
-    findPanelController.open("find");
+findPanelElements.findNextBtn.addEventListener('click', () => {
+  findPanelController.runFind(false);
 });
 
-selectionMenuElements.menu.addEventListener("pointerdown", (event) => {
-    event.preventDefault();
+findPanelElements.replaceBtn.addEventListener('click', () => {
+  findPanelController.runReplace();
 });
 
-selectionMenuElements.menu.addEventListener("click", (event) => {
-    const button = (event.target as Element).closest(".selection-inline-button") as HTMLElement | null;
-    if (!button) return;
-    const { action } = button.dataset;
-    if (!action) return;
-    selectionMenuController.handleAction(action);
+findPanelElements.replaceAllBtn.addEventListener('click', () => {
+  findPanelController.runReplaceAll();
 });
 
-headingDropdown.addEventListener("click", (event) => {
-    const option = (event.target as Element).closest(".heading-dropdown-option") as HTMLElement | null;
-    if (!option || !editor) return;
-    const level = parseInt(option.dataset.level ?? "", 10);
-    editor.insertFormat("heading", level);
-    editor.focus();
+findToggleBtn.addEventListener('click', () => {
+  if (findPanelController.isVisible()) {
+    findPanelController.close();
+    return;
+  }
+  findPanelController.open('find');
 });
 
-bulletListBtn.addEventListener("click", () => handleFormatAction("bulletList"));
-numberedListBtn.addEventListener("click", () => handleFormatAction("numberedList"));
-taskBtn.addEventListener("click", () => handleFormatAction("task"));
-codeBlockBtn.addEventListener("click", () => handleFormatAction("codeBlock"));
-quoteBtn.addEventListener("click", () => handleFormatAction("quote"));
-hrBtn.addEventListener("click", () => handleFormatAction("hr"));
-linkBtn.addEventListener("click", () => handleFormatAction("link"));
-wikiLinkBtn.addEventListener("click", () => handleFormatAction("wikiLink"));
-imageBtn.addEventListener("click", () => handleFormatAction("image"));
-exportHtmlOption.addEventListener("click", () => {
-    exportHandler.requestExport("html");
+selectionMenuElements.menu.addEventListener('pointerdown', (event) => {
+  event.preventDefault();
 });
-exportPdfOption.addEventListener("click", () => {
-    exportHandler.requestExport("pdf");
+
+selectionMenuElements.menu.addEventListener('click', (event) => {
+  const button = (event.target as Element).closest('.selection-inline-button') as HTMLElement | null;
+  if (!button) return;
+  const { action } = button.dataset;
+  if (!action) return;
+  selectionMenuController.handleAction(action);
 });
-outlineBtn.addEventListener("click", () => {
-    setOutlineVisible(!outlineController.isVisible());
+
+headingDropdown.addEventListener('click', (event) => {
+  const option = (event.target as Element).closest('.heading-dropdown-option') as HTMLElement | null;
+  if (!option || !editor) return;
+  const level = parseInt(option.dataset.level ?? '', 10);
+  editor.insertFormat('heading', level);
+  editor.focus();
 });
-lineNumbersBtn.addEventListener("click", toggleLineNumbers);
-gitChangesGutterBtn.addEventListener("click", toggleGitChangesGutter);
+
+bulletListBtn.addEventListener('click', () => handleFormatAction('bulletList'));
+numberedListBtn.addEventListener('click', () => handleFormatAction('numberedList'));
+taskBtn.addEventListener('click', () => handleFormatAction('task'));
+codeBlockBtn.addEventListener('click', () => handleFormatAction('codeBlock'));
+quoteBtn.addEventListener('click', () => handleFormatAction('quote'));
+hrBtn.addEventListener('click', () => handleFormatAction('hr'));
+linkBtn.addEventListener('click', () => handleFormatAction('link'));
+wikiLinkBtn.addEventListener('click', () => handleFormatAction('wikiLink'));
+imageBtn.addEventListener('click', () => handleFormatAction('image'));
+exportHtmlOption.addEventListener('click', () => {
+  exportHandler.requestExport('html');
+});
+exportPdfOption.addEventListener('click', () => {
+  exportHandler.requestExport('pdf');
+});
+outlineBtn.addEventListener('click', () => {
+  setOutlineVisible(!outlineController.isVisible());
+});
+lineNumbersBtn.addEventListener('click', toggleLineNumbers);
+gitChangesGutterBtn.addEventListener('click', toggleGitChangesGutter);
 
 persistModeState();
-vscode.postMessage({ type: "setMode", mode: currentMode });
+vscode.postMessage({ type: 'setMode', mode: currentMode });
 scheduleReadyHandshake();
 scheduleEditorBundleWarmupAfterReady();

--- a/webview/src/types.d.ts
+++ b/webview/src/types.d.ts
@@ -1,104 +1,76 @@
+type VimKeybinding = {
+    before: string;
+    after: string;
+    mode: "normal" | "insert" | "visual";
+    recursive: boolean;
+};
+
 declare function acquireVsCodeApi(): VsCodeWebviewApi;
 
 interface VsCodeWebviewApi {
-  getState?(): unknown;
-  setState?(state: unknown): void;
-  postMessage(message: WebviewMessage): void;
+    getState?(): unknown;
+    setState?(state: unknown): void;
+    postMessage(message: WebviewMessage): void;
 }
 
-type WebviewMessage =
-  | { type: 'ready' }
-  | { type: 'applyChanges'; content?: string; baseVersion: number; changes?: { from: number; to: number; insert: string }[] }
-  | { type: 'draftChanged'; text: string | null }
-  | { type: 'setMode'; mode: 'live' | 'source' }
-  | { type: 'setLineNumbers'; visible: boolean }
-  | { type: 'setGitChangesGutter'; visible: boolean }
-  | { type: 'setOutlineVisible'; visible: boolean }
-  | { type: 'setFindOptions'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
-  | { type: 'viewPositionChanged'; topLine: number; topLineOffset?: number }
-  | { type: 'openLink'; href: string }
-  | { type: 'resolveImageSrc'; requestId: string; url: string }
-  | { type: 'resolveWikiLinks'; requestId: string; targets: string[] }
-  | { type: 'resolveLocalLinks'; requestId: string; targets: string[] }
-  | { type: 'saveDocument' }
-  | { type: 'exportDocument'; format: 'html' | 'pdf' }
-  | { type: 'exportSnapshot'; requestId: string; text: string; environment?: Record<string, unknown> }
-  | { type: 'exportSnapshotError'; requestId: string; error: string; message?: string }
-  | { type: 'saveImageFromClipboard'; requestId: string; imageData: string; fileName: string };
+type WebviewMessage = { type: "ready" } | { type: "applyChanges"; content?: string; baseVersion: number; changes?: { from: number; to: number; insert: string }[] } | { type: "draftChanged"; text: string | null } | { type: "setMode"; mode: "live" | "source" } | { type: "setLineNumbers"; visible: boolean } | { type: "setGitChangesGutter"; visible: boolean } | { type: "setOutlineVisible"; visible: boolean } | { type: "setFindOptions"; findOptions: { wholeWord: boolean; caseSensitive: boolean } } | { type: "viewPositionChanged"; topLine: number; topLineOffset?: number } | { type: "openLink"; href: string } | { type: "resolveImageSrc"; requestId: string; url: string } | { type: "resolveWikiLinks"; requestId: string; targets: string[] } | { type: "resolveLocalLinks"; requestId: string; targets: string[] } | { type: "saveDocument" } | { type: "exportDocument"; format: "html" | "pdf" } | { type: "exportSnapshot"; requestId: string; text: string; environment?: Record<string, unknown> } | { type: "exportSnapshotError"; requestId: string; error: string; message?: string } | { type: "saveImageFromClipboard"; requestId: string; imageData: string; fileName: string };
 
-type ExtensionMessage =
-  | { type: 'init'; text: string; version: number; theme: ThemeSettings; mode: 'live' | 'source'; outlinePosition: 'left' | 'right'; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; vimMode: boolean; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number }
-  | { type: 'docChanged'; text: string; version: number }
-  | { type: 'applied'; version: number }
-  | { type: 'focusEditor' }
-  | { type: 'revealSelection'; anchor: number; head: number; focus?: boolean }
-  | { type: 'themeChanged'; theme: ThemeSettings }
-  | { type: 'outlinePositionChanged'; position: 'left' | 'right' }
-  | { type: 'outlineVisibilityChanged'; visible: boolean }
-  | { type: 'lineNumbersChanged'; enabled: boolean }
-  | { type: 'gitChangesGutterChanged'; enabled: boolean }
-  | { type: 'gitDiffLineHighlightsChanged'; enabled: boolean }
-  | { type: 'vimModeChanged'; enabled: boolean }
-  | { type: 'findOptionsChanged'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
-  | { type: 'resolvedImageSrc'; requestId: string; resolvedUrl: string }
-  | { type: 'resolvedWikiLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
-  | { type: 'resolvedLocalLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
-  | { type: 'savedImagePath'; requestId: string; success: boolean; path?: string; error?: string };
+type ExtensionMessage = { type: "init"; text: string; version: number; theme: ThemeSettings; mode: "live" | "source"; outlinePosition: "left" | "right"; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number } | { type: "docChanged"; text: string; version: number } | { type: "applied"; version: number } | { type: "focusEditor" } | { type: "revealSelection"; anchor: number; head: number; focus?: boolean } | { type: "themeChanged"; theme: ThemeSettings } | { type: "outlinePositionChanged"; position: "left" | "right" } | { type: "outlineVisibilityChanged"; visible: boolean } | { type: "lineNumbersChanged"; enabled: boolean } | { type: "gitChangesGutterChanged"; enabled: boolean } | { type: "gitDiffLineHighlightsChanged"; enabled: boolean } | { type: "vimModeChanged"; enabled: boolean } | { type: "vimKeybindingsChanged"; keybindings: VimKeybinding[]; leaderKey: string } | { type: "findOptionsChanged"; findOptions: { wholeWord: boolean; caseSensitive: boolean } } | { type: "resolvedImageSrc"; requestId: string; resolvedUrl: string } | { type: "resolvedWikiLinks"; requestId: string; results: Array<{ target: string; exists: boolean }> } | { type: "resolvedLocalLinks"; requestId: string; results: Array<{ target: string; exists: boolean }> } | { type: "savedImagePath"; requestId: string; success: boolean; path?: string; error?: string };
 
 interface ThemeSettings {
-  id: string;
-  name: string;
-  colors: Record<string, string>;
-  syntaxTokens: Record<string, string>;
-  fonts: {
-    liveFont?: string;
-    sourceFont?: string;
-    liveFontWeight?: string;
-    sourceFontWeight?: string;
-    liveFontSize?: number | null;
-    sourceFontSize?: number | null;
-    h1FontSize?: number | null;
-    h2FontSize?: number | null;
-    h3FontSize?: number | null;
-    h4FontSize?: number | null;
-    h5FontSize?: number | null;
-    h6FontSize?: number | null;
-    h1FontWeight?: string;
-    h2FontWeight?: string;
-    h3FontWeight?: string;
-    h4FontWeight?: string;
-    h5FontWeight?: string;
-    h6FontWeight?: string;
-    liveLineHeight?: number;
-    sourceLineHeight?: number;
-  };
+    id: string;
+    name: string;
+    colors: Record<string, string>;
+    syntaxTokens: Record<string, string>;
+    fonts: {
+        liveFont?: string;
+        sourceFont?: string;
+        liveFontWeight?: string;
+        sourceFontWeight?: string;
+        liveFontSize?: number | null;
+        sourceFontSize?: number | null;
+        h1FontSize?: number | null;
+        h2FontSize?: number | null;
+        h3FontSize?: number | null;
+        h4FontSize?: number | null;
+        h5FontSize?: number | null;
+        h6FontSize?: number | null;
+        h1FontWeight?: string;
+        h2FontWeight?: string;
+        h3FontWeight?: string;
+        h4FontWeight?: string;
+        h5FontWeight?: string;
+        h6FontWeight?: string;
+        liveLineHeight?: number;
+        sourceLineHeight?: number;
+    };
 }
 
 interface WikiLinkStatus {
-  exists: boolean;
-  path?: string;
+    exists: boolean;
+    path?: string;
 }
 
 interface HeadingInfo {
-  text: string;
-  level: number;
-  from: number;
-  to: number;
-  lineFrom: number;
-  lineTo: number;
-  id: string;
+    text: string;
+    level: number;
+    from: number;
+    to: number;
+    lineFrom: number;
+    lineTo: number;
+    id: string;
 }
 
 interface GitDiffLine {
-  type: 'added' | 'removed' | 'modified' | 'unchanged';
-  oldLineNumber?: number;
-  newLineNumber?: number;
-  content: string;
+    type: "added" | "removed" | "modified" | "unchanged";
+    oldLineNumber?: number;
+    newLineNumber?: number;
+    content: string;
 }
 
 interface GitBlameInfo {
-  hash: string;
-  author: string;
-  date: string;
-  message: string;
+    hash: string;
+    author: string;
+    date: string;
+    message: string;
 }

--- a/webview/src/types.d.ts
+++ b/webview/src/types.d.ts
@@ -1,76 +1,112 @@
-type VimKeybinding = {
-    before: string;
-    after: string;
-    mode: "normal" | "insert" | "visual";
-    recursive: boolean;
-};
-
 declare function acquireVsCodeApi(): VsCodeWebviewApi;
 
 interface VsCodeWebviewApi {
-    getState?(): unknown;
-    setState?(state: unknown): void;
-    postMessage(message: WebviewMessage): void;
+  getState?(): unknown;
+  setState?(state: unknown): void;
+  postMessage(message: WebviewMessage): void;
 }
 
-type WebviewMessage = { type: "ready" } | { type: "applyChanges"; content?: string; baseVersion: number; changes?: { from: number; to: number; insert: string }[] } | { type: "draftChanged"; text: string | null } | { type: "setMode"; mode: "live" | "source" } | { type: "setLineNumbers"; visible: boolean } | { type: "setGitChangesGutter"; visible: boolean } | { type: "setOutlineVisible"; visible: boolean } | { type: "setFindOptions"; findOptions: { wholeWord: boolean; caseSensitive: boolean } } | { type: "viewPositionChanged"; topLine: number; topLineOffset?: number } | { type: "openLink"; href: string } | { type: "resolveImageSrc"; requestId: string; url: string } | { type: "resolveWikiLinks"; requestId: string; targets: string[] } | { type: "resolveLocalLinks"; requestId: string; targets: string[] } | { type: "saveDocument" } | { type: "exportDocument"; format: "html" | "pdf" } | { type: "exportSnapshot"; requestId: string; text: string; environment?: Record<string, unknown> } | { type: "exportSnapshotError"; requestId: string; error: string; message?: string } | { type: "saveImageFromClipboard"; requestId: string; imageData: string; fileName: string };
+type WebviewMessage =
+  | { type: 'ready' }
+  | { type: 'applyChanges'; content?: string; baseVersion: number; changes?: { from: number; to: number; insert: string }[] }
+  | { type: 'draftChanged'; text: string | null }
+  | { type: 'setMode'; mode: 'live' | 'source' }
+  | { type: 'setLineNumbers'; visible: boolean }
+  | { type: 'setGitChangesGutter'; visible: boolean }
+  | { type: 'setOutlineVisible'; visible: boolean }
+  | { type: 'setFindOptions'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
+  | { type: 'viewPositionChanged'; topLine: number; topLineOffset?: number }
+  | { type: 'openLink'; href: string }
+  | { type: 'resolveImageSrc'; requestId: string; url: string }
+  | { type: 'resolveWikiLinks'; requestId: string; targets: string[] }
+  | { type: 'resolveLocalLinks'; requestId: string; targets: string[] }
+  | { type: 'saveDocument' }
+  | { type: 'exportDocument'; format: 'html' | 'pdf' }
+  | { type: 'exportSnapshot'; requestId: string; text: string; environment?: Record<string, unknown> }
+  | { type: 'exportSnapshotError'; requestId: string; error: string; message?: string }
+  | { type: 'saveImageFromClipboard'; requestId: string; imageData: string; fileName: string };
 
-type ExtensionMessage = { type: "init"; text: string; version: number; theme: ThemeSettings; mode: "live" | "source"; outlinePosition: "left" | "right"; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number } | { type: "docChanged"; text: string; version: number } | { type: "applied"; version: number } | { type: "focusEditor" } | { type: "revealSelection"; anchor: number; head: number; focus?: boolean } | { type: "themeChanged"; theme: ThemeSettings } | { type: "outlinePositionChanged"; position: "left" | "right" } | { type: "outlineVisibilityChanged"; visible: boolean } | { type: "lineNumbersChanged"; enabled: boolean } | { type: "gitChangesGutterChanged"; enabled: boolean } | { type: "gitDiffLineHighlightsChanged"; enabled: boolean } | { type: "vimModeChanged"; enabled: boolean } | { type: "vimKeybindingsChanged"; keybindings: VimKeybinding[]; leaderKey: string } | { type: "findOptionsChanged"; findOptions: { wholeWord: boolean; caseSensitive: boolean } } | { type: "resolvedImageSrc"; requestId: string; resolvedUrl: string } | { type: "resolvedWikiLinks"; requestId: string; results: Array<{ target: string; exists: boolean }> } | { type: "resolvedLocalLinks"; requestId: string; results: Array<{ target: string; exists: boolean }> } | { type: "savedImagePath"; requestId: string; success: boolean; path?: string; error?: string };
+type VimKeybinding = {
+  before: string;
+  after: string;
+  mode: 'normal' | 'insert' | 'visual';
+  recursive: boolean;
+};
+
+type ExtensionMessage =
+  | { type: 'init'; text: string; version: number; theme: ThemeSettings; mode: 'live' | 'source'; outlinePosition: 'left' | 'right'; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number }
+  | { type: 'docChanged'; text: string; version: number }
+  | { type: 'applied'; version: number }
+  | { type: 'focusEditor' }
+  | { type: 'revealSelection'; anchor: number; head: number; focus?: boolean }
+  | { type: 'themeChanged'; theme: ThemeSettings }
+  | { type: 'outlinePositionChanged'; position: 'left' | 'right' }
+  | { type: 'outlineVisibilityChanged'; visible: boolean }
+  | { type: 'lineNumbersChanged'; enabled: boolean }
+  | { type: 'gitChangesGutterChanged'; enabled: boolean }
+  | { type: 'gitDiffLineHighlightsChanged'; enabled: boolean }
+  | { type: 'vimModeChanged'; enabled: boolean }
+  | { type: 'vimKeybindingsChanged'; keybindings: VimKeybinding[]; leaderKey: string }
+  | { type: 'findOptionsChanged'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
+  | { type: 'resolvedImageSrc'; requestId: string; resolvedUrl: string }
+  | { type: 'resolvedWikiLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
+  | { type: 'resolvedLocalLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
+  | { type: 'savedImagePath'; requestId: string; success: boolean; path?: string; error?: string };
 
 interface ThemeSettings {
-    id: string;
-    name: string;
-    colors: Record<string, string>;
-    syntaxTokens: Record<string, string>;
-    fonts: {
-        liveFont?: string;
-        sourceFont?: string;
-        liveFontWeight?: string;
-        sourceFontWeight?: string;
-        liveFontSize?: number | null;
-        sourceFontSize?: number | null;
-        h1FontSize?: number | null;
-        h2FontSize?: number | null;
-        h3FontSize?: number | null;
-        h4FontSize?: number | null;
-        h5FontSize?: number | null;
-        h6FontSize?: number | null;
-        h1FontWeight?: string;
-        h2FontWeight?: string;
-        h3FontWeight?: string;
-        h4FontWeight?: string;
-        h5FontWeight?: string;
-        h6FontWeight?: string;
-        liveLineHeight?: number;
-        sourceLineHeight?: number;
-    };
+  id: string;
+  name: string;
+  colors: Record<string, string>;
+  syntaxTokens: Record<string, string>;
+  fonts: {
+    liveFont?: string;
+    sourceFont?: string;
+    liveFontWeight?: string;
+    sourceFontWeight?: string;
+    liveFontSize?: number | null;
+    sourceFontSize?: number | null;
+    h1FontSize?: number | null;
+    h2FontSize?: number | null;
+    h3FontSize?: number | null;
+    h4FontSize?: number | null;
+    h5FontSize?: number | null;
+    h6FontSize?: number | null;
+    h1FontWeight?: string;
+    h2FontWeight?: string;
+    h3FontWeight?: string;
+    h4FontWeight?: string;
+    h5FontWeight?: string;
+    h6FontWeight?: string;
+    liveLineHeight?: number;
+    sourceLineHeight?: number;
+  };
 }
 
 interface WikiLinkStatus {
-    exists: boolean;
-    path?: string;
+  exists: boolean;
+  path?: string;
 }
 
 interface HeadingInfo {
-    text: string;
-    level: number;
-    from: number;
-    to: number;
-    lineFrom: number;
-    lineTo: number;
-    id: string;
+  text: string;
+  level: number;
+  from: number;
+  to: number;
+  lineFrom: number;
+  lineTo: number;
+  id: string;
 }
 
 interface GitDiffLine {
-    type: "added" | "removed" | "modified" | "unchanged";
-    oldLineNumber?: number;
-    newLineNumber?: number;
-    content: string;
+  type: 'added' | 'removed' | 'modified' | 'unchanged';
+  oldLineNumber?: number;
+  newLineNumber?: number;
+  content: string;
 }
 
 interface GitBlameInfo {
-    hash: string;
-    author: string;
-    date: string;
-    message: string;
+  hash: string;
+  author: string;
+  date: string;
+  message: string;
 }


### PR DESCRIPTION
## Changes

### Vim mode in live mode
Removed the \`currentMode === 'source'\` guard so vim motions work in both source and live modes.

### VSCodeVim auto-detection
When \`markdownEditorOptimized.vimMode.enabled\` is not explicitly set, vim mode is automatically enabled if the VSCodeVim extension (\`vscodevim.vim\`) is installed, mirroring its \`vim.enable\` setting. Changes to \`vim.enable\` take effect immediately without a reload.

### Custom keybinding sync
All custom keybindings from VSCodeVim settings are read and applied to the CodeMirror vim instance:
- \`vim.normalModeKeyBindings\` / \`vim.normalModeKeyBindingsNonRecursive\`
- \`vim.insertModeKeyBindings\` / \`vim.insertModeKeyBindingsNonRecursive\`
- \`vim.visualModeKeyBindings\` / \`vim.visualModeKeyBindingsNonRecursive\`
- \`vim.leader\`

Recursive bindings use \`Vim.map\`, non-recursive use \`Vim.noremap\`. Changes to any of these settings take effect immediately without restarting the editor.

## Files changed
- \`src/shared/extensionConfig.ts\` — \`VimKeybinding\` type, \`getVimKeybindings()\`, \`getVimLeaderKey()\`
- \`src/extension/panelSession.ts\` — \`vimKeybindings\` + \`vimLeader\` in init message
- \`src/extension.ts\` — watches \`vim.*KeyBindings*\` + \`vim.leader\` config changes
- \`webview/src/editor.ts\` — live mode support, \`applyVimKeybindings()\`, \`setVimKeybindings()\`
- \`webview/src/types.d.ts\` — \`VimKeybinding\` type, \`vimKeybindingsChanged\` message
- \`webview/src/index.ts\` — wires keybindings on init and \`vimKeybindingsChanged\`
- \`package.json\` — updated setting description to document auto-detection