### PR TITLE
feat: optional VS Code theme highlighting for code blocks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "mermaid": "^11.4.1",
         "puppeteer-core": "^24.1.1",
         "sanitize-html": "^2.17.0",
+        "shiki": "^4.2.0",
       },
       "devDependencies": {
         "@types/markdown-it": "^14.1.2",
@@ -128,6 +129,22 @@
 
     "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
+    "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w=="],
+
+    "@shikijs/types": ["@shikijs/types@4.2.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
@@ -194,9 +211,13 @@
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
     "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 
     "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
@@ -206,9 +227,13 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
     "@types/vscode": ["@types/vscode@1.109.0", "", {}, "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
@@ -240,6 +265,12 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
     "chevrotain": ["chevrotain@11.0.3", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.0.3", "@chevrotain/gast": "11.0.3", "@chevrotain/regexp-to-ast": "11.0.3", "@chevrotain/types": "11.0.3", "@chevrotain/utils": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw=="],
 
     "chevrotain-allstar": ["chevrotain-allstar@0.3.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^11.0.0" } }, "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw=="],
@@ -251,6 +282,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -344,6 +377,10 @@
 
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
     "devtools-protocol": ["devtools-protocol@0.0.1566079", "", {}, "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -390,7 +427,13 @@
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
@@ -430,9 +473,21 @@
 
     "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
     "mdurl": ["mdurl@2.0.0", "", {}, "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="],
 
     "mermaid": ["mermaid@11.12.2", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.1", "@mermaid-js/parser": "^0.6.3", "@types/d3": "^7.4.3", "cytoscape": "^3.29.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.13", "dayjs": "^1.11.18", "dompurify": "^3.2.5", "katex": "^0.16.22", "khroma": "^2.1.0", "lodash-es": "^4.17.21", "marked": "^16.2.1", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
@@ -445,6 +500,10 @@
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
@@ -472,6 +531,8 @@
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
     "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
@@ -481,6 +542,12 @@
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "puppeteer-core": ["puppeteer-core@24.37.5", "", { "dependencies": { "@puppeteer/browsers": "2.13.0", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1566079", "typed-query-selector": "^2.12.0", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.19.0" } }, "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -496,6 +563,8 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
@@ -506,9 +575,13 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
     "streamx": ["streamx@2.23.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -526,6 +599,8 @@
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -540,7 +615,21 @@
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
@@ -573,6 +662,8 @@
     "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@chevrotain/cst-dts-gen/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 

--- a/package.json
+++ b/package.json
@@ -203,6 +203,12 @@
           "order": 6,
           "description": "Enable Vim keybindings in Source mode."
         },
+        "markdownEditorOptimized.codeBlocks.useVscodeTheme": {
+          "type": "boolean",
+          "default": false,
+          "order": 7,
+          "description": "Highlight fenced code blocks using your active VS Code color theme (via Shiki/TextMate), including bracket pair colorization. When off, code blocks use the built-in highlighter. Languages without a Shiki grammar always fall back to the built-in highlighter."
+        },
         "markdownEditorOptimized.rememberPosition.lines": {
           "type": "number",
           "default": 100,
@@ -741,7 +747,8 @@
     "markdown-it-emoji": "^3.0.0",
     "mermaid": "^11.4.1",
     "puppeteer-core": "^24.1.1",
-    "sanitize-html": "^2.17.0"
+    "sanitize-html": "^2.17.0",
+    "shiki": "^4.2.0"
   },
   "devDependencies": {
     "@types/markdown-it": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
           "type": "boolean",
           "default": false,
           "order": 7,
-          "description": "Highlight fenced code blocks using your active VS Code color theme (via Shiki/TextMate), including bracket pair colorization. When off, code blocks use the built-in highlighter. Languages without a Shiki grammar always fall back to the built-in highlighter."
+          "description": "Highlight fenced code blocks using your active VS Code color theme."
         },
         "markdownEditorOptimized.rememberPosition.lines": {
           "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,9 @@ import {
   LINE_NUMBERS_SETTING_KEY,
   OUTLINE_VISIBLE_KEY,
   VIM_MODE_SETTING_KEY,
+  CODE_BLOCKS_VSCODE_THEME_SETTING_KEY,
+  getUseVscodeThemeForCodeBlocks,
+  getCodeBlockVscodeTheme,
   syncEditorAssociations,
   type ExportHtmlImageMode,
   getExportHtmlImageMode,
@@ -162,6 +165,12 @@ export function activate(context: vscode.ExtensionContext): void {
       }
 
       void provider.handleConfigurationChanged(event);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveColorTheme(() => {
+      provider.notifyThemeChanged();
     })
   );
 
@@ -541,12 +550,20 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
     if (
       event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`)
     ) {
-      this.broadcast({ type: 'themeChanged', theme: getThemeSettings() });
+      this.broadcast({ type: 'themeChanged', theme: getThemeSettings(), codeTheme: getCodeBlockVscodeTheme() });
+    }
+
+    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${CODE_BLOCKS_VSCODE_THEME_SETTING_KEY}`)) {
+      this.broadcast({
+        type: 'shikiCodeBlocksChanged',
+        enabled: getUseVscodeThemeForCodeBlocks(),
+        codeTheme: getCodeBlockVscodeTheme()
+      });
     }
   }
 
   notifyThemeChanged(): void {
-    this.broadcast({ type: 'themeChanged', theme: getThemeSettings() });
+    this.broadcast({ type: 'themeChanged', theme: getThemeSettings(), codeTheme: getCodeBlockVscodeTheme() });
   }
 
   async toggleActiveEditorMode(): Promise<void> {
@@ -891,7 +908,7 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
       `img-src ${webview.cspSource} https:`,
       `font-src ${webview.cspSource}`,
       `style-src ${webview.cspSource} 'unsafe-inline'`,
-      `script-src ${webview.cspSource} 'nonce-${nonce}'`
+      `script-src ${webview.cspSource} 'nonce-${nonce}' 'wasm-unsafe-eval'`
     ].join('; ');
 
     return `<!DOCTYPE html>

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -12,7 +12,9 @@ import {
   getOutlineVisible,
   getRememberPositionLines,
   getThemeSettings,
-  getVimModeEnabled
+  getVimModeEnabled,
+  getUseVscodeThemeForCodeBlocks,
+  getCodeBlockVscodeTheme
 } from '../shared/extensionConfig';
 import { openLink, resolveLocalLinkTargets, resolveWebviewImageSrc, resolveWikiLinkTargets } from '../shared/documentLinks';
 import { GitDocumentState, hashGitBaselinePayload } from '../git/documentState';
@@ -20,6 +22,7 @@ import { openGitRevisionForLine, openGitWorktreeForLine, resolveGitBlameForReque
 import type { GitBaselinePayload, GitBlameLineResult } from '../git/types';
 import type { ExportStyleEnvironment } from '../export/runtime';
 import type { ThemeSettings } from '../shared/themeDefaults';
+import type { RawVscodeTheme } from '../shared/vscodeTheme';
 import type { OutlinePosition } from '../shared/extensionConfig';
 
 export type EditorMode = 'live' | 'source';
@@ -43,6 +46,8 @@ type InitMessage = {
   outlinePosition: OutlinePosition;
   outlineVisible: boolean;
   theme: ThemeSettings;
+  shikiCodeBlocks: boolean;
+  codeTheme: RawVscodeTheme | null;
   restoreTopLine?: number;
   restoreTopLineOffset?: number;
 };
@@ -465,6 +470,8 @@ export function createPanelSessionController(params: PanelSessionControllerParam
       outlinePosition: getOutlinePosition(),
       outlineVisible: getOutlineVisible(context),
       theme: getThemeSettings(),
+      shikiCodeBlocks: getUseVscodeThemeForCodeBlocks(),
+      codeTheme: getCodeBlockVscodeTheme(),
       restoreTopLine: pendingRestoreTopLine ?? undefined,
       restoreTopLineOffset: pendingRestoreTopLine === null ? undefined : pendingRestoreTopLineOffset
     };

--- a/src/shared/extensionConfig.ts
+++ b/src/shared/extensionConfig.ts
@@ -6,12 +6,14 @@ import {
   type ThemeSettings,
   validateThemePayload
 } from './themeDefaults';
+import { getActiveVscodeRawTheme, type RawVscodeTheme } from './vscodeTheme';
 
 export const EXTENSION_CONFIG_SECTION = 'markdownEditorOptimized';
 export const LINE_NUMBERS_SETTING_KEY = 'lineNumbers.visible';
 export const GIT_CHANGES_GUTTER_SETTING_KEY = 'gitChanges.visible';
 export const GIT_DIFF_LINE_HIGHLIGHTS_SETTING_KEY = 'gitChanges.lineHighlights';
 export const VIM_MODE_SETTING_KEY = 'vimMode.enabled';
+export const CODE_BLOCKS_VSCODE_THEME_SETTING_KEY = 'codeBlocks.useVscodeTheme';
 export const REMEMBER_POSITION_LINES_SETTING_KEY = 'rememberPosition.lines';
 export const LINE_NUMBERS_LEGACY_SETTING_KEY = 'lineNumbers.enabled';
 export const LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY = 'lineNumbers.visibility';
@@ -64,6 +66,16 @@ export function getGitDiffLineHighlightsEnabled(): boolean {
 
 export function getVimModeEnabled(context: vscode.ExtensionContext): boolean {
   return getToggleSettingValue(context, VIM_MODE_SETTING_KEY, VIM_MODE_KEY, [], false);
+}
+
+export function getUseVscodeThemeForCodeBlocks(): boolean {
+  return vscode.workspace
+    .getConfiguration(EXTENSION_CONFIG_SECTION)
+    .get<boolean>(CODE_BLOCKS_VSCODE_THEME_SETTING_KEY, false);
+}
+
+export function getCodeBlockVscodeTheme(): RawVscodeTheme | null {
+  return getUseVscodeThemeForCodeBlocks() ? getActiveVscodeRawTheme() : null;
 }
 
 export function getRememberPositionLines(): number {

--- a/src/shared/vscodeTheme.ts
+++ b/src/shared/vscodeTheme.ts
@@ -1,0 +1,162 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+
+export type RawVscodeTheme = {
+  name: string;
+  type: 'light' | 'dark';
+  colors: Record<string, string>;
+  tokenColors: unknown[];
+};
+
+type RawTheme = {
+  include?: string;
+  colors?: Record<string, string | null | undefined>;
+  tokenColors?: unknown[];
+};
+
+type MergedTheme = {
+  colors: Record<string, string>;
+  tokenColors: unknown[];
+};
+
+function parseJsonc(text: string): unknown {
+  let out = '';
+  let inString = false;
+  let stringQuote = '';
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    const next = text[i + 1];
+
+    if (inLineComment) {
+      if (ch === '\n') {
+        inLineComment = false;
+        out += ch;
+      }
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (inString) {
+      out += ch;
+      if (ch === '\\') {
+        out += next ?? '';
+        i += 1;
+        continue;
+      }
+      if (ch === stringQuote) {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      stringQuote = ch;
+      out += ch;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i += 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+
+  return JSON.parse(out.replace(/,(\s*[}\]])/g, '$1'));
+}
+
+function readRawTheme(themePath: string): RawTheme | undefined {
+  try {
+    const parsed = parseJsonc(fs.readFileSync(themePath, 'utf8'));
+    return parsed && typeof parsed === 'object' ? (parsed as RawTheme) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function loadMergedTheme(themePath: string, seen = new Set<string>()): MergedTheme {
+  const merged: MergedTheme = { colors: {}, tokenColors: [] };
+  const normalizedPath = path.normalize(themePath);
+  if (seen.has(normalizedPath)) {
+    return merged;
+  }
+  seen.add(normalizedPath);
+
+  const raw = readRawTheme(themePath);
+  if (!raw) {
+    return merged;
+  }
+
+  if (typeof raw.include === 'string' && raw.include) {
+    const base = loadMergedTheme(path.join(path.dirname(themePath), raw.include), seen);
+    merged.colors = { ...base.colors };
+    merged.tokenColors = [...base.tokenColors];
+  }
+
+  if (raw.colors && typeof raw.colors === 'object') {
+    for (const [key, value] of Object.entries(raw.colors)) {
+      if (typeof value === 'string') {
+        merged.colors[key] = value;
+      }
+    }
+  }
+  if (Array.isArray(raw.tokenColors)) {
+    merged.tokenColors.push(...raw.tokenColors);
+  }
+
+  return merged;
+}
+
+function findThemeContribution(themeLabelOrId: string): { path: string; uiTheme: string } | undefined {
+  for (const extension of vscode.extensions.all) {
+    const contributedThemes = extension.packageJSON?.contributes?.themes;
+    if (!Array.isArray(contributedThemes)) {
+      continue;
+    }
+    for (const contributed of contributedThemes) {
+      if (contributed?.label === themeLabelOrId || contributed?.id === themeLabelOrId) {
+        const relativePath = typeof contributed.path === 'string' ? contributed.path : '';
+        if (!relativePath) {
+          return undefined;
+        }
+        return {
+          path: path.join(extension.extensionPath, relativePath),
+          uiTheme: typeof contributed.uiTheme === 'string' ? contributed.uiTheme : 'vs-dark'
+        };
+      }
+    }
+  }
+  return undefined;
+}
+
+export function getActiveVscodeRawTheme(): RawVscodeTheme | null {
+  const themeLabel = vscode.workspace.getConfiguration('workbench').get<string>('colorTheme');
+  if (!themeLabel) {
+    return null;
+  }
+  const found = findThemeContribution(themeLabel);
+  if (!found) {
+    return null;
+  }
+  const merged = loadMergedTheme(found.path);
+  if (!merged.tokenColors.length && !Object.keys(merged.colors).length) {
+    return null;
+  }
+  const type = found.uiTheme === 'vs' || found.uiTheme === 'hc-light' ? 'light' : 'dark';
+  return { name: themeLabel, type, colors: merged.colors, tokenColors: merged.tokenColors };
+}

--- a/webview/src/editor.ts
+++ b/webview/src/editor.ts
@@ -5,6 +5,7 @@ import { markdown, markdownKeymap, markdownLanguage } from '@codemirror/lang-mar
 import { indentUnit, syntaxHighlighting, syntaxTree, forceParsing } from '@codemirror/language';
 import { vim } from '@replit/codemirror-vim';
 import { highlightStyle } from './theme';
+import { shikiCodeHighlight } from './helpers/shikiDecorations';
 import { liveModeExtensions } from './liveMode';
 import { headingCollapseSharedExtensions, headingCollapseSourceSpacerExtensions } from './helpers/headingCollapse';
 import { resolveCodeLanguage, insertCodeBlock, sourceCodeBlockField } from './helpers/codeBlocks';
@@ -1120,6 +1121,7 @@ export function createEditor({
       gitGutterCompartment.of(startMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()),
       highlightActiveLineGutter(),
       highlightActiveLine(),
+      shikiCodeHighlight,
       EditorView.lineWrapping,
       scrollPastEnd(),
       EditorView.domEventHandlers({

--- a/webview/src/helpers/shikiDecorations.ts
+++ b/webview/src/helpers/shikiDecorations.ts
@@ -1,0 +1,190 @@
+import { RangeSetBuilder, StateEffect, Prec } from '@codemirror/state';
+import { Decoration, ViewPlugin, EditorView, type DecorationSet, type ViewUpdate } from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+import { getFencedCodeInfo } from './codeBlocks';
+import {
+  resolveShikiLang,
+  getShikiTokens,
+  requestShikiTokens,
+  isShikiThemeReady,
+  isShikiEnabled,
+  subscribeShikiRefresh,
+  getShikiThemeMeta,
+  type ShikiToken
+} from './shikiHighlighter';
+
+const shikiRefreshEffect = StateEffect.define<null>();
+
+const FONT_STYLE_ITALIC = 1;
+const FONT_STYLE_BOLD = 2;
+const FONT_STYLE_UNDERLINE = 4;
+
+function tokenStyle(token: ShikiToken): string {
+  let style = token.color ? `color:${token.color}` : '';
+  const fontStyle = token.fontStyle ?? 0;
+  if (fontStyle & FONT_STYLE_ITALIC) {
+    style += ';font-style:italic';
+  }
+  if (fontStyle & FONT_STYLE_BOLD) {
+    style += ';font-weight:bold';
+  }
+  if (fontStyle & FONT_STYLE_UNDERLINE) {
+    style += ';text-decoration:underline';
+  }
+  return style;
+}
+
+function addBlockDecorations(
+  view: EditorView,
+  node: { name: string; from: number; to: number },
+  builder: RangeSetBuilder<Decoration>,
+  markCache: Map<string, Decoration>
+): void {
+  const { state } = view;
+  const info = node.name === 'FencedCode' ? getFencedCodeInfo(state, node) : null;
+  const lang = resolveShikiLang(info);
+  if (!lang) {
+    return;
+  }
+
+  const startLine = state.doc.lineAt(node.from);
+  const endLine = state.doc.lineAt(Math.max(node.to - 1, node.from));
+  if (endLine.number - startLine.number < 2) {
+    return;
+  }
+
+  const contentFrom = state.doc.line(startLine.number + 1).from;
+  const contentTo = state.doc.line(endLine.number - 1).to;
+  if (contentFrom >= contentTo) {
+    return;
+  }
+
+  const code = state.doc.sliceString(contentFrom, contentTo);
+  const tokens = getShikiTokens(lang, code);
+  if (!tokens) {
+    requestShikiTokens(lang, code);
+    return;
+  }
+
+  const meta = getShikiThemeMeta();
+  const bracketColors = meta.bracketColors;
+  const numBracketColors = bracketColors.length;
+
+  const addMark = (from: number, to: number, style: string): void => {
+    if (from >= to || !style) {
+      return;
+    }
+    let deco = markCache.get(style);
+    if (!deco) {
+      deco = Decoration.mark({ attributes: { style } });
+      markCache.set(style, deco);
+    }
+    builder.add(from, to, deco);
+  };
+
+  let depth = 0;
+
+  for (const line of tokens) {
+    for (const token of line) {
+      const content = token.content;
+      if (!content) {
+        continue;
+      }
+      const tokenFrom = contentFrom + token.offset;
+      if (tokenFrom < contentFrom || tokenFrom + content.length > contentTo) {
+        continue;
+      }
+      const baseStyle = tokenStyle(token);
+      const inStringOrComment = token.isStringComment === true;
+
+      if (numBracketColors === 0 || inStringOrComment) {
+        if (content.trim()) {
+          addMark(tokenFrom, tokenFrom + content.length, baseStyle);
+        }
+        continue;
+      }
+
+      let spanStart = 0;
+      for (let i = 0; i < content.length; i += 1) {
+        const ch = content[i];
+        const isOpen = ch === '(' || ch === '[' || ch === '{';
+        const isClose = ch === ')' || ch === ']' || ch === '}';
+        if (!isOpen && !isClose) {
+          continue;
+        }
+        if (i > spanStart && content.slice(spanStart, i).trim()) {
+          addMark(tokenFrom + spanStart, tokenFrom + i, baseStyle);
+        }
+        let bracketColor: string;
+        if (isOpen) {
+          bracketColor = bracketColors[depth % numBracketColors];
+          depth += 1;
+        } else if (depth === 0) {
+          bracketColor = meta.unexpectedBracket;
+        } else {
+          depth -= 1;
+          bracketColor = bracketColors[depth % numBracketColors];
+        }
+        addMark(tokenFrom + i, tokenFrom + i + 1, `color:${bracketColor}`);
+        spanStart = i + 1;
+      }
+      if (content.length > spanStart && content.slice(spanStart).trim()) {
+        addMark(tokenFrom + spanStart, tokenFrom + content.length, baseStyle);
+      }
+    }
+  }
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+  if (!isShikiEnabled() || !isShikiThemeReady()) {
+    return Decoration.none;
+  }
+  const builder = new RangeSetBuilder<Decoration>();
+  const markCache = new Map<string, Decoration>();
+  try {
+    syntaxTree(view.state).iterate({
+      enter(node) {
+        if (node.name === 'FencedCode' || node.name === 'CodeBlock') {
+          addBlockDecorations(view, node, builder, markCache);
+          return false;
+        }
+        return undefined;
+      }
+    });
+  } catch {
+    return Decoration.none;
+  }
+  return builder.finish();
+}
+
+const shikiPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    private readonly unsubscribe: () => void;
+
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+      this.unsubscribe = subscribeShikiRefresh(() => {
+        view.dispatch({ effects: shikiRefreshEffect.of(null) });
+      });
+    }
+
+    update(update: ViewUpdate): void {
+      const refreshed = update.transactions.some((transaction) =>
+        transaction.effects.some((effect) => effect.is(shikiRefreshEffect))
+      );
+      if (update.docChanged || refreshed) {
+        this.decorations = buildDecorations(update.view);
+      }
+    }
+
+    destroy(): void {
+      this.unsubscribe();
+    }
+  },
+  {
+    decorations: (plugin) => plugin.decorations
+  }
+);
+
+export const shikiCodeHighlight = Prec.high(shikiPlugin);

--- a/webview/src/helpers/shikiHighlighter.ts
+++ b/webview/src/helpers/shikiHighlighter.ts
@@ -273,6 +273,16 @@ async function tokenizeAndCache(key: string, lang: string, code: string): Promis
 
 export function setShikiTheme(theme: RawVscodeTheme | null | undefined): void {
   if (!theme) {
+    if (!rawTheme && !highlighterPromise && tokenCache.size === 0 && pending.size === 0) {
+      return;
+    }
+    rawTheme = null;
+    themeVersion += 1;
+    highlighterPromise = null;
+    loadedLangs.clear();
+    tokenCache.clear();
+    pending.clear();
+    notifyRefresh();
     return;
   }
   rawTheme = theme;

--- a/webview/src/helpers/shikiHighlighter.ts
+++ b/webview/src/helpers/shikiHighlighter.ts
@@ -1,0 +1,289 @@
+import type { HighlighterCore } from 'shiki/core';
+
+export type RawVscodeTheme = {
+  name: string;
+  type: 'light' | 'dark';
+  colors: Record<string, string>;
+  tokenColors: unknown[];
+};
+
+const THEME_NAME = 'meo-code-theme';
+const CACHE_LIMIT = 300;
+
+const LANG_LOADERS: Record<string, () => Promise<{ default: unknown }>> = {
+  javascript: () => import('@shikijs/langs/javascript'),
+  jsx: () => import('@shikijs/langs/jsx'),
+  typescript: () => import('@shikijs/langs/typescript'),
+  tsx: () => import('@shikijs/langs/tsx'),
+  python: () => import('@shikijs/langs/python'),
+  css: () => import('@shikijs/langs/css'),
+  html: () => import('@shikijs/langs/html'),
+  json: () => import('@shikijs/langs/json'),
+  markdown: () => import('@shikijs/langs/markdown'),
+  rust: () => import('@shikijs/langs/rust'),
+  go: () => import('@shikijs/langs/go'),
+  java: () => import('@shikijs/langs/java'),
+  sql: () => import('@shikijs/langs/sql'),
+  csharp: () => import('@shikijs/langs/csharp'),
+  cpp: () => import('@shikijs/langs/cpp'),
+  c: () => import('@shikijs/langs/c'),
+  swift: () => import('@shikijs/langs/swift'),
+  bash: () => import('@shikijs/langs/bash'),
+  powerquery: () => import('@shikijs/langs/powerquery'),
+  yaml: () => import('@shikijs/langs/yaml')
+};
+
+const MEO_TO_SHIKI_LANG: Record<string, string> = {
+  javascript: 'javascript', js: 'javascript',
+  jsx: 'jsx',
+  typescript: 'typescript', ts: 'typescript',
+  tsx: 'tsx',
+  python: 'python', py: 'python',
+  css: 'css',
+  html: 'html', htm: 'html',
+  json: 'json',
+  markdown: 'markdown', md: 'markdown',
+  rust: 'rust', rs: 'rust',
+  go: 'go', golang: 'go',
+  java: 'java',
+  sql: 'sql',
+  csharp: 'csharp', cs: 'csharp', 'c#': 'csharp',
+  cpp: 'cpp', 'c++': 'cpp',
+  c: 'c',
+  swift: 'swift',
+  bash: 'bash', sh: 'bash', shell: 'bash', zsh: 'bash',
+  powerquery: 'powerquery', pq: 'powerquery', m: 'powerquery',
+  yaml: 'yaml', yml: 'yaml'
+};
+
+export function resolveShikiLang(info: string | null | undefined): string | null {
+  if (!info) {
+    return null;
+  }
+  return MEO_TO_SHIKI_LANG[info.toLowerCase().trim()] ?? null;
+}
+
+export type ShikiToken = {
+  offset: number;
+  content: string;
+  color?: string;
+  fontStyle?: number;
+  isStringComment?: boolean;
+};
+
+export type ShikiThemeMeta = {
+  bracketColors: string[];
+  unexpectedBracket: string;
+};
+
+const DEFAULT_BRACKET_COLORS_DARK = ['#FFD700', '#DA70D6', '#179FFF'];
+const DEFAULT_BRACKET_COLORS_LIGHT = ['#0431FA', '#319331', '#7B3814'];
+
+const isTransparent = (value: string): boolean => /^#[0-9a-fA-F]{6}00$/.test(value) || value === '#00000000';
+
+function computeThemeMeta(theme: RawVscodeTheme): ShikiThemeMeta {
+  const colors = theme.colors ?? {};
+  let bracketColors = [1, 2, 3, 4, 5, 6]
+    .map((i) => colors[`editorBracketHighlight.foreground${i}`])
+    .filter((value): value is string => typeof value === 'string' && !isTransparent(value));
+  if (!bracketColors.length) {
+    bracketColors = theme.type === 'light' ? DEFAULT_BRACKET_COLORS_LIGHT : DEFAULT_BRACKET_COLORS_DARK;
+  }
+  return {
+    bracketColors,
+    unexpectedBracket: colors['editorBracketHighlight.unexpectedBracket.foreground'] || '#FF1212'
+  };
+}
+
+let themeMeta: ShikiThemeMeta = {
+  bracketColors: DEFAULT_BRACKET_COLORS_DARK,
+  unexpectedBracket: '#FF1212'
+};
+
+export function getShikiThemeMeta(): ShikiThemeMeta {
+  return themeMeta;
+}
+
+let rawTheme: RawVscodeTheme | null = null;
+let themeVersion = 0;
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+const loadedLangs = new Set<string>();
+const tokenCache = new Map<string, ShikiToken[][]>();
+const pending = new Set<string>();
+const refreshListeners = new Set<() => void>();
+
+function notifyRefresh(): void {
+  for (const listener of refreshListeners) {
+    listener();
+  }
+}
+
+export function subscribeShikiRefresh(listener: () => void): () => void {
+  refreshListeners.add(listener);
+  return () => refreshListeners.delete(listener);
+}
+
+let enabled = false;
+
+export function isShikiEnabled(): boolean {
+  return enabled;
+}
+
+export function setShikiEnabled(value: boolean): void {
+  if (enabled === value) {
+    return;
+  }
+  enabled = value;
+  if (enabled && rawTheme) {
+    void getHighlighter();
+  }
+  notifyRefresh();
+}
+
+export function isShikiThemeReady(): boolean {
+  return rawTheme !== null;
+}
+
+function cacheKey(lang: string, code: string): string {
+  return `${themeVersion} ${lang} ${code}`;
+}
+
+export function getShikiTokens(lang: string, code: string): ShikiToken[][] | null {
+  return tokenCache.get(cacheKey(lang, code)) ?? null;
+}
+
+export function requestShikiTokens(lang: string, code: string): void {
+  if (!rawTheme) {
+    return;
+  }
+  const key = cacheKey(lang, code);
+  if (tokenCache.has(key) || pending.has(key)) {
+    return;
+  }
+  pending.add(key);
+  void tokenizeAndCache(key, lang, code);
+}
+
+function toShikiTheme(theme: RawVscodeTheme) {
+  return {
+    name: THEME_NAME,
+    type: theme.type,
+    colors: theme.colors ?? {},
+    settings: (theme.tokenColors as any[]) ?? [],
+    fg: theme.colors?.['editor.foreground'],
+    bg: theme.colors?.['editor.background']
+  };
+}
+
+async function createHighlighter(theme: RawVscodeTheme): Promise<HighlighterCore> {
+  const [{ createHighlighterCore }, { createOnigurumaEngine }] = await Promise.all([
+    import('shiki/core'),
+    import('shiki/engine/oniguruma')
+  ]);
+  loadedLangs.clear();
+  return createHighlighterCore({
+    themes: [toShikiTheme(theme) as any],
+    langs: [],
+    engine: await createOnigurumaEngine(import('shiki/wasm'))
+  });
+}
+
+function tokenIsStringComment(token: { explanation?: { scopes?: { scopeName?: string }[] }[] }): boolean {
+  if (!token.explanation) {
+    return false;
+  }
+  for (const part of token.explanation) {
+    for (const scope of part.scopes ?? []) {
+      const name = scope.scopeName ?? '';
+      if (name.startsWith('string') || name.startsWith('comment')) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function getHighlighter(): Promise<HighlighterCore> | null {
+  if (!rawTheme) {
+    return null;
+  }
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter(rawTheme);
+  }
+  return highlighterPromise;
+}
+
+async function ensureLang(highlighter: HighlighterCore, lang: string): Promise<boolean> {
+  if (loadedLangs.has(lang)) {
+    return true;
+  }
+  const loader = LANG_LOADERS[lang];
+  if (!loader) {
+    return false;
+  }
+  const grammar = (await loader()).default;
+  await highlighter.loadLanguage(grammar as any);
+  loadedLangs.add(lang);
+  return true;
+}
+
+async function tokenizeAndCache(key: string, lang: string, code: string): Promise<void> {
+  try {
+    const highlighterRef = getHighlighter();
+    if (!highlighterRef) {
+      pending.delete(key);
+      return;
+    }
+    const highlighter = await highlighterRef;
+    const ok = await ensureLang(highlighter, lang);
+    if (!ok) {
+      pending.delete(key);
+      return;
+    }
+    if (!tokenCache.has(key) && cacheKey(lang, code) === key) {
+      const { tokens } = highlighter.codeToTokens(code, {
+        lang,
+        theme: THEME_NAME,
+        includeExplanation: 'scopeName'
+      });
+      const mapped: ShikiToken[][] = tokens.map((line) =>
+        line.map((token) => ({
+          offset: token.offset,
+          content: token.content,
+          color: token.color,
+          fontStyle: token.fontStyle,
+          isStringComment: tokenIsStringComment(token as any)
+        }))
+      );
+      if (tokenCache.size >= CACHE_LIMIT) {
+        const oldest = tokenCache.keys().next().value;
+        if (oldest !== undefined) {
+          tokenCache.delete(oldest);
+        }
+      }
+      tokenCache.set(key, mapped);
+    }
+    pending.delete(key);
+    notifyRefresh();
+  } catch (error) {
+    pending.delete(key);
+    console.error('[MEO webview] Shiki tokenization failed', error);
+  }
+}
+
+export function setShikiTheme(theme: RawVscodeTheme | null | undefined): void {
+  if (!theme) {
+    return;
+  }
+  rawTheme = theme;
+  themeMeta = computeThemeMeta(theme);
+  themeVersion += 1;
+  highlighterPromise = null;
+  loadedLangs.clear();
+  tokenCache.clear();
+  pending.clear();
+  if (enabled) {
+    void getHighlighter();
+  }
+  notifyRefresh();
+}

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -6,6 +6,7 @@ import { normalizeWikiTarget, replaceWikiLinkStatuses, initializeWikiLinkHandlin
 import { initializeLocalLinkHandling, requestLocalLinkStatuses, scheduleLocalLinkStatusRefresh, setLocalLinkRefreshContext, cancelPendingLocalLinkStatusRefresh, handleResolvedLocalLinks } from './helpers/localLinks';
 import { setGitDiffLineHighlightsEnabled } from './helpers/gitDiffLineHighlights';
 import { applyThemeSettings } from './helpers/theme';
+import { setShikiTheme, setShikiEnabled } from './helpers/shikiHighlighter';
 import { createFailureNoticeManager, getErrorMessage, isTransientMermaidRuntimeError, shouldAutoFallbackToSourceForLiveError, logWebviewRenderError, type EditorNotice, type FailureNoticeManager } from './helpers/errors';
 import { isPrimaryModifier, isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from './helpers/shortcuts';
 import { createFindPanel, createFindPanelController, type FindPanelController } from './helpers/findPanel';
@@ -1261,6 +1262,8 @@ window.addEventListener('message', (event) => {
     acknowledgeReadyHandshake();
     withMessageErrorBoundary('init handler', () => {
       applyThemeSettings(message.theme);
+      setShikiEnabled(message.shikiCodeBlocks === true);
+      setShikiTheme(message.codeTheme);
       initialMountRecoveryAttempted = false;
       failureNotice.clearFailureNotice();
       gitClient?.resetForInit({ hideTooltip: false });
@@ -1295,9 +1298,19 @@ window.addEventListener('message', (event) => {
   if (message.type === 'themeChanged') {
     withMessageErrorBoundary('themeChanged handler', () => {
       applyThemeSettings(message.theme);
+      setShikiTheme(message.codeTheme);
     });
     return;
   }
+
+  if (message.type === 'shikiCodeBlocksChanged') {
+    withMessageErrorBoundary('shikiCodeBlocksChanged handler', () => {
+      setShikiTheme(message.codeTheme);
+      setShikiEnabled(message.enabled === true);
+    });
+    return;
+  }
+
 
   if (message.type === 'revealSelection') {
     applyRevealSelectionFromHost(message);


### PR DESCRIPTION
I love this extension's idea.  My issue is that my brain is used to seeing code in my regular theme's styling and so the context switch in editing/viewing code in meo was tricky.

I hope you don't mind; I added an option to use Shiki to render the code and provide its tokens to CodeMirror.  This gets us consistently themed code.  I made the default false so as to not change anybody's setup.

If I can make any improvements, let me know!