### PR TITLE
feat(Live): default to proportional fonts à la VS Code's Markdown Preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Write to bun install cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck:webview
+
+  unit:
+    needs: setup
+    runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Read from bun install cache?
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Unit tests
+        run: bun run test:unit
+
+  browser:
+    needs: setup
+    runs-on: ubuntu-latest
+    env:
+      # For _this_ job, we do need `puppeteer` to install Chrome for Testing using its `postinstall` hook.
+      PUPPETEER_SKIP_DOWNLOAD: 0
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Read from bun install cache?
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Cache the puppeteer browser
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Allow puppeteer's Chrome sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Browser tests
+        run: bun run test:browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,45 @@ jobs:
 
       - name: Browser tests
         run: bun run test:browser
+
+  package:
+    needs: [unit, browser]
+    # Only produce `.vsix` artifacts on 'branch' and manual/'workflow_dispatch' builds
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      PUPPETEER_SKIP_DOWNLOAD: 1
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Read from bun install cache?
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build the webview and extension bundles
+        run: bun run build
+
+      # `vsce` may skip deps since we're already bundling everything into `dist/`, and `**/node_modules/` are excluded anyway.
+      # Also note that aside from `--no-dependencies`, `vsce` is only constrained by `/.vscodeignore` and not by `.gitignore`, etc.
+      - name: List the package contents
+        run: bunx @vscode/vsce@3 ls --tree --no-dependencies
+      - name: Package the extension
+        run: bunx @vscode/vsce@3 package --no-dependencies
+
+      # A `.vsix` is itself a zip archive,
+      # so **`archive: false`** uploads it as-is rather than nesting it inside a (`name`able) outer archive.
+      - name: Upload the `.vsix` package
+        uses: actions/upload-artifact@v7
+        with:
+          path: "*.vsix"
+          archive: false
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ webview/dist
 bun.lockb
 *.vsix
 releases/
-tests/
 assets/
 .claude/
 AGENTS.md

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.github/**
 .vscode/**
 .vscode-test/**
 out/**
@@ -13,7 +14,7 @@ src/**
 **/.vscode-test.*
 scripts/**
 releases/**
-tests/**
+**/tests/**
 docs/**
 assets/**
 .claude/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,22 +1,34 @@
-.github/**
-.vscode/**
-.vscode-test/**
-out/**
-node_modules/**
-webview/node_modules/**
-webview/src/**
-webview/.gitignore
-webview/tsconfig.*
-src/**
-.gitignore
+# These are `minimatch` globs, not `.gitignore` patterns
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension#using-vscodeignore
+
+# Directory trees from repo root
+.github/
+.vscode/
+.vscode-test/
+assets/
+browserTests/
+docs/
+out/
+releases/
+scripts/
+src/
+webview/src/
+
+# File paths from repo root
+bun.lock
+features.md
+
+# Directories at any level
+**/.claude/
+**/.git/
+**/node_modules/
+**/tests/
+
+# Files at any level
+**/*.code-workspace
 **/*.map
 **/*.ts
+**/.gitignore
 **/.vscode-test.*
-scripts/**
-releases/**
-**/tests/**
-docs/**
-assets/**
-.claude/
-AGENTS.md
-features.md
+**/AGENTS.md
+**/tsconfig.*

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,30 @@
+# Testing
+
+`bun run test` invokes all test suites.
+
+## Unit tests
+
+`bun run test:unit` runs `src/**/*.test.ts` and `webview/**/*.test.ts`.
+It exercises the CodeMirror `EditorState`s and loads `lezer` GitHub-Flavored Markdown syntax trees,
+but does not load a DOM.
+
+## Browser tests
+
+`bun run test:browser` loads `browserTests/**/*.test.ts`.
+
+Each test uses Puppeteer's build of Chrome for Testing, headless,
+to load a page containing our webview bundle and a VS Code [webview API](https://code.visualstudio.com/api/extension-guides/webview) spy,
+and then uses [Puppeteer](https://pptr.dev/) to manipulate the CodeMirror and observe what's rendered.
+
+### Limitations
+
+- These tests don't cover `./src/extension/`.
+  The test harness composes postMessages itself rather than delegating to `./src/extension/panelSession.ts`.
+- The harness doesn't fake any of the `--vscode-*` CSS variables that VS Code would inject into a real webview,
+  so **all `var(--vscode-*)` values effectively resolve to `unset`.**
+- The harness currently doesn't load a Mermaid runtime.
+
+## VS Code extension tests
+
+**TODO:** Use [`@vscode/test-electron`](https://github.com/microsoft/vscode-test)
+to exercise `./src/extension/` in an actual running instance of VS Code.

--- a/browserTests/harness.html
+++ b/browserTests/harness.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="./katex/katex.min.css" rel="stylesheet" />
+    <link href="./index.css" rel="stylesheet" />
+
+    <title>MEO browser test harness</title>
+
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+      }
+
+      #app {
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+    </style>
+
+    <script>
+      /* Fake the VS Code webview API. */
+      window.__postedMessages = [];
+      window.acquireVsCodeApi = () => ({
+        postMessage: (message) => { window.__postedMessages.push(message); },
+        getState: () => undefined,
+        setState: () => {},
+      });
+    </script>
+  </head>
+
+  <body>
+    <div id="app" class="editor-root"></div>
+    <script type="module" src="./index.js"></script>
+  </body>
+
+</html>

--- a/browserTests/harness.test.ts
+++ b/browserTests/harness.test.ts
@@ -1,0 +1,28 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { startBrowserHarness, type BrowserHarness } from './harness';
+
+let harness: BrowserHarness;
+
+beforeAll(async () => {
+  harness = await startBrowserHarness();
+});
+
+afterAll(async () => {
+  await harness?.close();
+});
+
+describe('browser test harness', () => {
+  it('boots an editor in Live mode', async () => {
+    const page = await harness.openLiveEditor('# Harness\n\nBody text.\n');
+
+    const content = await page.evaluate(() => document.querySelector('.cm-content')?.textContent ?? '');
+    expect(content).toContain('Harness');
+
+    const postedTypes = await page.evaluate(() =>
+      (window as any).__postedMessages.map((message: any) => message.type)
+    );
+    expect(postedTypes.length).toBeGreaterThan(0);
+
+    await page.close();
+  });
+});

--- a/browserTests/harness.ts
+++ b/browserTests/harness.ts
@@ -1,0 +1,87 @@
+import { join } from 'node:path';
+import puppeteer, { type Page } from 'puppeteer';
+
+const distDir = join(import.meta.dir, '../webview/dist');
+const harnessPath = join(import.meta.dir, 'harness.html');
+
+export interface BrowserHarness {
+  /**
+   * @param doc        Initial document text
+   * @param initExtras Test-specific properties for the initial ExtensionMessage (`type: 'init'`)
+   */
+  openLiveEditor(doc: string, initExtras?: Record<string, unknown>): Promise<Page>;
+
+  close(): Promise<void>;
+}
+
+export async function startBrowserHarness(): Promise<BrowserHarness> {
+  const bundle = Bun.file(join(distDir, 'index.js'));
+
+  if (!(await bundle.exists())) {
+    throw new Error('Can\'t find webview; try `bun run build:webview`.');
+  }
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const pathname = new URL(request.url).pathname;
+
+      if (pathname === '/' || pathname === '/harness.html') {
+        return new Response(Bun.file(harnessPath));
+      }
+
+      const asset = Bun.file(join(distDir, pathname));
+      if (await asset.exists()) {
+        return new Response(asset);
+      }
+
+      return new Response('Not Found', { status: 404 });
+    }
+  });
+
+  const browser = await puppeteer.launch({ headless: true });
+
+  return {
+    async openLiveEditor(doc, initExtras = {}): Promise<Page> {
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1200, height: 900 });
+
+      await page.goto(`http://127.0.0.1:${server.port}/harness.html`, {
+        waitUntil: 'networkidle0',
+      });
+
+      await page.evaluate(
+        (doc, initExtras) => {
+          // Send initial ExtensionMessage.
+          window.postMessage(
+            {
+              type: 'init',
+              text: doc,
+              mode: 'live',
+              version: 1,
+              ...initExtras
+            },
+            '*',
+          );
+        },
+        doc,
+        initExtras,
+      );
+
+      await page.waitForSelector('.cm-editor.meo-mode-live .cm-line');
+
+      return page;
+    },
+
+    async close() {
+      // With bun, puppeteer's graceful Browser.close() can stall (https://github.com/oven-sh/bun/issues/31792),
+      // so fall back to killing the browser process wholesale.
+      await Promise.race([
+        browser.close(),
+        new Promise((resolve) => setTimeout(resolve, 5_000))
+      ]);
+      browser.process()?.kill('SIGKILL');
+      server.stop(true);
+    }
+  };
+}

--- a/browserTests/liveFontFallback.test.ts
+++ b/browserTests/liveFontFallback.test.ts
@@ -1,0 +1,69 @@
+import {
+  describe, describe as context, it,
+  beforeAll, afterAll, beforeEach, afterEach,
+  expect,
+} from 'bun:test';
+import type { Page } from 'puppeteer';
+import { startBrowserHarness, type BrowserHarness } from './harness';
+
+const doc = '# Heading\n\nBody text for font inspection.\n';
+
+function contentFontFamily(page: Page): Promise<string> {
+  return page.evaluate(() => getComputedStyle(document.querySelector('.cm-content')!).fontFamily);
+}
+
+let harness: BrowserHarness;
+beforeAll(async () => {
+  harness = await startBrowserHarness();
+});
+afterAll(async () => {
+  await harness?.close();
+});
+
+describe('MEO', () => {
+
+  context('given a valid `markdown.preview.fontFamily` config', () => {
+    let page: Page;
+    beforeEach(async () => {
+      page = await harness.openLiveEditor(doc, { vscodePreviewFontFamily: 'Georgia' });
+    });
+    afterEach(async () => {
+      await page.close();
+    });
+
+    it('uses that font family for Live mode', async () => {
+      expect(await contentFontFamily(page)).toContain('Georgia');
+    });
+
+    it('does not use that font family for Source mode', async () => {
+      await page.evaluate(() => {
+        window.postMessage({ type: 'toggleMode' }, '*');
+      });
+      await page.waitForSelector('.cm-editor.meo-mode-source');
+      expect(await contentFontFamily(page)).not.toContain('Georgia');
+    });
+  });
+
+  context('absent a `markdown.preview.fontFamily` config', () => {
+    let page: Page;
+    beforeEach(async () => {
+      page = await harness.openLiveEditor(doc);
+    });
+    afterEach(async () => {
+      await page.close();
+    });
+
+    it('uses the preview default for Live mode', async () => {
+      expect(await contentFontFamily(page)).toContain('Segoe WPC');
+    });
+
+    it('does not use the preview default for Source mode', async () => {
+      await page.evaluate(() => {
+        window.postMessage({ type: 'toggleMode' }, '*');
+      });
+      await page.waitForSelector('.cm-editor.meo-mode-source');
+      expect(await contentFontFamily(page)).not.toContain('Segoe WPC');
+    });
+  });
+
+});

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@lezer/highlight": "^1.2.3",
         "@replit/codemirror-vim": "^6.3.0",
         "@types/vscode": "^1.109.0",
+        "cspell-lib": "^10.0.1",
         "highlight.js": "^11.11.1",
         "katex": "^0.16.28",
         "lucide": "^0.564.0",
@@ -90,6 +91,146 @@
     "@codemirror/state": ["@codemirror/state@6.5.2", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA=="],
 
     "@codemirror/view": ["@codemirror/view@6.36.4", "", { "dependencies": { "@codemirror/state": "^6.5.0", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ZQ0V5ovw/miKEXTvjgzRyjnrk9TwriUB1k4R5p7uNnHR9Hus+D1SXHGdJshijEzPFjU25xea/7nhIeSqYFKdbA=="],
+
+    "@cspell/cspell-bundled-dicts": ["@cspell/cspell-bundled-dicts@10.0.1", "", { "dependencies": { "@cspell/dict-ada": "^4.1.1", "@cspell/dict-al": "^1.1.1", "@cspell/dict-aws": "^4.0.17", "@cspell/dict-bash": "^4.2.2", "@cspell/dict-companies": "^3.2.11", "@cspell/dict-cpp": "^7.0.2", "@cspell/dict-cryptocurrencies": "^5.0.5", "@cspell/dict-csharp": "^4.0.8", "@cspell/dict-css": "^4.1.1", "@cspell/dict-dart": "^2.3.2", "@cspell/dict-data-science": "^2.0.13", "@cspell/dict-django": "^4.1.6", "@cspell/dict-docker": "^1.1.17", "@cspell/dict-dotnet": "^5.0.13", "@cspell/dict-elixir": "^4.0.8", "@cspell/dict-en-common-misspellings": "^2.1.12", "@cspell/dict-en-gb-mit": "^3.1.22", "@cspell/dict-en_us": "^4.4.33", "@cspell/dict-filetypes": "^3.0.18", "@cspell/dict-flutter": "^1.1.1", "@cspell/dict-fonts": "^4.0.6", "@cspell/dict-fsharp": "^1.1.1", "@cspell/dict-fullstack": "^3.2.9", "@cspell/dict-gaming-terms": "^1.1.2", "@cspell/dict-git": "^3.1.0", "@cspell/dict-golang": "^6.0.26", "@cspell/dict-google": "^1.0.9", "@cspell/dict-haskell": "^4.0.6", "@cspell/dict-html": "^4.0.15", "@cspell/dict-html-symbol-entities": "^4.0.5", "@cspell/dict-java": "^5.0.12", "@cspell/dict-julia": "^1.1.1", "@cspell/dict-k8s": "^1.0.12", "@cspell/dict-kotlin": "^1.1.1", "@cspell/dict-latex": "^5.1.0", "@cspell/dict-lorem-ipsum": "^4.0.5", "@cspell/dict-lua": "^4.0.8", "@cspell/dict-makefile": "^1.0.5", "@cspell/dict-markdown": "^2.0.16", "@cspell/dict-monkeyc": "^1.0.12", "@cspell/dict-node": "^5.0.9", "@cspell/dict-npm": "^5.2.38", "@cspell/dict-php": "^4.1.1", "@cspell/dict-powershell": "^5.0.15", "@cspell/dict-public-licenses": "^2.0.16", "@cspell/dict-python": "^4.2.26", "@cspell/dict-r": "^2.1.1", "@cspell/dict-ruby": "^5.1.1", "@cspell/dict-rust": "^4.1.2", "@cspell/dict-scala": "^5.0.9", "@cspell/dict-shell": "^1.1.2", "@cspell/dict-software-terms": "^5.2.2", "@cspell/dict-sql": "^2.2.1", "@cspell/dict-svelte": "^1.0.7", "@cspell/dict-swift": "^2.0.6", "@cspell/dict-terraform": "^1.1.3", "@cspell/dict-typescript": "^3.2.3", "@cspell/dict-vue": "^3.0.5", "@cspell/dict-zig": "^1.0.0" } }, "sha512-WvkSDNX4Uyyj/ZgbPO6L38iFNMfK1EqsH1FteRiI2qLz6QZMXRFrIt12OqiWIplzZDDaVpBH9FCJOPJll0fjCQ=="],
+
+    "@cspell/cspell-performance-monitor": ["@cspell/cspell-performance-monitor@10.0.1", "", {}, "sha512-9tVcHXwRnbazUv4WSG0h3MqV4+LgmLNgSALAQUflPPW0EMxTf7C4Dmv9cgxJyCEQrdnVKCr58nPPaahhz9LJUg=="],
+
+    "@cspell/cspell-pipe": ["@cspell/cspell-pipe@10.0.1", "", {}, "sha512-HPeXMD9AZ3V/qPkvQaPcak+C7cJ2z7JTHN8smd6J8L2aThLRky2cHc2OyeaHPSHB7WA47b4z2n5u5nawZhv5VQ=="],
+
+    "@cspell/cspell-resolver": ["@cspell/cspell-resolver@10.0.1", "", { "dependencies": { "global-directory": "^5.0.0" } }, "sha512-PIzkZHD1fGUQx1XteK2d1iQ0Mzq/maYcoB4jkvAiiR6WqP3MWYNKFdI9z+R5pOq5KgMfW+5Ig1q0oSR6h8irlA=="],
+
+    "@cspell/cspell-service-bus": ["@cspell/cspell-service-bus@10.0.1", "", {}, "sha512-y6NcIGP2IdXaBL4PVH8vxsr7K27wzz3Ech87UtUtrDSXAiVEOvXgAIknEOUVp59rTlUE8Rn4IRURC6f/hgMyfw=="],
+
+    "@cspell/cspell-types": ["@cspell/cspell-types@10.0.1", "", {}, "sha512-kLgLShnWADDVreKC63pBrWkcvxgZzFIfO34Jhx/SWfuOIA3cD8AXT+HjyuLfoGJ7mUb58hv2kUziKzEy4INb1w=="],
+
+    "@cspell/dict-ada": ["@cspell/dict-ada@4.1.1", "", {}, "sha512-E+0YW9RhZod/9Qy2gxfNZiHJjCYFlCdI69br1eviQQWB8yOTJX0JHXLs79kOYhSW0kINPVUdvddEBe6Lu6CjGQ=="],
+
+    "@cspell/dict-al": ["@cspell/dict-al@1.1.1", "", {}, "sha512-sD8GCaZetgQL4+MaJLXqbzWcRjfKVp8x+px3HuCaaiATAAtvjwUQ5/Iubiqwfd1boIh2Y1/3EgM3TLQ7Q8e0wQ=="],
+
+    "@cspell/dict-aws": ["@cspell/dict-aws@4.0.17", "", {}, "sha512-ORcblTWcdlGjIbWrgKF+8CNEBQiLVKdUOFoTn0KPNkAYnFcdPP0muT4892h7H4Xafh3j72wqB4/loQ6Nti9E/w=="],
+
+    "@cspell/dict-bash": ["@cspell/dict-bash@4.2.3", "", { "dependencies": { "@cspell/dict-shell": "1.2.0" } }, "sha512-ljUZoKHbDqw5Sx0qpL2qTUlmkmr+vhZH/sCNrNaBZKTbdgiswErSnIF1jRbGmEitJNxHRHWsuZyVgnTGfVO1Yw=="],
+
+    "@cspell/dict-companies": ["@cspell/dict-companies@3.2.12", "", {}, "sha512-mjiz/N3zWOCsz5VfwMUydSl7uW0OU9H2PnbCNc3RV44Vj6Q59CSp6EYGSGZQxrXU1gpsuZUrwr6QCjNjFOOg5A=="],
+
+    "@cspell/dict-cpp": ["@cspell/dict-cpp@7.0.2", "", {}, "sha512-dfbeERiVNeqmo/npivdR6rDiBCqZi3QtjH2Z0HFcXwpdj6i97dX1xaKyK2GUsO/p4u1TOv63Dmj5Vm48haDpuA=="],
+
+    "@cspell/dict-cryptocurrencies": ["@cspell/dict-cryptocurrencies@5.0.5", "", {}, "sha512-R68hYYF/rtlE6T/dsObStzN5QZw+0aQBinAXuWCVqwdS7YZo0X33vGMfChkHaiCo3Z2+bkegqHlqxZF4TD3rUA=="],
+
+    "@cspell/dict-csharp": ["@cspell/dict-csharp@4.0.8", "", {}, "sha512-qmk45pKFHSxckl5mSlbHxmDitSsGMlk/XzFgt7emeTJWLNSTUK//MbYAkBNRtfzB4uD7pAFiKgpKgtJrTMRnrQ=="],
+
+    "@cspell/dict-css": ["@cspell/dict-css@4.1.2", "", {}, "sha512-+ylGoKdwZ2sVOCOnU2Eq5wDZx+RaVX3HoKyNHGGsFvhSw6IidQ6tH/mAPKBDofViHJoWCPNlklE0lTr6MDG3QA=="],
+
+    "@cspell/dict-dart": ["@cspell/dict-dart@2.3.2", "", {}, "sha512-sUiLW56t9gfZcu8iR/5EUg+KYyRD83Cjl3yjDEA2ApVuJvK1HhX+vn4e4k4YfjpUQMag8XO2AaRhARE09+/rqw=="],
+
+    "@cspell/dict-data-science": ["@cspell/dict-data-science@2.0.16", "", {}, "sha512-M72mxv5asuAnORurz4iXRJ+Tw9XBq6eu7D2Ne7biP0Z1RciKGNxXWu9JycA/KlVvK1hAlKj/fANlXhuEWpXKFg=="],
+
+    "@cspell/dict-django": ["@cspell/dict-django@4.1.6", "", {}, "sha512-SdbSFDGy9ulETqNz15oWv2+kpWLlk8DJYd573xhIkeRdcXOjskRuxjSZPKfW7O3NxN/KEf3gm3IevVOiNuFS+w=="],
+
+    "@cspell/dict-docker": ["@cspell/dict-docker@1.1.17", "", {}, "sha512-OcnVTIpHIYYKhztNTyK8ShAnXTfnqs43hVH6p0py0wlcwRIXe5uj4f12n7zPf2CeBI7JAlPjEsV0Rlf4hbz/xQ=="],
+
+    "@cspell/dict-dotnet": ["@cspell/dict-dotnet@5.0.13", "", {}, "sha512-xPp7jMnFpOri7tzmqmm/dXMolXz1t2bhNqxYkOyMqXhvs08oc7BFs+EsbDY0X7hqiISgeFZGNqn0dOCr+ncPYw=="],
+
+    "@cspell/dict-elixir": ["@cspell/dict-elixir@4.0.8", "", {}, "sha512-CyfphrbMyl4Ms55Vzuj+mNmd693HjBFr9hvU+B2YbFEZprE5AG+EXLYTMRWrXbpds4AuZcvN3deM2XVB80BN/Q=="],
+
+    "@cspell/dict-en-common-misspellings": ["@cspell/dict-en-common-misspellings@2.1.13", "", {}, "sha512-00rpydUxKNWY2xxrSx+h46aNWLvbkJdd57SsnEFt24fbs1fROhXZ6XSQu+gQz/zNuiCvFi4Ro3ej9DLbEdWQmQ=="],
+
+    "@cspell/dict-en-gb-mit": ["@cspell/dict-en-gb-mit@3.1.25", "", {}, "sha512-zGODptk24CMrXi49ieG2SUm94CKxEsVF0dYNF+1ZYH0MSsQDZ/PKDlrrbvtBqSupKdPSj0Z9sjOmMNfHHW9ZSg=="],
+
+    "@cspell/dict-en_us": ["@cspell/dict-en_us@4.4.36", "", {}, "sha512-2yOhI/+7d1DbfvMljGW4jw8pLqDEsVmnvUXBOCFXtLU2BWgQkrqOJDCNseYjEiEbTp0OtdrWEWWPFSP1TNugQw=="],
+
+    "@cspell/dict-filetypes": ["@cspell/dict-filetypes@3.0.18", "", {}, "sha512-yU7RKD/x1IWmDLzWeiItMwgV+6bUcU/af23uS0+uGiFUbsY1qWV/D4rxlAAO6Z7no3J2z8aZOkYIOvUrJq0Rcw=="],
+
+    "@cspell/dict-flutter": ["@cspell/dict-flutter@1.1.1", "", {}, "sha512-UlOzRcH2tNbFhZmHJN48Za/2/MEdRHl2BMkCWZBYs+30b91mWvBfzaN4IJQU7dUZtowKayVIF9FzvLZtZokc5A=="],
+
+    "@cspell/dict-fonts": ["@cspell/dict-fonts@4.0.6", "", {}, "sha512-aR/0csY01dNb0A1tw/UmN9rKgHruUxsYsvXu6YlSBJFu60s26SKr/k1o4LavpHTQ+lznlYMqAvuxGkE4Flliqw=="],
+
+    "@cspell/dict-fsharp": ["@cspell/dict-fsharp@1.1.1", "", {}, "sha512-imhs0u87wEA4/cYjgzS0tAyaJpwG7vwtC8UyMFbwpmtw+/bgss+osNfyqhYRyS/ehVCWL17Ewx2UPkexjKyaBA=="],
+
+    "@cspell/dict-fullstack": ["@cspell/dict-fullstack@3.2.9", "", {}, "sha512-diZX+usW5aZ4/b2T0QM/H/Wl9aNMbdODa1Jq0ReBr/jazmNeWjd+PyqeVgzd1joEaHY+SAnjrf/i9CwKd2ZtWQ=="],
+
+    "@cspell/dict-gaming-terms": ["@cspell/dict-gaming-terms@1.1.2", "", {}, "sha512-9XnOvaoTBscq0xuD6KTEIkk9hhdfBkkvJAIsvw3JMcnp1214OCGW8+kako5RqQ2vTZR3Tnf3pc57o7VgkM0q1Q=="],
+
+    "@cspell/dict-git": ["@cspell/dict-git@3.1.0", "", {}, "sha512-KEt9zGkxqGy2q1nwH4CbyqTSv5nadpn8BAlDnzlRcnL0Xb3LX9xTgSGShKvzb0bw35lHoYyLWN2ZKAqbC4pgGQ=="],
+
+    "@cspell/dict-golang": ["@cspell/dict-golang@6.0.26", "", {}, "sha512-YKA7Xm5KeOd14v5SQ4ll6afe9VSy3a2DWM7L9uBq4u3lXToRBQ1W5PRa+/Q9udd+DTURyVVnQ+7b9cnOlNxaRg=="],
+
+    "@cspell/dict-google": ["@cspell/dict-google@1.0.9", "", {}, "sha512-biL65POqialY0i4g6crj7pR6JnBkbsPovB2WDYkj3H4TuC/QXv7Pu5pdPxeUJA6TSCHI7T5twsO4VSVyRxD9CA=="],
+
+    "@cspell/dict-haskell": ["@cspell/dict-haskell@4.0.6", "", {}, "sha512-ib8SA5qgftExpYNjWhpYIgvDsZ/0wvKKxSP+kuSkkak520iPvTJumEpIE+qPcmJQo4NzdKMN8nEfaeci4OcFAQ=="],
+
+    "@cspell/dict-html": ["@cspell/dict-html@4.0.15", "", {}, "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw=="],
+
+    "@cspell/dict-html-symbol-entities": ["@cspell/dict-html-symbol-entities@4.0.5", "", {}, "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA=="],
+
+    "@cspell/dict-java": ["@cspell/dict-java@5.0.12", "", {}, "sha512-qPSNhTcl7LGJ5Qp6VN71H8zqvRQK04S08T67knMq9hTA8U7G1sTKzLmBaDOFhq17vNX/+rT+rbRYp+B5Nwza1A=="],
+
+    "@cspell/dict-julia": ["@cspell/dict-julia@1.1.1", "", {}, "sha512-WylJR9TQ2cgwd5BWEOfdO3zvDB+L7kYFm0I9u0s9jKHWQ6yKmfKeMjU9oXxTBxIufhCXm92SKwwVNAC7gjv+yA=="],
+
+    "@cspell/dict-k8s": ["@cspell/dict-k8s@1.0.13", "", {}, "sha512-ELGkS13k7K/NEfVimBSrxVTfqXvOF/Kvxj4I62YxRm8bvHbfoXgrGaOx28lPiNRz+dmu+yYtvuXbnURKtYbC6g=="],
+
+    "@cspell/dict-kotlin": ["@cspell/dict-kotlin@1.1.1", "", {}, "sha512-J3NzzfgmxRvEeOe3qUXnSJQCd38i/dpF9/t3quuWh6gXM+krsAXP75dY1CzDmS8mrJAlBdVBeAW5eAZTD8g86Q=="],
+
+    "@cspell/dict-latex": ["@cspell/dict-latex@5.1.0", "", {}, "sha512-qxT4guhysyBt0gzoliXYEBYinkAdEtR2M7goRaUH0a7ltCsoqqAeEV8aXYRIdZGcV77gYSobvu3jJL038tlPAw=="],
+
+    "@cspell/dict-lorem-ipsum": ["@cspell/dict-lorem-ipsum@4.0.5", "", {}, "sha512-9a4TJYRcPWPBKkQAJ/whCu4uCAEgv/O2xAaZEI0n4y1/l18Yyx8pBKoIX5QuVXjjmKEkK7hi5SxyIsH7pFEK9Q=="],
+
+    "@cspell/dict-lua": ["@cspell/dict-lua@4.0.8", "", {}, "sha512-N4PkgNDMu9JVsRu7JBS/3E/dvfItRgk9w5ga2dKq+JupP2Y3lojNaAVFhXISh4Y0a6qXDn2clA6nvnavQ/jjLA=="],
+
+    "@cspell/dict-makefile": ["@cspell/dict-makefile@1.0.5", "", {}, "sha512-4vrVt7bGiK8Rx98tfRbYo42Xo2IstJkAF4tLLDMNQLkQ86msDlYSKG1ZCk8Abg+EdNcFAjNhXIiNO+w4KflGAQ=="],
+
+    "@cspell/dict-markdown": ["@cspell/dict-markdown@2.0.17", "", { "peerDependencies": { "@cspell/dict-css": "^4.1.2", "@cspell/dict-html": "^4.0.15", "@cspell/dict-html-symbol-entities": "^4.0.5", "@cspell/dict-typescript": "^3.2.3" } }, "sha512-H8bAxih6U8NOnSPL7R8My+tqjaB4tmnJTjERuz4zYqmf+cH+5xshX3UVgKlwWFcyjsYfv/zEDuRdMctQv1q6HQ=="],
+
+    "@cspell/dict-monkeyc": ["@cspell/dict-monkeyc@1.0.12", "", {}, "sha512-MN7Vs11TdP5mbdNFQP5x2Ac8zOBm97ARg6zM5Sb53YQt/eMvXOMvrep7+/+8NJXs0jkp70bBzjqU4APcqBFNAw=="],
+
+    "@cspell/dict-node": ["@cspell/dict-node@5.0.9", "", {}, "sha512-hO+ga+uYZ/WA4OtiMEyKt5rDUlUyu3nXMf8KVEeqq2msYvAPdldKBGH7lGONg6R/rPhv53Rb+0Y1SLdoK1+7wQ=="],
+
+    "@cspell/dict-npm": ["@cspell/dict-npm@5.2.43", "", {}, "sha512-H2gYwtu59dNO9662Uq0usfuhyNd7lZJE1C61a/UXcpRyWWSrTo2Bz+vwGYp1bXZ1LmjXadqvwJ8ArFlGdiadNQ=="],
+
+    "@cspell/dict-php": ["@cspell/dict-php@4.1.1", "", {}, "sha512-EXelI+4AftmdIGtA8HL8kr4WlUE11OqCSVlnIgZekmTkEGSZdYnkFdiJ5IANSALtlQ1mghKjz+OFqVs6yowgWA=="],
+
+    "@cspell/dict-powershell": ["@cspell/dict-powershell@5.0.15", "", {}, "sha512-l4S5PAcvCFcVDMJShrYD0X6Huv9dcsQPlsVsBGbH38wvuN7gS7+GxZFAjTNxDmTY1wrNi1cCatSg6Pu2BW4rgg=="],
+
+    "@cspell/dict-public-licenses": ["@cspell/dict-public-licenses@2.0.16", "", {}, "sha512-EQRrPvEOmwhwWezV+W7LjXbIBjiy6y/shrET6Qcpnk3XANTzfvWflf9PnJ5kId/oKWvihFy0za0AV1JHd03pSQ=="],
+
+    "@cspell/dict-python": ["@cspell/dict-python@4.2.29", "", { "dependencies": { "@cspell/dict-data-science": "^2.0.16" } }, "sha512-OnEt1a35iuQzc2Ize1qU/43ZyF10urRKAm+mlTz++vnAgDLBHpKfWakpSK50nyL5/1WvyQ8BaMjb52MBLEpTeA=="],
+
+    "@cspell/dict-r": ["@cspell/dict-r@2.1.1", "", {}, "sha512-71Ka+yKfG4ZHEMEmDxc6+blFkeTTvgKbKAbwiwQAuKl3zpqs1Y0vUtwW2N4b3LgmSPhV3ODVY0y4m5ofqDuKMw=="],
+
+    "@cspell/dict-ruby": ["@cspell/dict-ruby@5.1.1", "", {}, "sha512-LHrp84oEV6q1ZxPPyj4z+FdKyq1XAKYPtmGptrd+uwHbrF/Ns5+fy6gtSi7pS+uc0zk3JdO9w/tPK+8N1/7WUA=="],
+
+    "@cspell/dict-rust": ["@cspell/dict-rust@4.1.2", "", {}, "sha512-O1FHrumYcO+HZti3dHfBPUdnDFkI+nbYK3pxYmiM1sr+G0ebOd6qchmswS0Wsc6ZdEVNiPYJY/gZQR6jfW3uOg=="],
+
+    "@cspell/dict-scala": ["@cspell/dict-scala@5.0.9", "", {}, "sha512-AjVcVAELgllybr1zk93CJ5wSUNu/Zb5kIubymR/GAYkMyBdYFCZ3Zbwn4Zz8GJlFFAbazABGOu0JPVbeY59vGg=="],
+
+    "@cspell/dict-shell": ["@cspell/dict-shell@1.2.0", "", {}, "sha512-PVctvT22lJ49niMiakO8xieY7ELCAzjSqhejWR7bAMb5AZ9F4WDEs+XdGMnoVHWeXq7K5rcepLPmEJb+37zzIw=="],
+
+    "@cspell/dict-software-terms": ["@cspell/dict-software-terms@5.2.4", "", {}, "sha512-z6y/TGH3QNf5wB4pVvN/P3GfFEW/Whf6QAekNsIn06VKl95dnamfpkPWqV8rEtCixQFaKalb5+y9hRQXH3XQ1g=="],
+
+    "@cspell/dict-sql": ["@cspell/dict-sql@2.2.1", "", {}, "sha512-qDHF8MpAYCf4pWU8NKbnVGzkoxMNrFqBHyG/dgrlic5EQiKANCLELYtGlX5auIMDLmTf1inA0eNtv74tyRJ/vg=="],
+
+    "@cspell/dict-svelte": ["@cspell/dict-svelte@1.0.7", "", {}, "sha512-hGZsGqP0WdzKkdpeVLBivRuSNzOTvN036EBmpOwxH+FTY2DuUH7ecW+cSaMwOgmq5JFSdTcbTNFlNC8HN8lhaQ=="],
+
+    "@cspell/dict-swift": ["@cspell/dict-swift@2.0.6", "", {}, "sha512-PnpNbrIbex2aqU1kMgwEKvCzgbkHtj3dlFLPMqW1vSniop7YxaDTtvTUO4zA++ugYAEL+UK8vYrBwDPTjjvSnA=="],
+
+    "@cspell/dict-terraform": ["@cspell/dict-terraform@1.1.4", "", {}, "sha512-Ere42ilvMFvQA4GlcN0OKlruMPR6EsvaB+iTHzj2xc+NJGRK64V7yApUcWrOrSgTiM/vhWXPIsK3OMfiAiNdmA=="],
+
+    "@cspell/dict-typescript": ["@cspell/dict-typescript@3.2.3", "", {}, "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg=="],
+
+    "@cspell/dict-vue": ["@cspell/dict-vue@3.0.5", "", {}, "sha512-Mqutb8jbM+kIcywuPQCCaK5qQHTdaByoEO2J9LKFy3sqAdiBogNkrplqUK0HyyRFgCfbJUgjz3N85iCMcWH0JA=="],
+
+    "@cspell/dict-zig": ["@cspell/dict-zig@1.0.0", "", {}, "sha512-XibBIxBlVosU06+M6uHWkFeT0/pW5WajDRYdXG2CgHnq85b0TI/Ks0FuBJykmsgi2CAD3Qtx8UHFEtl/DSFnAQ=="],
+
+    "@cspell/dynamic-import": ["@cspell/dynamic-import@10.0.1", "", { "dependencies": { "@cspell/url": "10.0.1", "import-meta-resolve": "^4.2.0" } }, "sha512-mP1gdq00aIcH8HxNMqnH11X6BKxLcneDtFgl/ecjIKnaGKwi44m8AndP5Kr4ODaYdl8UUw9O3dJh7KaQXnLHZQ=="],
+
+    "@cspell/filetypes": ["@cspell/filetypes@10.0.1", "", {}, "sha512-Z5S35giU5IW49fBBq6BksUbE8PC4IYPfaKuwl5Nl9jkf/OkAKiBmCowKX45NzRUQInwK/GSqqIUifrNeI6LdLw=="],
+
+    "@cspell/rpc": ["@cspell/rpc@10.0.1", "", {}, "sha512-axSRKv3zEAmBm66iD/FV/MPmE4/Yf7c3PZiwTW894Yd3iEhtn3KPKeTrqQ2/tDrhB1Z2qTsap/Hue0MK4o5WXg=="],
+
+    "@cspell/strong-weak-map": ["@cspell/strong-weak-map@10.0.1", "", {}, "sha512-lenN1DVyPi8nJLSMSJJ670ddTjyiruLueuSZO1qLcxBqUhgxDt/mALu9N/1m6WdOVcg6m/5cLiZVg2KOo2UzRw=="],
+
+    "@cspell/url": ["@cspell/url@10.0.1", "", {}, "sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -245,6 +386,8 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "array-timsort": ["array-timsort@1.0.3", "", {}, "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="],
+
     "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
@@ -287,11 +430,27 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "comment-json": ["comment-json@5.0.0", "", { "dependencies": { "array-timsort": "^1.0.3", "esprima": "^4.0.1" } }, "sha512-uiqLcOiVDJtBP8WGkZHEP+FZIhTzP1dxvn59EfoYUi9gqupjrBWVQkO2atDrbnKPwLeotFYDsuNb26uBMqB+hw=="],
+
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
+    "cspell-config-lib": ["cspell-config-lib@10.0.1", "", { "dependencies": { "@cspell/cspell-types": "10.0.1", "comment-json": "^5.0.0", "smol-toml": "^1.6.1", "yaml": "^2.9.0" } }, "sha512-hMpo/0j6k7pbiqrLDOLJKD2IGP9XwhjKf2miiM6p84Xeo4nyuFZaxxDCQ68R851HSYFrrdltgpoipMbj1h2Tnw=="],
+
+    "cspell-dictionary": ["cspell-dictionary@10.0.1", "", { "dependencies": { "@cspell/cspell-performance-monitor": "10.0.1", "@cspell/cspell-pipe": "10.0.1", "@cspell/cspell-types": "10.0.1", "cspell-trie-lib": "10.0.1", "fast-equals": "^6.0.0" } }, "sha512-3cZ659vgsZWkzGQJR/sNqGDVt/OnvTSieLKI76V++4t1bHJfochb9ZrrwsuMsb1VPGiyqClUP1/O6WrefF/FVg=="],
+
+    "cspell-glob": ["cspell-glob@10.0.1", "", { "dependencies": { "@cspell/url": "10.0.1", "picomatch": "^4.0.4" } }, "sha512-7bII9J3aSSpZDwhx7w+zfQXbMxHZQ3be0ilUp5bHrsjz6o07v/NqOHMGcwKdPn1sw2dxDz9sv057xE5pqXnSdw=="],
+
+    "cspell-grammar": ["cspell-grammar@10.0.1", "", { "dependencies": { "@cspell/cspell-pipe": "10.0.1", "@cspell/cspell-types": "10.0.1" }, "bin": { "cspell-grammar": "bin.mjs" } }, "sha512-xC9AFYmaI9wsO//a7S5tdDGKGJVD5UEEsTg+Up2fi7lPfXIryisYmV6tePNL1SEg0idYss4ja8LUZ3Mib09BjQ=="],
+
+    "cspell-io": ["cspell-io@10.0.1", "", { "dependencies": { "@cspell/cspell-service-bus": "10.0.1", "@cspell/url": "10.0.1" } }, "sha512-8C2ka07faxflnaqEBO3pektS21XViE/SEHT7F5ZD1ou7FyMR5u3xawTBJSczClfsxLt/WYeztBYrpmGAjmjksw=="],
+
+    "cspell-lib": ["cspell-lib@10.0.1", "", { "dependencies": { "@cspell/cspell-bundled-dicts": "10.0.1", "@cspell/cspell-performance-monitor": "10.0.1", "@cspell/cspell-pipe": "10.0.1", "@cspell/cspell-resolver": "10.0.1", "@cspell/cspell-types": "10.0.1", "@cspell/dynamic-import": "10.0.1", "@cspell/filetypes": "10.0.1", "@cspell/rpc": "10.0.1", "@cspell/strong-weak-map": "10.0.1", "@cspell/url": "10.0.1", "cspell-config-lib": "10.0.1", "cspell-dictionary": "10.0.1", "cspell-glob": "10.0.1", "cspell-grammar": "10.0.1", "cspell-io": "10.0.1", "cspell-trie-lib": "10.0.1", "env-paths": "^4.0.0", "gensequence": "^8.0.8", "import-fresh": "^4.0.0", "resolve-from": "^5.0.0", "vscode-languageserver-textdocument": "^1.0.12", "vscode-uri": "^3.1.0", "xdg-basedir": "^5.1.0" } }, "sha512-RpsIPiLzc4/YMW8BMRKpyJ81x439qjYWcqgdKeXnMkbKM88J9PexzutfFf/4v97v96KzfNitEzMpbI0uj8OeUg=="],
+
+    "cspell-trie-lib": ["cspell-trie-lib@10.0.1", "", { "peerDependencies": { "@cspell/cspell-types": "10.0.1" } }, "sha512-BFvhalSkRQFjKrZ//FKK7fRGrZFpifnxB5AwCkzsIsBZqicsfafcQ1xP21qpb0QqyV/IomjNgviG+tRJs+0rMw=="],
 
     "cytoscape": ["cytoscape@3.33.1", "", {}, "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ=="],
 
@@ -399,6 +558,8 @@
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "env-paths": ["env-paths@4.0.0", "", { "dependencies": { "is-safe-filename": "^0.1.0" } }, "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw=="],
+
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
@@ -415,15 +576,21 @@
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
+    "fast-equals": ["fast-equals@6.0.2", "", {}, "sha512-sAjhj9ZhOxYCGiNMnZLaucOqf5ZeFnHNoKoAZiD9thhJ0N8RP85qJK759/97C/3L7NzzmGVB5uiX9AUpySZmUQ=="],
+
     "fast-fifo": ["fast-fifo@1.3.2", "", {}, "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
+
+    "gensequence": ["gensequence@8.0.8", "", {}, "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
@@ -443,6 +610,12 @@
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "import-fresh": ["import-fresh@4.0.0", "", {}, "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
@@ -450,6 +623,8 @@
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
+
+    "is-safe-filename": ["is-safe-filename@0.1.1", "", {}, "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="],
 
     "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
 
@@ -521,6 +696,8 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
@@ -551,6 +728,8 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
     "robust-predicates": ["robust-predicates@3.0.2", "", {}, "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
@@ -566,6 +745,8 @@
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "smol-toml": ["smol-toml@1.7.0", "", {}, "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ=="],
 
     "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
 
@@ -641,7 +822,7 @@
 
     "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
 
-    "vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
@@ -653,7 +834,11 @@
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -680,6 +865,8 @@
     "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "langium/vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,14 +35,20 @@
         "shiki": "^4.2.0",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/markdown-it": "^14.1.2",
         "@types/sanitize-html": "^2.16.0",
+        "puppeteer": "^24.1.1",
         "typescript": "^5.9.3",
       },
     },
   },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
 
@@ -266,7 +272,7 @@
 
     "@mermaid-js/parser": ["@mermaid-js/parser@0.6.3", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA=="],
 
-    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.0", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA=="],
+    "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
     "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
@@ -287,6 +293,8 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
 
@@ -408,6 +416,10 @@
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -435,6 +447,8 @@
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
@@ -540,7 +554,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "devtools-protocol": ["devtools-protocol@0.0.1566079", "", {}, "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ=="],
+    "devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -559,6 +573,8 @@
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@4.0.0", "", { "dependencies": { "is-safe-filename": "^0.1.0" } }, "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -620,11 +636,19 @@
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
     "is-safe-filename": ["is-safe-filename@0.1.1", "", {}, "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
 
@@ -633,6 +657,8 @@
     "langium": ["langium@3.3.1", "", { "dependencies": { "chevrotain": "~11.0.3", "chevrotain-allstar": "~0.3.0", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.0.8" } }, "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w=="],
 
     "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
 
@@ -686,6 +712,10 @@
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
     "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
@@ -718,7 +748,9 @@
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "puppeteer-core": ["puppeteer-core@24.37.5", "", { "dependencies": { "@puppeteer/browsers": "2.13.0", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1566079", "typed-query-selector": "^2.12.0", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.19.0" } }, "sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ=="],
+    "puppeteer": ["puppeteer@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "cosmiconfig": "^9.0.0", "devtools-protocol": "0.0.1608973", "puppeteer-core": "24.43.1", "typed-query-selector": "^2.12.2" }, "bin": { "puppeteer": "lib/cjs/puppeteer/node/cli.js" } }, "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw=="],
+
+    "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -786,7 +818,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typed-query-selector": ["typed-query-selector@2.12.0", "", {}, "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="],
+    "typed-query-selector": ["typed-query-selector@2.12.2", "", {}, "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -832,7 +864,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
@@ -858,6 +890,10 @@
 
     "chevrotain/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
 
+    "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
+
+    "cosmiconfig/import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
 
     "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
@@ -867,6 +903,8 @@
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "langium/vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
+
+    "cosmiconfig/import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -123,8 +123,8 @@ Each key in `syntaxTokens` maps to a syntax category. Color values must use `#he
 
 `fonts` controls typography in live/source editors and heading/line-height behavior.
 
-- `liveFont`: Font family for rendered markdown text.
-- `sourceFont`: Font family for source/code text (also used for inline code and code blocks in Live mode).
+- `liveFont`: Font family for rendered markdown text (empty defaults to the same proportional fonts used in VS Code's Markdown Preview).
+- `sourceFont`: Font family for source/code text (also used for inline code and code blocks in Live mode; empty defaults to VS Code's monospace editor font).
 - `liveFontWeight`: Font weight for live mode text. Free-form CSS font-weight values (for example `normal`, `bold`, `500`, `600`).
 - `sourceFontWeight`: Font weight for source mode text (and monospaced token rendering in both export and Live mode code areas).
 - `liveFontSize`: Live mode font size (`null` = use VS Code editor font size).
@@ -137,7 +137,8 @@ Each key in `syntaxTokens` maps to a syntax category. Color values must use `#he
 
 - Empty syntax token color (`""`) falls back to that token's palette-derived default.
 - Missing `backgroundColor` in older theme files falls back to `var(--vscode-editor-background)`.
-- Empty `fonts.liveFont` or `fonts.sourceFont` falls back to VS Code editor font family.
+- Empty `fonts.liveFont` falls back to your VS Code `markdown.preview.fontFamily`, or, failing that, VS Code's [defaults](https://github.com/microsoft/vscode/blob/1.96.4/extensions/markdown-language-features/package.json#L343-L348).
+- Empty `fonts.sourceFont` falls back to VS Code's editor font family (the monospace font from `editor.fontFamily`).
 - `fonts.liveFontSize: null` and `fonts.sourceFontSize: null` fall back to VS Code editor font size.
 - Empty `fonts.liveFontWeight` or `fonts.sourceFontWeight` falls back to VS Code editor font weight.
 - `fonts.h1FontSize` to `fonts.h6FontSize` default to `1.6`, `1.5`, `1.3`, `1.2`, `1.1`, and `1` respectively (and `null` falls back to those defaults).

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.26",
   "publisher": "vadimmelnicuk",
   "private": true,
+  "packageManager": "bun@1.3.14",
   "icon": "logo.png",
   "engines": {
     "vscode": "^1.97.0"
@@ -747,6 +748,9 @@
   "scripts": {
     "install:all": "bun install && (cd webview && bun install)",
     "typecheck:webview": "tsc -p webview/tsconfig.json --noEmit",
+    "test": "bun run test:unit && bun run test:browser",
+    "test:unit": "bun test src webview",
+    "test:browser": "bun run build:webview && bun test --timeout 60000 browserTests",
     "build": "bun run build:webview && bun run build:extension",
     "build:webview": "rm -rf webview/dist && mkdir -p webview/dist webview/dist/katex && bun build webview/src/index.ts --target=browser --format=esm --splitting --minify --outdir=webview/dist && cp webview/src/styles.css webview/dist/index.css && cp node_modules/mermaid/dist/mermaid.min.js webview/dist/mermaid.min.js && cp node_modules/katex/dist/katex.min.css webview/dist/katex/katex.min.css && cp -R node_modules/katex/dist/fonts webview/dist/katex/fonts",
     "build:extension": "bun run build:extension:main && bun run build:extension:export-runtime && bun run build:extension:puppeteer-runtime",
@@ -789,8 +793,10 @@
     "shiki": "^4.2.0"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/markdown-it": "^14.1.2",
     "@types/sanitize-html": "^2.16.0",
+    "puppeteer": "^24.1.1",
     "typescript": "^5.9.3"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,7 @@ import {
   getGitChangesGutterEnabled,
   getGitDiffLineHighlightsEnabled,
   getLineNumbersEnabled,
+  getVSCodePreviewFontFamily,
   getOutlinePosition,
   getOutlineVisible,
   getContentMaxWidthEnabled,
@@ -583,9 +584,10 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
     }
 
     if (
-      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`)
+      event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.theme`) ||
+      event.affectsConfiguration('markdown.preview.fontFamily')
     ) {
-      this.broadcast({ type: 'themeChanged', theme: getThemeSettings(), codeTheme: getCodeBlockVscodeTheme() });
+      this.notifyThemeChanged();
     }
 
     if (
@@ -610,7 +612,12 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
   }
 
   notifyThemeChanged(): void {
-    this.broadcast({ type: 'themeChanged', theme: getThemeSettings(), codeTheme: getCodeBlockVscodeTheme() });
+    this.broadcast({
+      type: 'themeChanged',
+      theme: getThemeSettings(),
+      vscodePreviewFontFamily: getVSCodePreviewFontFamily(),
+      codeTheme: getCodeBlockVscodeTheme()
+    });
   }
 
   async toggleActiveEditorMode(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,7 @@ import {
 } from './shared/extensionConfig';
 import { createPanelSessionController, type ExportFormat, type PanelSession } from './extension/panelSession';
 import { serializeThemeSettings, themePresets, type ThemeSettings, validateThemePayload } from './shared/themeDefaults';
+import type { ExtensionMessage } from './shared/webviewMessages';
 import {
   runWithTimedUiTimeout,
   showTimedErrorMessage,
@@ -620,7 +621,9 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
 
     this.lastActivePanel = session.panel;
     await session.ensureInitDelivered();
-    await session.panel.webview.postMessage({ type: 'toggleMode' });
+
+    const toggleMode: ExtensionMessage = { type: 'toggleMode' };
+    await session.panel.webview.postMessage(toggleMode);
   }
 
   async resolveCustomTextEditor(
@@ -688,7 +691,7 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
     this.updateActiveEditorContext();
   }
 
-  private broadcast(message: Record<string, unknown>): void {
+  private broadcast(message: ExtensionMessage): void {
     for (const panel of this.activePanels) {
       void panel.webview.postMessage(message);
     }

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -24,6 +24,16 @@ import {
   type VimKeybinding
 } from '../shared/extensionConfig';
 import { openLink, resolveLocalLinkTargets, resolveWebviewImageSrc, resolveWikiLinkTargets } from '../shared/documentLinks';
+import type {
+  ApplyChangesMessage,
+  EditorMode,
+  ExportFormat,
+  ExtensionMessage,
+  FindOptions,
+  RequestDiagnosticSuggestionsMessage,
+  SaveImageFromClipboardMessage,
+  WebviewMessage
+} from '../shared/webviewMessages';
 import { GitDocumentState, hashGitBaselinePayload } from '../git/documentState';
 import { openGitRevisionForLine, openGitWorktreeForLine, resolveGitBlameForRequest } from '../git/blameActions';
 import type { GitBaselinePayload, GitBlameLineResult } from '../git/types';
@@ -38,13 +48,7 @@ import {
   MEO_SPELL_DIAGNOSTIC_SOURCE
 } from '../spell/spellDiagnostics';
 
-export type EditorMode = 'live' | 'source';
-export type ExportFormat = 'html' | 'pdf';
-
-type FindOptions = {
-  wholeWord: boolean;
-  caseSensitive: boolean;
-};
+export type { EditorMode, ExportFormat };
 
 type InitMessage = {
   type: 'init';
@@ -97,107 +101,6 @@ type RevealSelectionPayload = {
   head: number;
 };
 
-type ApplyChangesMessage = {
-  type: 'applyChanges';
-  baseVersion: number;
-  changes: Array<{ from: number; to: number; insert: string }>;
-};
-
-type DraftChangedMessage = {
-  type: 'draftChanged';
-  text: string | null;
-};
-
-type SetModeMessage = {
-  type: 'setMode';
-  mode: EditorMode;
-};
-
-type OpenLinkMessage = {
-  type: 'openLink';
-  href: string;
-};
-
-type ResolveImageSrcMessage = {
-  type: 'resolveImageSrc';
-  requestId: string;
-  url: string;
-};
-
-type ResolveWikiLinksMessage = {
-  type: 'resolveWikiLinks';
-  requestId: string;
-  targets: string[];
-};
-
-type ResolveLocalLinksMessage = {
-  type: 'resolveLocalLinks';
-  requestId: string;
-  targets: string[];
-};
-
-type SaveDocumentMessage = {
-  type: 'saveDocument';
-};
-
-type ExportDocumentMessage = {
-  type: 'exportDocument';
-  format: ExportFormat;
-};
-
-type ExportSnapshotMessage = {
-  type: 'exportSnapshot';
-  requestId: string;
-  text: string;
-  environment?: ExportStyleEnvironment;
-};
-
-type ExportSnapshotErrorMessage = {
-  type: 'exportSnapshotError';
-  requestId: string;
-  message: string;
-};
-
-type SetLineNumbersMessage = {
-  type: 'setLineNumbers';
-  visible?: boolean;
-  enabled?: boolean;
-};
-
-type SetGitChangesGutterMessage = {
-  type: 'setGitChangesGutter';
-  visible?: boolean;
-  enabled?: boolean;
-};
-
-type SetSpellCheckMessage = {
-  type: 'setSpellCheck';
-  enabled: boolean;
-};
-
-type SetOutlineVisibleMessage = {
-  type: 'setOutlineVisible';
-  visible: boolean;
-};
-
-type SetContentMaxWidthMessage = {
-  type: 'setContentMaxWidth';
-  enabled: boolean;
-};
-
-type SetFindOptionsMessage = {
-  type: 'setFindOptions';
-  wholeWord?: boolean;
-  caseSensitive?: boolean;
-  findOptions?: Partial<FindOptions>;
-};
-
-type ViewPositionChangedMessage = {
-  type: 'viewPositionChanged';
-  topLine: number;
-  topLineOffset?: number;
-};
-
 type ResolvedImageSrcMessage = {
   type: 'resolvedImageSrc';
   requestId: string;
@@ -219,43 +122,6 @@ type ResolvedLocalLinksMessage = {
 type RequestExportSnapshotMessage = {
   type: 'requestExportSnapshot';
   requestId: string;
-};
-
-type RequestGitBlameMessage = {
-  type: 'requestGitBlame';
-  requestId: string;
-  lineNumber: number;
-  text?: string;
-  localEditGeneration: number;
-};
-
-type OpenGitRevisionForLineMessage = {
-  type: 'openGitRevisionForLine';
-  lineNumber: number;
-  text?: string;
-};
-
-type OpenGitWorktreeForLineMessage = {
-  type: 'openGitWorktreeForLine';
-  lineNumber: number;
-  text?: string;
-};
-
-type SaveImageFromClipboardMessage = {
-  type: 'saveImageFromClipboard';
-  requestId: string;
-  imageData: string;
-  fileName: string;
-};
-
-type RequestDiagnosticSuggestionsMessage = {
-  type: 'requestDiagnosticSuggestions';
-  requestId: string;
-  from: number;
-  to: number;
-  message: string;
-  source?: string;
-  code?: string;
 };
 
 type DiagnosticSuggestionsResultMessage = {
@@ -301,32 +167,6 @@ type DiagnosticsChangedMessage = {
   type: 'diagnosticsChanged';
   diagnostics: SerializedDiagnostic[];
 };
-
-type WebviewMessage =
-  | ApplyChangesMessage
-  | DraftChangedMessage
-  | SetModeMessage
-  | SetLineNumbersMessage
-  | SetGitChangesGutterMessage
-  | SetSpellCheckMessage
-  | SetOutlineVisibleMessage
-  | SetContentMaxWidthMessage
-  | SetFindOptionsMessage
-  | ViewPositionChangedMessage
-  | OpenLinkMessage
-  | ResolveImageSrcMessage
-  | ResolveWikiLinksMessage
-  | ResolveLocalLinksMessage
-  | SaveDocumentMessage
-  | ExportDocumentMessage
-  | ExportSnapshotMessage
-  | ExportSnapshotErrorMessage
-  | RequestGitBlameMessage
-  | OpenGitRevisionForLineMessage
-  | OpenGitWorktreeForLineMessage
-  | SaveImageFromClipboardMessage
-  | RequestDiagnosticSuggestionsMessage
-  | { type: 'ready' };
 
 type RefreshGitBaselineOptions = {
   forcePost?: boolean;
@@ -455,7 +295,7 @@ export function createPanelSessionController(params: PanelSessionControllerParam
     });
   };
 
-  const postToWebview = async (message: Record<string, unknown>): Promise<boolean> => {
+  const postToWebview = async (message: ExtensionMessage): Promise<boolean> => {
     if (disposed) {
       return false;
     }

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -894,7 +894,7 @@ export function createPanelSessionController(params: PanelSessionControllerParam
         });
         return;
       case 'exportSnapshotError':
-        rejectPendingExportSnapshot(raw.requestId, new Error(raw.message || 'Failed to collect export snapshot.'));
+        rejectPendingExportSnapshot(raw.requestId, new Error(raw.error || 'Failed to collect export snapshot.'));
         return;
       case 'requestGitBlame': {
         const resolved = await resolveGitBlameForRequest(documentUri, raw, document.getText(), gitDocumentState);

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -12,6 +12,7 @@ import {
   getGitChangesGutterEnabled,
   getGitDiffLineHighlightsEnabled,
   getSpellCheckEnabled,
+  getVSCodePreviewFontFamily,
   getOutlinePosition,
   getOutlineVisible,
   getRememberPositionLines,
@@ -65,6 +66,7 @@ type InitMessage = {
   vimKeybindings: VimKeybinding[];
   vimLeader: string;
   findOptions: FindOptions;
+  vscodePreviewFontFamily?: string;
   outlinePosition: OutlinePosition;
   outlineVisible: boolean;
   theme: ThemeSettings;
@@ -394,6 +396,7 @@ export function createPanelSessionController(params: PanelSessionControllerParam
       vimKeybindings: getVimKeybindings(),
       vimLeader: getVimLeaderKey(),
       findOptions: getFindOptions(),
+      vscodePreviewFontFamily: getVSCodePreviewFontFamily(),
       outlinePosition: getOutlinePosition(),
       outlineVisible: getOutlineVisible(context),
       theme: getThemeSettings(),

--- a/src/shared/extensionConfig.ts
+++ b/src/shared/extensionConfig.ts
@@ -222,6 +222,16 @@ export function getExportEditorFontEnvironment(): { editorFontFamily?: string; e
   };
 }
 
+/**
+ * This is currently passed to webview as an additional postMessage property,
+ * complementing the `--vscode-editor-font-family` CSS variable that VS Code already passes.
+ */
+export function getVSCodePreviewFontFamily(): string | undefined {
+  const markdownConfig = vscode.workspace.getConfiguration('markdown');
+  const fontFamily = `${markdownConfig.get<string>('preview.fontFamily', '') ?? ''}`.trim();
+  return fontFamily || undefined;
+}
+
 export function isMarkdownDocumentPath(filePath: string): boolean {
   return MARKDOWN_FILE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
 }

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -1,0 +1,105 @@
+import type { ExportStyleEnvironment } from '../export/exportStyles';
+import type { VimKeybinding } from './extensionConfig';
+import type { ThemeSettings } from './themeDefaults';
+import type { RawVscodeTheme } from './vscodeTheme';
+
+export type EditorMode = 'live' | 'source';
+
+export type ExportFormat = 'html' | 'pdf';
+
+export type FindOptions = {
+  wholeWord: boolean;
+  caseSensitive: boolean;
+};
+
+export interface EditorDiagnostic {
+  from: number;
+  to: number;
+  severity: 0 | 1 | 2 | 3;
+  message: string;
+  source?: string;
+  code?: string;
+}
+
+export type ExtensionMessage =
+  | {
+    type: 'init';
+    text: string;
+    version: number;
+    diagnostics: EditorDiagnostic[];
+    theme: ThemeSettings;
+    shikiCodeBlocks: boolean;
+    codeTheme: RawVscodeTheme | null;
+    mode: 'live' | 'source';
+    outlinePosition: 'left' | 'right';
+    outlineVisible: boolean;
+    lineNumbers: boolean;
+    gitChangesGutter: boolean;
+    gitDiffLineHighlights: boolean;
+    spellCheckEnabled: boolean;
+    contentMaxWidthEnabled: boolean;
+    vimMode: boolean;
+    vimKeybindings: VimKeybinding[];
+    vimLeader: string;
+    findOptions: { wholeWord: boolean; caseSensitive: boolean };
+    restoreTopLine?: number;
+    restoreTopLineOffset?: number;
+  }
+  | { type: 'docChanged'; text: string; version: number }
+  | { type: 'applied'; version: number }
+  | { type: 'focusEditor' }
+  | { type: 'revealSelection'; anchor: number; head: number; focus?: boolean }
+  | { type: 'diagnosticsChanged'; diagnostics: EditorDiagnostic[] }
+  | { type: 'themeChanged'; theme: ThemeSettings; codeTheme: RawVscodeTheme | null }
+  | { type: 'shikiCodeBlocksChanged'; enabled: boolean; codeTheme: RawVscodeTheme | null }
+  | { type: 'toggleMode' }
+  | { type: 'outlinePositionChanged'; position: 'left' | 'right' }
+  | { type: 'outlineVisibilityChanged'; visible: boolean }
+  | { type: 'lineNumbersChanged'; enabled: boolean }
+  | { type: 'gitChangesGutterChanged'; enabled: boolean }
+  | { type: 'gitDiffLineHighlightsChanged'; enabled: boolean }
+  | { type: 'spellCheckChanged'; enabled: boolean }
+  | { type: 'contentMaxWidthChanged'; enabled: boolean }
+  | { type: 'vimModeChanged'; enabled: boolean }
+  | { type: 'vimKeybindingsChanged'; keybindings: VimKeybinding[]; leaderKey: string }
+  | { type: 'findOptionsChanged'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
+  | { type: 'resolvedImageSrc'; requestId: string; resolvedUrl: string }
+  | { type: 'resolvedWikiLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
+  | { type: 'resolvedLocalLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
+  | { type: 'diagnosticSuggestionsResult'; requestId: string; from: number; to: number; suggestions: string[] }
+  | { type: 'savedImagePath'; requestId: string; success: boolean; path?: string; error?: string }
+  | { type: 'requestExportSnapshot'; requestId: string }
+  | { type: 'gitBaselineChanged'; version: number; payload: unknown }
+  | { type: 'gitBlameResult'; requestId: string; lineNumber: number; localEditGeneration: number; result: unknown };
+
+// `setLineNumbers`, `setGitChangesGutter`, and `setFindOptions` each accept two shapes,
+// since the extension still reads a legacy spelling (`enabled`, and the flattened find options) alongside the current one.
+export type WebviewMessage =
+  | { type: 'ready' }
+  | { type: 'applyChanges'; baseVersion: number; changes: Array<{ from: number; to: number; insert: string }> }
+  | { type: 'draftChanged'; text: string | null }
+  | { type: 'setMode'; mode: EditorMode }
+  | { type: 'setLineNumbers'; visible?: boolean; enabled?: boolean }
+  | { type: 'setGitChangesGutter'; visible?: boolean; enabled?: boolean }
+  | { type: 'setSpellCheck'; enabled: boolean }
+  | { type: 'setContentMaxWidth'; enabled: boolean }
+  | { type: 'setOutlineVisible'; visible: boolean }
+  | { type: 'setFindOptions'; wholeWord?: boolean; caseSensitive?: boolean; findOptions?: Partial<FindOptions> }
+  | { type: 'viewPositionChanged'; topLine: number; topLineOffset?: number }
+  | { type: 'openLink'; href: string }
+  | { type: 'resolveImageSrc'; requestId: string; url: string }
+  | { type: 'resolveWikiLinks'; requestId: string; targets: string[] }
+  | { type: 'resolveLocalLinks'; requestId: string; targets: string[] }
+  | { type: 'requestDiagnosticSuggestions'; requestId: string; from: number; to: number; message: string; source?: string; code?: string }
+  | { type: 'saveDocument' }
+  | { type: 'exportDocument'; format: ExportFormat }
+  | { type: 'exportSnapshot'; requestId: string; text: string; environment?: ExportStyleEnvironment }
+  | { type: 'exportSnapshotError'; requestId: string; error: string }
+  | { type: 'saveImageFromClipboard'; requestId: string; imageData: string; fileName: string }
+  | { type: 'requestGitBlame'; requestId: string; lineNumber: number; text?: string; localEditGeneration: number }
+  | { type: 'openGitRevisionForLine'; lineNumber: number; text?: string }
+  | { type: 'openGitWorktreeForLine'; lineNumber: number; text?: string };
+
+export type ApplyChangesMessage = Extract<WebviewMessage, { type: 'applyChanges' }>;
+export type RequestDiagnosticSuggestionsMessage = Extract<WebviewMessage, { type: 'requestDiagnosticSuggestions' }>;
+export type SaveImageFromClipboardMessage = Extract<WebviewMessage, { type: 'saveImageFromClipboard' }>;

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -30,6 +30,7 @@ export type ExtensionMessage =
     theme: ThemeSettings;
     shikiCodeBlocks: boolean;
     codeTheme: RawVscodeTheme | null;
+    vscodePreviewFontFamily?: string;
     mode: 'live' | 'source';
     outlinePosition: 'left' | 'right';
     outlineVisible: boolean;
@@ -50,7 +51,7 @@ export type ExtensionMessage =
   | { type: 'focusEditor' }
   | { type: 'revealSelection'; anchor: number; head: number; focus?: boolean }
   | { type: 'diagnosticsChanged'; diagnostics: EditorDiagnostic[] }
-  | { type: 'themeChanged'; theme: ThemeSettings; codeTheme: RawVscodeTheme | null }
+  | { type: 'themeChanged'; theme: ThemeSettings; codeTheme: RawVscodeTheme | null; vscodePreviewFontFamily?: string }
   | { type: 'shikiCodeBlocksChanged'; enabled: boolean; codeTheme: RawVscodeTheme | null }
   | { type: 'toggleMode' }
   | { type: 'outlinePositionChanged'; position: 'left' | 'right' }

--- a/src/smoke.test.ts
+++ b/src/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'bun:test';
+
+describe('unit test runner', () => {
+  it('finds tests in src/', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/webview/src/helpers/diagnostics.ts
+++ b/webview/src/helpers/diagnostics.ts
@@ -1,14 +1,9 @@
 import { RangeSetBuilder, StateEffect, StateField, type Transaction } from '@codemirror/state';
 import { Decoration, EditorView, type DecorationSet } from '@codemirror/view';
 
-export type EditorDiagnostic = {
-  from: number;
-  to: number;
-  severity: 0 | 1 | 2 | 3;
-  message: string;
-  source?: string;
-  code?: string;
-};
+import type { EditorDiagnostic } from '../../../src/shared/webviewMessages';
+
+export type { EditorDiagnostic };
 
 export const setDiagnosticsEffect = StateEffect.define<EditorDiagnostic[]>();
 

--- a/webview/src/helpers/shikiHighlighter.ts
+++ b/webview/src/helpers/shikiHighlighter.ts
@@ -1,11 +1,8 @@
 import type { HighlighterCore } from 'shiki/core';
 
-export type RawVscodeTheme = {
-  name: string;
-  type: 'light' | 'dark';
-  colors: Record<string, string>;
-  tokenColors: unknown[];
-};
+import type { RawVscodeTheme } from '../../../src/shared/vscodeTheme';
+
+export type { RawVscodeTheme };
 
 const THEME_NAME = 'meo-code-theme';
 const CACHE_LIMIT = 300;

--- a/webview/src/helpers/theme.ts
+++ b/webview/src/helpers/theme.ts
@@ -5,8 +5,6 @@ import {
   themeColorKeys
 } from '../../../src/shared/themeDefaults';
 
-const vscodeEditorFontFamily = 'var(--vscode-editor-font-family)';
-const vscodeEditorFontSize = 'var(--vscode-editor-font-size, 13px)';
 const styleValueInjectionPattern = /[\n\r;{}]/g;
 const defaultHeadingFontWeight = '600';
 const headingSizeFallbacks = ['1.6em', '1.5em', '1.3em', '1.2em', '1.1em', '1em'] as const;
@@ -92,7 +90,10 @@ const normalizeThemeHeadingSize = (value: number | undefined, fallback: string, 
   return `${value}px`;
 };
 
-export const applyThemeSettings = (theme?: ThemeSettings): void => {
+export const applyThemeSettings = (
+  theme?: ThemeSettings,
+  { vscodePreviewFontFamily }: { vscodePreviewFontFamily?: string } = {}
+): void => {
   let resolvedTheme: ThemeSettings;
   const editorFontWeight = resolveEditorFontWeight();
   try {
@@ -161,12 +162,15 @@ export const applyThemeSettings = (theme?: ThemeSettings): void => {
   ];
   const liveLineHeight = normalizeThemeLineHeight(resolvedTheme.fonts.liveLineHeight, 1.5);
   const sourceLineHeight = normalizeThemeLineHeight(resolvedTheme.fonts.sourceLineHeight, 1.5);
-  rootStyle.setProperty('--meo-font-live', liveFont || vscodeEditorFontFamily);
-  rootStyle.setProperty('--meo-font-source', sourceFont || vscodeEditorFontFamily);
+
+  // Setting a property to '' removes it, per the CSS Object Model,
+  // so any unresolved property will fall through to the default value that we set in `./webview/src/styles.css`.
+  rootStyle.setProperty('--meo-font-live', liveFont || sanitizeThemeFontStyle(vscodePreviewFontFamily ?? ''));
+  rootStyle.setProperty('--meo-font-source', sourceFont);
   rootStyle.setProperty('--meo-font-live-weight', liveFontWeight || editorFontWeight);
   rootStyle.setProperty('--meo-font-source-weight', sourceFontWeight || editorFontWeight);
-  rootStyle.setProperty('--meo-font-live-size', liveFontSize || vscodeEditorFontSize);
-  rootStyle.setProperty('--meo-font-source-size', sourceFontSize || vscodeEditorFontSize);
+  rootStyle.setProperty('--meo-font-live-size', liveFontSize);
+  rootStyle.setProperty('--meo-font-source-size', sourceFontSize);
   for (const [index, size] of headingFontSizes.entries()) {
     rootStyle.setProperty(`--meo-heading-${index + 1}-size`, size);
   }

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -1437,7 +1437,7 @@ window.addEventListener('message', (event) => {
   if (message.type === 'init') {
     acknowledgeReadyHandshake();
     withMessageErrorBoundary('init handler', () => {
-      applyThemeSettings(message.theme);
+      applyThemeSettings(message.theme, { vscodePreviewFontFamily: message.vscodePreviewFontFamily });
       setShikiEnabled(message.shikiCodeBlocks === true);
       setShikiTheme(message.codeTheme);
       initialMountRecoveryAttempted = false;
@@ -1473,7 +1473,7 @@ window.addEventListener('message', (event) => {
 
   if (message.type === 'themeChanged') {
     withMessageErrorBoundary('themeChanged handler', () => {
-      applyThemeSettings(message.theme);
+      applyThemeSettings(message.theme, { vscodePreviewFontFamily: message.vscodePreviewFontFamily });
       refreshMermaidTheme();
       setShikiTheme(message.codeTheme);
       editor?.refreshDecorations();

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -1428,7 +1428,7 @@ const withMessageErrorBoundary = (context: string, action: () => void): void => 
 };
 
 window.addEventListener('message', (event) => {
-  const message = event.data;
+  const message = event.data as ExtensionMessage;
 
   if (!message || typeof message !== 'object') {
     return;

--- a/webview/src/smoke.test.ts
+++ b/webview/src/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'bun:test';
+
+describe('unit test runner', () => {
+  it('finds tests in webview/src/', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -26,13 +26,22 @@
     var(--meo-code-background, var(--vscode-textCodeBlock-background)) 82%,
     var(--vscode-editor-selectionBackground) 18%
   );
+
   --meo-code-block-active-line-bg-live: color-mix(in srgb, var(--vscode-sideBar-background) 50%, transparent 50%);
-  --meo-font-live: var(--vscode-editor-font-family);
-  --meo-font-source: var(--vscode-editor-font-family);
+  /* VS Code passes a CSS variable naming the (usually monospace) editor font family
+   * but does _not_ pass an equivalent for the (usually proportional) Markdown Preview font family, so -
+   * at least while we wait for `init` or `applyThemeSettings` to name something more appropriate -
+   * Live mode falls back to this **hardcoded** font stack, copied and pasted from VS Code's default for `markdown.preview.fontFamily`
+   * (https://github.com/microsoft/vscode/blob/1.96.4/extensions/markdown-language-features/package.json#L343-L348).
+   */
+  --meo-font-live: -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', system-ui, 'Ubuntu', 'Droid Sans', sans-serif;
   --meo-font-live-weight: var(--vscode-editor-font-weight);
-  --meo-font-source-weight: var(--vscode-editor-font-weight);
   --meo-font-live-size: var(--vscode-editor-font-size, 13px);
+
+  --meo-font-source: var(--vscode-editor-font-family);
+  --meo-font-source-weight: var(--vscode-editor-font-weight);
   --meo-font-source-size: var(--vscode-editor-font-size, 13px);
+
   --meo-heading-1-size: 1.6em;
   --meo-heading-2-size: 1.5em;
   --meo-heading-3-size: 1.3em;

--- a/webview/src/types.d.ts
+++ b/webview/src/types.d.ts
@@ -6,98 +6,15 @@ interface VsCodeWebviewApi {
   postMessage(message: WebviewMessage): void;
 }
 
-type WebviewMessage =
-  | { type: 'ready' }
-  | { type: 'applyChanges'; content?: string; baseVersion: number; changes?: { from: number; to: number; insert: string }[] }
-  | { type: 'draftChanged'; text: string | null }
-  | { type: 'setMode'; mode: 'live' | 'source' }
-  | { type: 'setLineNumbers'; visible: boolean }
-  | { type: 'setGitChangesGutter'; visible: boolean }
-  | { type: 'setSpellCheck'; enabled: boolean }
-  | { type: 'setContentMaxWidth'; enabled: boolean }
-  | { type: 'setOutlineVisible'; visible: boolean }
-  | { type: 'setFindOptions'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
-  | { type: 'viewPositionChanged'; topLine: number; topLineOffset?: number }
-  | { type: 'openLink'; href: string }
-  | { type: 'resolveImageSrc'; requestId: string; url: string }
-  | { type: 'resolveWikiLinks'; requestId: string; targets: string[] }
-  | { type: 'resolveLocalLinks'; requestId: string; targets: string[] }
-  | { type: 'requestDiagnosticSuggestions'; requestId: string; from: number; to: number; message: string; source?: string; code?: string }
-  | { type: 'saveDocument' }
-  | { type: 'exportDocument'; format: 'html' | 'pdf' }
-  | { type: 'exportSnapshot'; requestId: string; text: string; environment?: Record<string, unknown> }
-  | { type: 'exportSnapshotError'; requestId: string; error: string; message?: string }
-  | { type: 'saveImageFromClipboard'; requestId: string; imageData: string; fileName: string };
+type WebviewMessage = import('../../src/shared/webviewMessages').WebviewMessage;
 
-type VimKeybinding = {
-  before: string;
-  after: string;
-  mode: 'normal' | 'insert' | 'visual';
-  recursive: boolean;
-};
+type VimKeybinding = import('../../src/shared/extensionConfig').VimKeybinding;
 
-type ExtensionMessage =
-  | { type: 'init'; text: string; version: number; diagnostics: EditorDiagnostic[]; theme: ThemeSettings; mode: 'live' | 'source'; outlinePosition: 'left' | 'right'; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; spellCheckEnabled: boolean; contentMaxWidthEnabled: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number }
-  | { type: 'docChanged'; text: string; version: number }
-  | { type: 'applied'; version: number }
-  | { type: 'focusEditor' }
-  | { type: 'revealSelection'; anchor: number; head: number; focus?: boolean }
-  | { type: 'diagnosticsChanged'; diagnostics: EditorDiagnostic[] }
-  | { type: 'themeChanged'; theme: ThemeSettings }
-  | { type: 'outlinePositionChanged'; position: 'left' | 'right' }
-  | { type: 'outlineVisibilityChanged'; visible: boolean }
-  | { type: 'lineNumbersChanged'; enabled: boolean }
-  | { type: 'gitChangesGutterChanged'; enabled: boolean }
-  | { type: 'gitDiffLineHighlightsChanged'; enabled: boolean }
-  | { type: 'spellCheckChanged'; enabled: boolean }
-  | { type: 'contentMaxWidthChanged'; enabled: boolean }
-  | { type: 'vimModeChanged'; enabled: boolean }
-  | { type: 'vimKeybindingsChanged'; keybindings: VimKeybinding[]; leaderKey: string }
-  | { type: 'findOptionsChanged'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
-  | { type: 'resolvedImageSrc'; requestId: string; resolvedUrl: string }
-  | { type: 'resolvedWikiLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
-  | { type: 'resolvedLocalLinks'; requestId: string; results: Array<{ target: string; exists: boolean }> }
-  | { type: 'diagnosticSuggestionsResult'; requestId: string; from: number; to: number; suggestions: string[] }
-  | { type: 'savedImagePath'; requestId: string; success: boolean; path?: string; error?: string };
+type ExtensionMessage = import('../../src/shared/webviewMessages').ExtensionMessage;
 
-interface ThemeSettings {
-  id: string;
-  name: string;
-  backgroundColor?: string;
-  colors: Record<string, string>;
-  syntaxTokens: Record<string, string>;
-  fonts: {
-    liveFont?: string;
-    sourceFont?: string;
-    liveFontWeight?: string;
-    sourceFontWeight?: string;
-    liveFontSize?: number | null;
-    sourceFontSize?: number | null;
-    h1FontSize?: number | null;
-    h2FontSize?: number | null;
-    h3FontSize?: number | null;
-    h4FontSize?: number | null;
-    h5FontSize?: number | null;
-    h6FontSize?: number | null;
-    h1FontWeight?: string;
-    h2FontWeight?: string;
-    h3FontWeight?: string;
-    h4FontWeight?: string;
-    h5FontWeight?: string;
-    h6FontWeight?: string;
-    liveLineHeight?: number;
-    sourceLineHeight?: number;
-  };
-}
+type ThemeSettings = import('../../src/shared/themeDefaults').ThemeSettings;
 
-interface EditorDiagnostic {
-  from: number;
-  to: number;
-  severity: 0 | 1 | 2 | 3;
-  message: string;
-  source?: string;
-  code?: string;
-}
+type EditorDiagnostic = import('../../src/shared/webviewMessages').EditorDiagnostic;
 
 interface WikiLinkStatus {
   exists: boolean;


### PR DESCRIPTION
[Only the **last** commit is relevant here, as the first six commits will disappear if/when #67 and #68 get merged. Unfortunately it seems that `main` is the only branch available for use a merge base.]

- An empty `fonts.liveFont` now falls back to the user's `markdown.preview.fontFamily` (available in the webview thanks to a new `vscodePreviewFontFamily` postMessage property), then to VS Code's own default for that setting (hardcoded, since VS Code passes no `--vscode-preview-font-family` to webviews).

- Refactor: an empty `fonts.sourceFont`, `fonts.liveFontSize`, or `fonts.sourceFontSize` now falls back through a single `:root` declaration in `./webview/src/styles.css`, without any duplicate declarations in `./webview/src/helpers/theme.ts`. (The fallback font values are available in the webview thanks to the `--vscode-editor-font-family` and `--vscode-editor-font-size` CSS variables.)