### PR TITLE
feat: Add a document Read Only lock for Live and Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Markdown Editor Optimized (MEO)
 ---
+## Unreleased
+- Added Live read-only reading view (`markdownEditorOptimized.live.readOnly`) with toolbar toggle and command
+- Read-only Live disables active-line highlight/source reveal and blocks edits while keeping selection/copy
+
 ## 0.1.26
 - Improved dark Mermaid diagram line contrast
 - Fixed live find matches and preserve active highlight

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An optimized markdown editor with live editing mode for VS Code.
 ### Writing & Editing
 
 - **Live/Source modes** - Switch between clean writing and raw markdown in a single tab
+- **Live read-only** - Optional reading view (no active-line source swap, no accidental edits); edit in Source or turn the option off
 - **Toolbar formatting** - Insert headings, lists, tasks, tables, code blocks, links, images, and quotes in one click
 - **Floating selection menu** - Instantly apply bold, italic, strikethrough, inline code, or links on any text selection
 - **Spellcheck** - Fix issues with built-in spelling suggestions

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
         "icon": "$(sync)"
       },
       {
+        "command": "markdownEditorOptimized.toggleLiveReadOnly",
+        "title": "Markdown Editor Optimized: Toggle Live Read-only",
+        "icon": "$(book)"
+      },
+      {
         "command": "markdownEditorOptimized.exportHtml",
         "title": "Markdown Editor Optimized: Export as HTML",
         "icon": "$(export)"
@@ -184,6 +189,12 @@
           "default": false,
           "order": 3,
           "description": "Constrain the editor content to a centered 800px column."
+        },
+        "markdownEditorOptimized.live.readOnly": {
+          "type": "boolean",
+          "default": false,
+          "order": 3,
+          "description": "When enabled, Live mode is a read-only reading view: no active-line source reveal, no active-line highlight, and no typing/edits. Switch to Source (or turn this off) to edit. Default off."
         },
         "markdownEditorOptimized.lineNumbers.visible": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import {
   VIM_MODE_SETTING_KEY,
   CODE_BLOCKS_VSCODE_THEME_SETTING_KEY,
   CONTENT_MAX_WIDTH_SETTING_KEY,
+  LIVE_READ_ONLY_SETTING_KEY,
   SPELL_CHECK_SETTING_KEY,
   getUseVscodeThemeForCodeBlocks,
   getCodeBlockVscodeTheme,
@@ -53,6 +54,7 @@ import {
   getOutlinePosition,
   getOutlineVisible,
   getContentMaxWidthEnabled,
+  getLiveReadOnlyEnabled,
   getSpellCheckEnabled,
   getThemeSettings,
   getVimKeybindings,
@@ -435,6 +437,9 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   context.subscriptions.push(
+    vscode.commands.registerCommand('markdownEditorOptimized.toggleLiveReadOnly', async () => {
+      await provider.toggleLiveReadOnly();
+    }),
     vscode.commands.registerCommand('markdownEditorOptimized.toggleMode', async () => {
       await provider.toggleActiveEditorMode();
     })
@@ -557,6 +562,10 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
       this.broadcast({ type: 'contentMaxWidthChanged', enabled: getContentMaxWidthEnabled(this.context) });
     }
 
+    if (event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${LIVE_READ_ONLY_SETTING_KEY}`)) {
+      this.broadcast({ type: 'liveReadOnlyChanged', enabled: getLiveReadOnlyEnabled() });
+    }
+
     if (
       event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_BEHAVIOR_SETTING_KEY}`) ||
       event.affectsConfiguration(`${EXTENSION_CONFIG_SECTION}.${VIM_MODE_SETTING_KEY}`) ||
@@ -621,6 +630,13 @@ class MarkdownWebviewProvider implements vscode.CustomTextEditorProvider {
     this.lastActivePanel = session.panel;
     await session.ensureInitDelivered();
     await session.panel.webview.postMessage({ type: 'toggleMode' });
+  }
+
+  async toggleLiveReadOnly(): Promise<void> {
+    const config = vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION);
+    const current = getLiveReadOnlyEnabled();
+    await config.update(LIVE_READ_ONLY_SETTING_KEY, !current, vscode.ConfigurationTarget.Global);
+    // Configuration listener broadcasts liveReadOnlyChanged.
   }
 
   async resolveCustomTextEditor(

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -6,12 +6,14 @@ import {
   LINE_NUMBERS_SETTING_KEY,
   GIT_CHANGES_GUTTER_SETTING_KEY,
   CONTENT_MAX_WIDTH_SETTING_KEY,
+  LIVE_READ_ONLY_SETTING_KEY,
   SPELL_CHECK_SETTING_KEY,
   getContentMaxWidthEnabled,
   getLineNumbersEnabled,
   getGitChangesGutterEnabled,
   getGitDiffLineHighlightsEnabled,
   getSpellCheckEnabled,
+  getLiveReadOnlyEnabled,
   getOutlinePosition,
   getOutlineVisible,
   getRememberPositionLines,
@@ -53,6 +55,7 @@ type InitMessage = {
   diagnostics: SerializedDiagnostic[];
   mode: EditorMode;
   lineNumbers: boolean;
+  liveReadOnly: boolean;
   gitChangesGutter: boolean;
   gitDiffLineHighlights: boolean;
   spellCheckEnabled: boolean;
@@ -185,6 +188,11 @@ type SetContentMaxWidthMessage = {
   enabled: boolean;
 };
 
+type SetLiveReadOnlyMessage = {
+  type: 'setLiveReadOnly';
+  enabled: boolean;
+};
+
 type SetFindOptionsMessage = {
   type: 'setFindOptions';
   wholeWord?: boolean;
@@ -311,6 +319,7 @@ type WebviewMessage =
   | SetSpellCheckMessage
   | SetOutlineVisibleMessage
   | SetContentMaxWidthMessage
+  | SetLiveReadOnlyMessage
   | SetFindOptionsMessage
   | ViewPositionChangedMessage
   | OpenLinkMessage
@@ -546,6 +555,7 @@ export function createPanelSessionController(params: PanelSessionControllerParam
       diagnostics: serializeDiagnostics(document),
       mode,
       lineNumbers: getLineNumbersEnabled(context),
+      liveReadOnly: getLiveReadOnlyEnabled(),
       gitChangesGutter: getGitChangesGutterEnabled(context),
       gitDiffLineHighlights: getGitDiffLineHighlightsEnabled(),
       spellCheckEnabled: getSpellCheckEnabled(),
@@ -850,6 +860,10 @@ export function createPanelSessionController(params: PanelSessionControllerParam
     if (!webviewReady) {
       return;
     }
+    // Avoid stealing keyboard focus from chat/agent inputs while Live is in reading mode.
+    if (mode === 'live' && getLiveReadOnlyEnabled()) {
+      return;
+    }
     await ensureInitDelivered();
     if (!initDelivered) {
       return;
@@ -998,6 +1012,14 @@ export function createPanelSessionController(params: PanelSessionControllerParam
           .getConfiguration(EXTENSION_CONFIG_SECTION)
           .update(CONTENT_MAX_WIDTH_SETTING_KEY, raw.enabled === true, vscode.ConfigurationTarget.Global);
         return;
+      case 'setLiveReadOnly': {
+        const enabled = raw.enabled === true;
+        await vscode.workspace
+          .getConfiguration(EXTENSION_CONFIG_SECTION)
+          .update(LIVE_READ_ONLY_SETTING_KEY, enabled, vscode.ConfigurationTarget.Global);
+        return;
+      }
+
       case 'setFindOptions': {
         const wholeWord = raw.findOptions?.wholeWord ?? raw.wholeWord;
         const caseSensitive = raw.findOptions?.caseSensitive ?? raw.caseSensitive;

--- a/src/shared/extensionConfig.ts
+++ b/src/shared/extensionConfig.ts
@@ -18,6 +18,7 @@ export const VIM_MODE_SETTING_KEY = 'vimMode.enabled';
 export const CODE_BLOCKS_VSCODE_THEME_SETTING_KEY = 'codeBlocks.useVscodeTheme';
 export const REMEMBER_POSITION_LINES_SETTING_KEY = 'rememberPosition.lines';
 export const CONTENT_MAX_WIDTH_SETTING_KEY = 'contentMaxWidth.visible';
+export const LIVE_READ_ONLY_SETTING_KEY = 'live.readOnly';
 export const LINE_NUMBERS_LEGACY_SETTING_KEY = 'lineNumbers.enabled';
 export const LINE_NUMBERS_LEGACY_VISIBLE_SETTING_KEY = 'lineNumbers.visibility';
 export const GIT_CHANGES_GUTTER_LEGACY_VISIBLE_SETTING_KEY = 'gitChanges.visibility';
@@ -73,6 +74,10 @@ export function getGitDiffLineHighlightsEnabled(): boolean {
 
 export function getSpellCheckEnabled(): boolean {
   return vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>(SPELL_CHECK_SETTING_KEY, true);
+}
+
+export function getLiveReadOnlyEnabled(): boolean {
+  return vscode.workspace.getConfiguration(EXTENSION_CONFIG_SECTION).get<boolean>(LIVE_READ_ONLY_SETTING_KEY, false);
 }
 
 export function getVimModeEnabled(context: vscode.ExtensionContext): boolean {

--- a/webview/src/editor.ts
+++ b/webview/src/editor.ts
@@ -1,4 +1,4 @@
-import { EditorState, Compartment, Transaction, StateEffect, StateField, RangeSetBuilder, type ChangeSpec } from '@codemirror/state';
+import { EditorState, Compartment, Transaction, StateEffect, StateField, RangeSetBuilder, Annotation, type ChangeSpec } from '@codemirror/state';
 import { EditorView, keymap, highlightActiveLine, lineNumbers, highlightActiveLineGutter, scrollPastEnd, Decoration, type ViewUpdate } from '@codemirror/view';
 import { defaultKeymap, history, historyKeymap, indentMore, indentLess, undo, redo } from '@codemirror/commands';
 import { markdown, markdownKeymap, markdownLanguage } from '@codemirror/lang-markdown';
@@ -6,7 +6,7 @@ import { indentUnit, syntaxHighlighting, syntaxTree, forceParsing } from '@codem
 import { vim, Vim } from '@replit/codemirror-vim';
 import { highlightStyle } from './theme';
 import { shikiCodeHighlight } from './helpers/shikiDecorations';
-import { liveModeExtensions } from './liveMode';
+import { liveModeExtensions, liveReadingFacet } from './liveMode';
 import { headingCollapseSharedExtensions, headingCollapseSourceSpacerExtensions } from './helpers/headingCollapse';
 import { resolveCodeLanguage, insertCodeBlock, sourceCodeBlockField } from './helpers/codeBlocks';
 import { sourceStrikeMarkerField } from './helpers/strikeMarkers';
@@ -83,6 +83,7 @@ type MarkerReplacementContext = {
 };
 
 const setSearchQueryEffect = StateEffect.define<SearchQueryState>();
+const meoExternalSyncAnnotation = Annotation.define<boolean>();
 const refreshDecorationsEffect = StateEffect.define();
 const searchMatchMark = Decoration.mark({ class: 'meo-search-match' });
 const activeSearchMatchMark = Decoration.mark({ class: 'meo-search-match meo-search-match-active' });
@@ -166,6 +167,7 @@ export function createEditor({
   initialTopLine = null,
   initialTopLineOffset = 0,
   initialLineNumbers = true,
+  initialLiveReadOnly = false,
   initialGitGutter = true,
   initialVimMode = false,
   initialVimKeybindings = [],
@@ -179,8 +181,11 @@ export function createEditor({
   const modeCompartment = new Compartment();
   const gitGutterCompartment = new Compartment();
   const vimCompartment = new Compartment();
+  const readingCompartment = new Compartment();
+  const activeLineHighlightCompartment = new Compartment();
   const startMode = initialMode === 'live' ? 'live' : 'source';
   let lineNumbersVisible = initialLineNumbers !== false;
+  let liveReadOnlyEnabled = initialLiveReadOnly === true;
   let gitGutterVisible = initialGitGutter !== false;
   let vimModeEnabled = initialVimMode === true;
   let vimKeybindings = initialVimKeybindings;
@@ -246,6 +251,50 @@ export function createEditor({
   let view = null;
   let currentMode = startMode;
   let applyingRenumber = false;
+
+  const isReadingLive = () => currentMode === 'live' && liveReadOnlyEnabled;
+  const readingExtensions = (enabled: boolean) => {
+    if (!enabled) {
+      return [];
+    }
+    return [
+      liveReadingFacet.of(true),
+      EditorView.editable.of(false),
+      EditorState.transactionFilter.of((tr) => {
+        if (tr.annotation(meoExternalSyncAnnotation)) {
+          return tr;
+        }
+        if (tr.docChanged) {
+          return [];
+        }
+        return tr;
+      })
+    ];
+  };
+  const activeLineHighlightExtensions = (enabled: boolean) => (
+    enabled ? [highlightActiveLineGutter(), highlightActiveLine()] : []
+  );
+  const syncReadingPresentation = () => {
+    if (!view) {
+      return;
+    }
+    const reading = isReadingLive();
+    view.dom.classList.toggle('meo-live-reading', reading);
+    view.dom.classList.toggle('meo-active-line-highlight-hidden', reading);
+  };
+  const reconfigureReadingState = () => {
+    if (!view) {
+      return;
+    }
+    const reading = isReadingLive();
+    view.dispatch({
+      effects: [
+        readingCompartment.reconfigure(readingExtensions(reading)),
+        activeLineHighlightCompartment.reconfigure(activeLineHighlightExtensions(!reading))
+      ]
+    });
+    syncReadingPresentation();
+  };
   let lastSearchStateSignature = '';
   // External syncs may carry stale selections in their history entries.
   // Preserve the user's current cursor once on the next undo of such a change.
@@ -1479,8 +1528,8 @@ export function createEditor({
       lineNumbers(),
       ...gitDiffGutterBaselineExtensions(),
       gitGutterCompartment.of(startMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()),
-      highlightActiveLineGutter(),
-      highlightActiveLine(),
+      readingCompartment.of(readingExtensions(startMode === 'live' && liveReadOnlyEnabled)),
+      activeLineHighlightCompartment.of(activeLineHighlightExtensions(!(startMode === 'live' && liveReadOnlyEnabled))),
       shikiCodeHighlight,
       EditorView.lineWrapping,
       scrollPastEnd(),
@@ -1747,6 +1796,7 @@ export function createEditor({
   syncLineNumbersVisibility();
   syncGitGutterVisibility();
   syncSelectionClass();
+  syncReadingPresentation();
   view.dispatch({ effects: setDiagnosticsEffect.of(currentDiagnostics) });
   emitSelectionChange();
 
@@ -1892,6 +1942,7 @@ export function createEditor({
     setText(textValue) {
       gitBlameHover?.hide();
       clearDiagnosticSuggestionState();
+      commitActiveTableInput();
       const currentText = view.state.doc.toString();
       const syncChange = findSyncChange(currentText, textValue);
       if (!syncChange) {
@@ -1903,12 +1954,16 @@ export function createEditor({
       const mappedAnchor = Math.min(mapPositionThroughChange(anchor, syncChange), newLength);
       const mappedHead = Math.min(mapPositionThroughChange(head, syncChange), newLength);
       applyingExternal = true;
-      view.dispatch({
-        changes: syncChange,
-        selection: { anchor: mappedAnchor, head: mappedHead }
-      });
-      applyingExternal = false;
-      pendingExternalUndoSelectionPreserve = true;
+      try {
+        view.dispatch({
+          changes: syncChange,
+          selection: { anchor: mappedAnchor, head: mappedHead },
+          annotations: meoExternalSyncAnnotation.of(true)
+        });
+        pendingExternalUndoSelectionPreserve = true;
+      } finally {
+        applyingExternal = false;
+      }
       syncSelectionClass();
       emitSelectionChange();
     },
@@ -1926,13 +1981,16 @@ export function createEditor({
       const previousMode = currentMode;
       currentMode = nextMode;
       try {
+        const reading = nextMode === 'live' && liveReadOnlyEnabled;
         view.dispatch({
           effects: [
             modeCompartment.reconfigure(nextMode === 'live' ? liveModeExtensions() : sourceMode()),
             gitGutterCompartment.reconfigure(
               nextMode === 'live' ? gitDiffGutterLiveRenderExtensions() : gitDiffGutterRenderExtensions()
             ),
-            vimCompartment.reconfigure(vimExtensionsForState())
+            vimCompartment.reconfigure(vimExtensionsForState()),
+            readingCompartment.reconfigure(readingExtensions(reading)),
+            activeLineHighlightCompartment.reconfigure(activeLineHighlightExtensions(!reading))
           ]
         });
         forceParsing(view, view.state.doc.length, 500);
@@ -1943,8 +2001,27 @@ export function createEditor({
       }
       syncModeClasses();
       syncGitGutterVisibility();
+      syncReadingPresentation();
 
       restoreTopVisibleLine(topPosition.lineNumber, topPosition.lineOffset, { syncCursor: false });
+    },
+    setLiveReadOnly(enabled) {
+      const nextEnabled = enabled === true;
+      if (nextEnabled === liveReadOnlyEnabled) {
+        syncReadingPresentation();
+        return;
+      }
+      liveReadOnlyEnabled = nextEnabled;
+      if (liveReadOnlyEnabled) {
+        commitActiveTableInput();
+      }
+      reconfigureReadingState();
+    },
+    isLiveReadOnly() {
+      return liveReadOnlyEnabled;
+    },
+    isReadingLive() {
+      return isReadingLive();
     },
     setLineNumbers(visible) {
       const nextVisible = visible !== false;
@@ -1985,6 +2062,9 @@ export function createEditor({
       }
     },
     insertFormat(action, level) {
+      if (isReadingLive()) {
+        return;
+      }
       const activeTableInput = getActiveTableInput();
       if (activeTableInput) {
         return insertFormatInActiveTableInput(activeTableInput, action);

--- a/webview/src/helpers/tables.ts
+++ b/webview/src/helpers/tables.ts
@@ -1,6 +1,7 @@
 import { StateField } from '@codemirror/state';
 import { syntaxTree } from '@codemirror/language';
 import { Decoration, EditorView, WidgetType } from '@codemirror/view';
+import { isLiveReadingMode } from '../liveMode';
 import { undo, redo } from '@codemirror/commands';
 import { ImageWidget } from './images';
 import { emojiData } from './emoji';
@@ -1584,6 +1585,10 @@ class HtmlTableWidget extends WidgetType {
   }
 
   focusCellInput(cell, { updateSelection = false } = {}) {
+    if (this.view && isLiveReadingMode(this.view.state)) {
+      return false;
+    }
+
     const input = cell.querySelector('textarea');
     if (!this.focusTableInput(input)) return false;
     if (!updateSelection) return true;
@@ -1927,6 +1932,7 @@ class HtmlTableWidget extends WidgetType {
   }
 
   commit(dom) {
+    if (this.view && isLiveReadingMode(this.view.state)) return;
     if (!this.hasPendingCellEdits) return;
     this.commitMatrix(this.readCellMatrix(), dom);
   }

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -1,4 +1,4 @@
-import { createElement, Heading, Heading1, Heading2, Heading3, Heading4, Heading5, Heading6, List, ListOrdered, ListTodo, ListTree, Hash, Code, Terminal, Quote, Minus, Table2, Link, Brackets, Image, Bold, Italic, Strikethrough, Search, Share, GitCompare, PanelLeftRightDashed, SpellCheck2 } from 'lucide';
+import { createElement, Heading, Heading1, Heading2, Heading3, Heading4, Heading5, Heading6, List, ListOrdered, ListTodo, ListTree, Hash, Code, Terminal, Quote, Minus, Table2, Link, Brackets, Image, Bold, Italic, Strikethrough, Search, Share, GitCompare, PanelLeftRightDashed, SpellCheck2, BookOpen } from 'lucide';
 import { setImageSrcResolver, initializeImageHandling, resolveImageSrc, settleImageSrcRequest, handleSavedImagePath, handleImagePaste } from './helpers/images';
 import { createGitClient } from './helpers/gitClient';
 import { createOutlineController } from './helpers/outline';
@@ -150,6 +150,7 @@ let vimKeybindingsState: VimKeybinding[] = [];
 let vimLeaderState = '\\';
 
 let lineNumbersVisible = true;
+let liveReadOnlyEnabled = false;
 let gitChangesGutterVisible = true;
 let gitDiffLineHighlightsEnabled = true;
 let spellCheckEnabled = true;
@@ -239,6 +240,43 @@ const setLineNumbersVisible = (visible, { post = true } = {}) => {
   updateLineNumbersUI();
   if (post && changed) {
     vscode.postMessage({ type: 'setLineNumbers', visible: lineNumbersVisible });
+  }
+};
+
+const isReadingLive = () => currentMode === 'live' && liveReadOnlyEnabled;
+
+const updateLiveReadOnlyUI = () => {
+  const reading = isReadingLive();
+  liveReadOnlyBtn.classList.toggle('is-active', liveReadOnlyEnabled);
+  liveReadOnlyBtn.setAttribute('aria-pressed', liveReadOnlyEnabled ? 'true' : 'false');
+  liveReadOnlyBtn.title = liveReadOnlyEnabled
+    ? 'Live read-only on (reading view). Click to allow Live editing.'
+    : 'Live read-only off. Click for a reading view without edit chrome.';
+  liveButton.textContent = liveReadOnlyEnabled ? 'Live · Read' : 'Live';
+  liveButton.title = liveReadOnlyEnabled ? 'Live (read-only reading view)' : 'Live';
+  root.classList.toggle('meo-live-reading', reading);
+  root.dataset.liveReadonly = liveReadOnlyEnabled ? 'true' : 'false';
+  formatGroup.classList.toggle('is-disabled', reading);
+  formatGroup.setAttribute('aria-disabled', reading ? 'true' : 'false');
+  for (const button of formatGroup.querySelectorAll('button')) {
+    if (button instanceof HTMLButtonElement) {
+      button.disabled = reading;
+    }
+  }
+  selectionMenuController?.hide?.();
+};
+
+const setLiveReadOnlyEnabled = (enabled: boolean, { post = true } = {}) => {
+  const nextEnabled = enabled === true;
+  const changed = nextEnabled !== liveReadOnlyEnabled;
+  liveReadOnlyEnabled = nextEnabled;
+  if (changed || editor) {
+    editor?.setLiveReadOnly?.(liveReadOnlyEnabled);
+  }
+  updateLiveReadOnlyUI();
+  updateModeUI();
+  if (post && changed) {
+    vscode.postMessage({ type: 'setLiveReadOnly', enabled: liveReadOnlyEnabled });
   }
 };
 
@@ -439,7 +477,7 @@ tableGrid.addEventListener('mouseleave', () => {
 
 tableGrid.addEventListener('click', (event) => {
   const cell = (event.target as Element).closest('.table-grid-cell') as HTMLElement | null;
-  if (!cell || !editor) return;
+  if (!cell || !editor || isReadingLive()) return;
   editor.insertFormat('table', { cols: selectedTableCols, rows: selectedTableRows });
   editor.focus();
 });
@@ -516,13 +554,33 @@ sourceButton.textContent = 'Source';
 sourceButton.setAttribute('role', 'tab');
 sourceButton.title = 'Source';
 
-modeGroup.append(liveButton, sourceButton);
+const liveReadOnlyBtn = document.createElement('button');
+liveReadOnlyBtn.type = 'button';
+liveReadOnlyBtn.className = 'format-button toggle-button mode-readonly-button';
+liveReadOnlyBtn.dataset.action = 'liveReadOnly';
+liveReadOnlyBtn.title = 'Toggle Live read-only (reading view)';
+liveReadOnlyBtn.setAttribute('aria-label', 'Toggle Live read-only reading view');
+liveReadOnlyBtn.setAttribute('aria-pressed', 'false');
+liveReadOnlyBtn.appendChild(createElement(BookOpen, { width: 18, height: 18 }));
+
+modeGroup.append(liveButton, sourceButton, liveReadOnlyBtn);
+liveReadOnlyBtn.addEventListener('click', () => {
+  setLiveReadOnlyEnabled(!liveReadOnlyEnabled, { post: true });
+});
 
 const findPanelElements = createFindPanel(findToggleBtn);
 const findPanelController = createFindPanelController(findPanelElements, () => editor, toolbar, modeGroup);
 
 const selectionMenuElements = createSelectionMenu();
 const selectionMenuController = createSelectionMenuController(selectionMenuElements, () => editor);
+const originalSelectionMenuUpdate = selectionMenuController.update.bind(selectionMenuController);
+selectionMenuController.update = (state: any) => {
+  if (isReadingLive()) {
+    selectionMenuController.hide();
+    return;
+  }
+  originalSelectionMenuUpdate(state);
+};
 
 const editorNoticeBanner = document.createElement('div');
 editorNoticeBanner.className = 'editor-notice';
@@ -932,6 +990,10 @@ const applyRevealSelectionFromHost = (revealMessage: any) => {
 };
 
 const focusEditorFromHost = () => {
+  if (isReadingLive()) {
+    pendingEditorFocus = false;
+    return;
+  }
   if (!editor) {
     pendingEditorFocus = true;
     return;
@@ -1117,6 +1179,9 @@ const shortcutHandlerContext: ShortcutHandlerContext = {
 };
 
 const queueChanges = (nextText: string) => {
+  if (isReadingLive()) {
+    return;
+  }
   bumpLocalEditGeneration();
   pendingText = nextText;
   syncPendingDraftState();
@@ -1147,6 +1212,7 @@ const updateModeUI = () => {
     button.setAttribute('aria-selected', selected ? 'true' : 'false');
     button.tabIndex = selected ? 0 : -1;
   }
+  updateLiveReadOnlyUI();
 };
 
 const applyMode = (mode: 'live' | 'source', { post = true, persist = true, userTriggered = false, reason = 'user' } = {}): boolean => {
@@ -1169,7 +1235,7 @@ const applyMode = (mode: 'live' | 'source', { post = true, persist = true, userT
     try {
       editor.setMode(mode);
       syncGitDiffLineHighlights();
-      if (shouldRestoreEditorFocus) {
+      if (shouldRestoreEditorFocus && !(mode === 'live' && liveReadOnlyEnabled)) {
         editor.focus();
       }
       if (mode === 'live') {
@@ -1246,6 +1312,7 @@ const mountInitialEditor = async () => {
       initialTopLine,
       initialTopLineOffset,
       initialLineNumbers: lineNumbersVisible,
+      initialLiveReadOnly: liveReadOnlyEnabled,
       initialGitGutter: gitChangesGutterVisible,
       initialVimMode: vimModeEnabled,
       initialVimKeybindings: vimKeybindingsState,
@@ -1367,6 +1434,9 @@ const handleInit = (message: any) => {
   }
   if (typeof message.lineNumbers === 'boolean') {
     setLineNumbersVisible(message.lineNumbers, { post: false });
+  }
+  if (typeof message.liveReadOnly === 'boolean') {
+    setLiveReadOnlyEnabled(message.liveReadOnly, { post: false });
   }
   if (typeof message.gitChangesGutter === 'boolean') {
     setGitChangesGutterVisible(message.gitChangesGutter, { post: false });
@@ -1502,6 +1572,16 @@ window.addEventListener('message', (event) => {
 
   if (message.type === 'toggleMode') {
     applyMode(currentMode === 'live' ? 'source' : 'live', { userTriggered: true, reason: 'command' });
+    return;
+  }
+
+  if (message.type === 'toggleLiveReadOnly') {
+    setLiveReadOnlyEnabled(!liveReadOnlyEnabled, { post: true });
+    return;
+  }
+
+  if (message.type === 'liveReadOnlyChanged') {
+    setLiveReadOnlyEnabled(message.enabled === true, { post: false });
     return;
   }
 
@@ -1859,6 +1939,7 @@ modeGroup.addEventListener('pointerdown', preserveEditorFocusOnModePointerToggle
 
 const handleFormatAction = (action: string) => {
   if (!editor) return;
+  if (isReadingLive()) return;
   editor.insertFormat(action);
   editor.focus();
 };
@@ -1956,6 +2037,7 @@ headingDropdown.addEventListener('click', (event) => {
   const option = (event.target as Element).closest('.heading-dropdown-option') as HTMLElement | null;
   if (!option || !editor) return;
   const level = parseInt(option.dataset.level ?? '', 10);
+  if (isReadingLive()) return;
   editor.insertFormat('heading', level);
   editor.focus();
 });

--- a/webview/src/liveMode.ts
+++ b/webview/src/liveMode.ts
@@ -1,4 +1,4 @@
-import { RangeSetBuilder, StateField, EditorState } from '@codemirror/state';
+import { RangeSetBuilder, StateField, EditorState, Facet } from '@codemirror/state';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
 import { syntaxHighlighting } from '@codemirror/language';
 import { Decoration, EditorView, GutterMarker, WidgetType, gutterLineClass } from '@codemirror/view';
@@ -885,7 +885,18 @@ function addSingleTildeStrikeDecorations(builder, state, activeLines, existingSt
   }
 }
 
+
+/** When true, Live mode stays fully rendered (no active-line source reveal) and is non-editable. */
+export const liveReadingFacet = Facet.define<boolean, boolean>({
+  combine: (values) => values.some(Boolean)
+});
+
+export const isLiveReadingMode = (state: EditorState): boolean => state.facet(liveReadingFacet);
+
 function collectActiveLines(state: EditorState): Set<number> {
+  if (isLiveReadingMode(state)) {
+    return new Set();
+  }
   const lines = new Set<number>();
   for (const range of state.selection.ranges) {
     // In live mode, only reveal markdown markers on the focused line.

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2977,3 +2977,37 @@ body {
 .cm-editor.meo-mode-live .cm-line.meo-md-alert .meo-md-alert-label-active {
   color: var(--meo-color-base05) !important;
 }
+
+
+/* Live read-only reading view */
+.cm-editor.meo-active-line-highlight-hidden .cm-activeLine,
+.cm-editor.meo-active-line-highlight-hidden .cm-activeLine.meo-md-code-block,
+.cm-editor.meo-mode-live.meo-active-line-highlight-hidden .cm-activeLine.meo-md-code-block {
+  background-color: transparent;
+}
+
+.cm-editor.meo-active-line-highlight-hidden .cm-gutterElement.cm-activeLineGutter {
+  background: transparent !important;
+}
+
+.editor-root.meo-live-reading .format-group.is-disabled,
+.editor-root.meo-live-reading .format-group[aria-disabled='true'] {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.editor-root.meo-live-reading .selection-inline-menu {
+  display: none !important;
+}
+
+.editor-root.meo-live-reading .cm-editor.meo-live-reading .meo-table-add-row-btn,
+.editor-root.meo-live-reading .meo-table-add-col-btn,
+.editor-root.meo-live-reading .meo-md-html-table-cell-content textarea,
+.cm-editor.meo-live-reading .meo-table-add-row-btn,
+.cm-editor.meo-live-reading .meo-table-add-col-btn {
+  pointer-events: none !important;
+}
+
+.mode-group .mode-readonly-button.is-active {
+  color: var(--vscode-button-foreground, inherit);
+}

--- a/webview/src/types.d.ts
+++ b/webview/src/types.d.ts
@@ -15,6 +15,7 @@ type WebviewMessage =
   | { type: 'setGitChangesGutter'; visible: boolean }
   | { type: 'setSpellCheck'; enabled: boolean }
   | { type: 'setContentMaxWidth'; enabled: boolean }
+  | { type: 'setLiveReadOnly'; enabled: boolean }
   | { type: 'setOutlineVisible'; visible: boolean }
   | { type: 'setFindOptions'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }
   | { type: 'viewPositionChanged'; topLine: number; topLineOffset?: number }
@@ -37,7 +38,7 @@ type VimKeybinding = {
 };
 
 type ExtensionMessage =
-  | { type: 'init'; text: string; version: number; diagnostics: EditorDiagnostic[]; theme: ThemeSettings; mode: 'live' | 'source'; outlinePosition: 'left' | 'right'; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; spellCheckEnabled: boolean; contentMaxWidthEnabled: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number }
+  | { type: 'init'; text: string; version: number; diagnostics: EditorDiagnostic[]; theme: ThemeSettings; mode: 'live' | 'source'; outlinePosition: 'left' | 'right'; outlineVisible: boolean; lineNumbers: boolean; liveReadOnly: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; spellCheckEnabled: boolean; contentMaxWidthEnabled: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number }
   | { type: 'docChanged'; text: string; version: number }
   | { type: 'applied'; version: number }
   | { type: 'focusEditor' }
@@ -51,6 +52,8 @@ type ExtensionMessage =
   | { type: 'gitDiffLineHighlightsChanged'; enabled: boolean }
   | { type: 'spellCheckChanged'; enabled: boolean }
   | { type: 'contentMaxWidthChanged'; enabled: boolean }
+  | { type: 'liveReadOnlyChanged'; enabled: boolean }
+  | { type: 'toggleLiveReadOnly' }
   | { type: 'vimModeChanged'; enabled: boolean }
   | { type: 'vimKeybindingsChanged'; keybindings: VimKeybinding[]; leaderKey: string }
   | { type: 'findOptionsChanged'; findOptions: { wholeWord: boolean; caseSensitive: boolean } }


### PR DESCRIPTION
Reading in Live currently reveals Markdown when the user clicks or selects text. This adds a Read Only lock beside Spell Check so the document stays rendered while reading. Live and Source retain their existing labels, and the lock remains active when switching between them.

The lock defaults to off and is remembered per document in the workspace. The toolbar button and the Toggle Read Only command control the current document. Typing, formatting, replacement, task changes, table edits, and outline rearrangement are blocked. Selection, copying rendered text, navigation, search, and external document updates remain available. Toggling preserves the viewport and commits an active table edit before locking.

The branch includes current main and resolves conflicts with recent keymap, table, and external-sync changes. Read-only transaction handling and rendered selection copying live in a focused helper.

Validation:
- `bun run typecheck:webview` passed.
- `bun run build` passed, rebuilding the shipped webview and extension bundles.
- Chromium checks against the built webview with a simulated VS Code message bridge verified toolbar placement, unchanged mode labels, locked Live and Source typing, inactive table editing, disabled outline dragging, selection and copying across rendered content, external document updates, and editing after unlocking. Visually inspected the rendered toolbar and document.
- `git diff --check` passed.
- Extension-wide `tsc --noEmit` reports five existing errors, reproduced on unchanged main, in PDF export globals, markdown-it-emoji typings, a Thenable/Promise mismatch, and git blame result narrowing.

Closes #71
