### PR TITLE
fix: more precisely detect the "primary" modifier (`Cmd` on macOS, `Ctrl` elsewhere)

### DIFF
--- a/webview/src/helpers/linkNavigation.ts
+++ b/webview/src/helpers/linkNavigation.ts
@@ -3,6 +3,7 @@ import type { EditorView } from '@codemirror/view';
 import { resolvedSyntaxTree } from './markdownSyntax';
 import { isWikiLinkNode, parseWikiLinkData } from './wikiLinks';
 import { findRawSourceUrlMatches, linkSchemeRe, normalizeSourceHref } from './rawUrls';
+import { hasPrimaryModifier, hasSecondaryModifier } from './modifiers';
 
 const linkReferenceCache = new WeakMap<object, Map<string, string>>();
 type LinkLookupOptions = {
@@ -188,7 +189,7 @@ export function isPrimaryModifierPointerClick(event: MouseEvent | PointerEvent):
   if (event.altKey || event.shiftKey) {
     return false;
   }
-  return event.metaKey || event.ctrlKey;
+  return hasPrimaryModifier(event) && !hasSecondaryModifier(event);
 }
 
 export function getDecoratedLinkHrefFromTarget(target: EventTarget | null): string {

--- a/webview/src/helpers/modifiers.ts
+++ b/webview/src/helpers/modifiers.ts
@@ -1,0 +1,9 @@
+export const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
+export const hasPrimaryModifier = (event: KeyboardEvent | MouseEvent): boolean => {
+  return isMac ? event.metaKey : event.ctrlKey;
+};
+
+export const hasSecondaryModifier = (event: KeyboardEvent | MouseEvent): boolean => {
+  return isMac ? event.ctrlKey : event.metaKey;
+};

--- a/webview/src/helpers/shortcuts.ts
+++ b/webview/src/helpers/shortcuts.ts
@@ -1,8 +1,4 @@
-const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-
-export const isPrimaryModifier = (event: KeyboardEvent): boolean => {
-  return event.metaKey !== event.ctrlKey && (event.metaKey || event.ctrlKey);
-};
+import { isMac, hasPrimaryModifier, hasSecondaryModifier } from './modifiers';
 
 export const isShortcutKey = (event: KeyboardEvent, key: string, code: string): boolean => {
   return event.key.toLowerCase() === key || event.code === code;
@@ -31,8 +27,9 @@ export const handleEditorShortcut = (
   if (!editor || event.isComposing) {
     return false;
   }
-  
-  const hasPrimaryModifier = isPrimaryModifier(event);
+
+  const primaryModifierHeld = hasPrimaryModifier(event);
+  const secondaryModifierHeld = hasSecondaryModifier(event);
   const editorFocused = editor.hasFocus();
   const vimEditorFocused = vimModeEnabled && editorFocused;
   const vimWinsCtrlConflicts = vimEditorFocused && !isMac;
@@ -61,14 +58,14 @@ export const handleEditorShortcut = (
     return false;
   }
 
-  if (hasPrimaryModifier && isShortcutKey(event, 's', 'KeyS') && !event.altKey) {
+  if (primaryModifierHeld && !secondaryModifierHeld && isShortcutKey(event, 's', 'KeyS') && !event.altKey) {
     event.preventDefault();
     event.stopPropagation();
     context.requestSave();
     return true;
   }
 
-  if (hasPrimaryModifier && isShortcutKey(event, 'f', 'KeyF') && !event.altKey && !event.shiftKey) {
+  if (primaryModifierHeld && !secondaryModifierHeld && isShortcutKey(event, 'f', 'KeyF') && !event.altKey && !event.shiftKey) {
     if (vimWinsCtrlConflicts) {
       return false;
     }
@@ -79,7 +76,7 @@ export const handleEditorShortcut = (
   }
 
   if (
-    hasPrimaryModifier &&
+    primaryModifierHeld && !secondaryModifierHeld &&
     (
       (isMac && isShortcutKey(event, 'f', 'KeyF') && event.altKey) ||
       (!isMac && isShortcutKey(event, 'h', 'KeyH') && !event.altKey)
@@ -98,7 +95,7 @@ export const handleEditorShortcut = (
     return false;
   }
 
-  if (!hasPrimaryModifier) {
+  if (!primaryModifierHeld || secondaryModifierHeld) {
     return false;
   }
 

--- a/webview/src/helpers/tables.ts
+++ b/webview/src/helpers/tables.ts
@@ -7,6 +7,7 @@ import { emojiData } from './emoji';
 import { parseKbdTagAt } from './kbd';
 import { createLatexMathElement, parseLatexMathAt } from './math';
 import { isPrimaryModifierPointerClick } from './linkNavigation';
+import { hasPrimaryModifier, hasSecondaryModifier } from './modifiers';
 import { wikiLinkScheme } from './wikiLinks';
 import { normalizeSourceHref } from './rawUrls';
 import type { EditorDiagnostic } from './diagnostics';
@@ -234,11 +235,6 @@ function isSelectionMenuTarget(target) {
 
 function targetElementFrom(target) {
   return target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
-}
-
-function isPrimaryModifier(event) {
-  if (event.altKey) return false;
-  return event.metaKey || event.ctrlKey;
 }
 
 function isModifierLinkActivationEvent(event) {
@@ -1725,7 +1721,7 @@ class HtmlTableWidget extends WidgetType {
   }
 
   handleHistoryShortcut(event, table) {
-    if (!isPrimaryModifier(event) || (!isUndoShortcut(event) && !isRedoShortcut(event))) {
+    if (!hasPrimaryModifier(event) || hasSecondaryModifier(event) || (!isUndoShortcut(event) && !isRedoShortcut(event))) {
       return false;
     }
     event.preventDefault();

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -8,7 +8,7 @@ import { setGitDiffLineHighlightsEnabled } from './helpers/gitDiffLineHighlights
 import { applyThemeSettings } from './helpers/theme';
 import { setShikiTheme, setShikiEnabled } from './helpers/shikiHighlighter';
 import { createFailureNoticeManager, getErrorMessage, isTransientMermaidRuntimeError, shouldAutoFallbackToSourceForLiveError, logWebviewRenderError, type EditorNotice, type FailureNoticeManager } from './helpers/errors';
-import { isPrimaryModifier, isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from './helpers/shortcuts';
+import { isShortcutKey, normalizeEol, handleEditorShortcut, type ShortcutHandlerContext } from './helpers/shortcuts';
 import { createFindPanel, createFindPanelController, type FindPanelController } from './helpers/findPanel';
 import { createSelectionMenu, createSelectionMenuController, type SelectionMenuController } from './helpers/selectionMenu';
 import { createExportHandler, type ExportHandlerContext } from './helpers/export';


### PR DESCRIPTION
# Background

Because MEO renders a CodeMirror in a sandboxed iframe, keystrokes typed therein fire in the webview's own DOM and never reach VS Code's dispatcher, therefore obviating the use of the usual `contributes.keybindings` path. (Contrast this with non-'editing' shortcuts, for example MEO's `toggleMode` command which is bound by default to `Alt + Shift M`.) MEO therefore implements its own `keydown` listener in order to support the following keyboard shortcuts:

- `Cmd/Ctrl + A` (select all)
- `Cmd/Ctrl + F` (find)
- `Cmd/Ctrl + S` (save)
- `Cmd/Ctrl + Y` (redo)
- `Cmd/Ctrl + Z` (undo)
- `Cmd/Ctrl + LeftClick` (following/opening a link instead of merely editing it)

wherein the "primary" modifier is always `Cmd`/`Ctrl` on macOS and other operating systems, respectively.

Unfortunately, the helper that is supposed to detect `Cmd` on macOS and `Ctrl` on Windows/Linux/etc. has been assessing state of `Cmd/Win/Meta` and `Ctrl` _interchangeably_, regardless of platform, thus unwittingly **intercepting any corresponding keystrokes that use the "secondary" modifier** and, thanks to `preventDefault()`, breaking unrelated OS or VS Code keyboard shortcuts.

Examples of broken macOS Cocoa defaults (R.I.P. KDE 3...):

- `Ctrl + A` (go to beginning of line)
- `Ctrl + F` (go forward one character)
- `Ctrl + Y` (yank, a rarely-used macOS default)
- `Ctrl + LeftClick` (open context menu)

Examples from Windows/Linux:

- `Win + ...`/`Meta + ...` (window management, etc.)

And, of course, a user may have attempted to reconfigure and use any of the affected keybindings `SecondaryModifier + A/F/S/Y/Z/LeftClick` for any purpose, either in VS Code or at the OS level.

# Code changes

- Consolidate modifier checks into `modifiers.ts` and split them into _atomic_, _platform-aware_ `hasPrimaryModifier` and `hasSecondaryModifier` predicates that can be, and are, used alongside `event.altKey` and `event.shiftKey`.
  - The original `isPrimaryModifier` implementations — whose function name was, I assume, intended to be a (metonymic) shorthand for `hasPrimaryModifierSansSecondary` — had behavior that was insufficiently platform-aware and mutually divergent:
    - `tables.ts:isPrimaryModifier` also effectively gated on `!event.altKey`, which seemed misleading and which my code no longer performs; see my note below about redo/undo in table cells.
    - `shortcuts.ts:isPrimaryModifier` did _not_ depend on `event.altKey`. For what it's worth, this particular implementation was (locally) aliased as `hasPrimaryModifier()`, which seemed misleading and is no longer necessary.
  - `linkNavigation.ts:isPrimaryModifierPointerClick` — whose name I've kept despite my above complaints about its former cousin, `isPrimaryModifier` — had behavior that was overly broad, triggering on both `Primary + LeftClick` _and_ `Secondary + LeftClick` and thus pre-empting macOS's builtin `Ctrl + LeftClick` (for example).

# User-facing changes

* macOS
  * `Ctrl + A/F/S/Y/Z/LeftClick` no longer trigger Select All / Find / Save / Redo / Undo / Open Link, respectively.
  * `Ctrl + A/F/Y` now do their "usual" Emacs-y things, or whatever they've been reconfigured to do.
  * `Ctrl + LeftClick` now performs its usual secondary click (open context menu)
* Windows, Linux, etc.
  * `Win/Meta + A/F/S/Y/Z/LeftClick` no longer trigger Select All / Find / Save / Redo / Undo, respectively.
  * `Win/Meta + A/F/S/Y/Z` now do whatever they would usually do.
  * `Win/Meta + LeftClick` now performs its usual secondary click _(perhaps irrelevant, since multi-button mice are omnipresent for Windows/Linux)_
- Inside a table cell, `Cmd/Ctrl + Alt + Y/Z` now perform redo/undo just as `Cmd/Ctrl + Y/Z` already did.
  - **If we dislike this change,** the cleanest remedy might be to add a `!event.altKey` gate in `tables.ts:handleHistoryShortcut` or thereabouts.

# Future work?

Ideally, a user would be able to customize each of the various MEO editing shortcuts, even though said shortcuts aren't dispatched by VS Code and _presumably_ (?) can't even be made configurable using the standard `keybindings.json` and Keyboard Shortcuts user interface. Windows or Linux, for example — or at least a VS Code instance running on such an operating system — might be configured to support the same text navigation shortcuts that are supported on macOS/Emacs, with `Win/Meta` becoming the desired "primary" modifier for the purposes of MEO, just like `Cmd` on macOS.