### PR TITLE
fix: harden external document sync and recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Markdown Editor Optimized (MEO)
 ---
+## Unreleased
+- Hardened external document sync (git/LLM/outside editors): prefer host content on conflict, fix stuck applyingExternal, Reload recovery
+- Avoid silent local-draft overwrite of external writes; surface appliedFailed + requestReload paths
+
 ## 0.1.26
 - Improved dark Mermaid diagram line contrast
 - Fixed live find matches and preserve active highlight

--- a/src/extension/panelSession.ts
+++ b/src/extension/panelSession.ts
@@ -81,6 +81,12 @@ type AppliedMessage = {
   version: number;
 };
 
+type AppliedFailedMessage = {
+  type: 'appliedFailed';
+  text: string;
+  version: number;
+};
+
 type RevealSelectionMessage = {
   type: 'revealSelection';
   anchor: number;
@@ -138,6 +144,10 @@ type ResolveLocalLinksMessage = {
 
 type SaveDocumentMessage = {
   type: 'saveDocument';
+};
+
+type RequestReloadMessage = {
+  type: 'requestReload';
 };
 
 type ExportDocumentMessage = {
@@ -318,6 +328,7 @@ type WebviewMessage =
   | ResolveWikiLinksMessage
   | ResolveLocalLinksMessage
   | SaveDocumentMessage
+  | RequestReloadMessage
   | ExportDocumentMessage
   | ExportSnapshotMessage
   | ExportSnapshotErrorMessage
@@ -418,6 +429,9 @@ export function createPanelSessionController(params: PanelSessionControllerParam
   let webviewReady = false;
   let initDelivered = false;
   let isApplyingOwnChange = false;
+  let applyGeneration = 0;
+  let lastAppliedNormalizedText: string | null = null;
+  let lastAppliedAtMs = 0;
   let gitRefreshRunning = false;
   let gitRefreshPending = false;
   let gitRefreshPendingForcePost = false;
@@ -616,6 +630,31 @@ export function createPanelSessionController(params: PanelSessionControllerParam
       version
     };
     return postToWebview(message);
+  };
+
+  const sendAppliedFailed = async (): Promise<boolean> => {
+    const message: AppliedFailedMessage = {
+      type: 'appliedFailed',
+      text: document.getText(),
+      version: document.version
+    };
+    return postToWebview(message);
+  };
+
+  const noteOwnAppliedText = (): void => {
+    lastAppliedNormalizedText = document.getText().replace(/\r\n/g, '\n');
+    lastAppliedAtMs = Date.now();
+  };
+
+  const isLikelyEchoOfOwnApply = (eventDocument: vscode.TextDocument): boolean => {
+    if (!lastAppliedNormalizedText) {
+      return false;
+    }
+    if (Date.now() - lastAppliedAtMs > 750) {
+      return false;
+    }
+    const incoming = eventDocument.getText().replace(/\r\n/g, '\n');
+    return incoming === lastAppliedNormalizedText;
   };
 
   const sendGitBaselineChanged = async (options: RefreshGitBaselineOptions = {}): Promise<boolean> => {
@@ -1077,12 +1116,23 @@ export function createPanelSessionController(params: PanelSessionControllerParam
       case 'applyChanges':
         agentReviewHandoff.noteRecentMEOOwnedFileChangeForUri(document.uri);
         isApplyingOwnChange = true;
+        applyGeneration += 1;
+        const applyGen = applyGeneration;
         try {
           await enqueue(async () => {
-            await applyDocumentChanges(document, raw, sendDocChanged, sendApplied);
+            await applyDocumentChanges(
+              document,
+              raw,
+              sendDocChanged,
+              sendApplied,
+              sendAppliedFailed,
+              noteOwnAppliedText
+            );
           });
         } finally {
-          isApplyingOwnChange = false;
+          if (applyGen === applyGeneration) {
+            isApplyingOwnChange = false;
+          }
         }
         return;
       case 'draftChanged':
@@ -1090,10 +1140,13 @@ export function createPanelSessionController(params: PanelSessionControllerParam
         return;
       case 'saveDocument':
         isApplyingOwnChange = true;
+        applyGeneration += 1;
+        const saveGen = applyGeneration;
         try {
           await enqueue(async () => {
             const appliedDraft = await applyPendingDraftIfNeeded();
             if (appliedDraft) {
+              noteOwnAppliedText();
               await sendDocChanged();
             } else if (pendingDraftText !== null) {
               await sendDocChanged();
@@ -1102,8 +1155,21 @@ export function createPanelSessionController(params: PanelSessionControllerParam
             await document.save();
           });
         } finally {
-          isApplyingOwnChange = false;
+          if (saveGen === applyGeneration) {
+            isApplyingOwnChange = false;
+          }
         }
+        return;
+      case 'requestReload':
+        await enqueue(async () => {
+          // Force a full re-init payload so the webview can hard-recover.
+          initDelivered = false;
+          webviewReady = true;
+          await ensureInitDelivered();
+          if (initDelivered) {
+            await sendDocChanged();
+          }
+        });
         return;
       case 'saveImageFromClipboard': {
         const response = await handleSaveImageFromClipboard(raw, documentUri);
@@ -1135,6 +1201,11 @@ export function createPanelSessionController(params: PanelSessionControllerParam
     scheduleSpellCheck();
 
     if (isApplyingOwnChange) {
+      return;
+    }
+
+    // Drop short-lived echoes of our own successful applyEdit (race after flag cleared).
+    if (isLikelyEchoOfOwnApply(event.document)) {
       return;
     }
 
@@ -1322,7 +1393,9 @@ async function applyDocumentChanges(
   document: vscode.TextDocument,
   message: ApplyChangesMessage,
   sendDocChanged: () => Promise<boolean>,
-  sendApplied: (version: number) => Promise<boolean>
+  sendApplied: (version: number) => Promise<boolean>,
+  sendAppliedFailed: () => Promise<boolean>,
+  noteOwnAppliedText: () => void
 ): Promise<void> {
   if (message.baseVersion !== document.version) {
     await sendDocChanged();
@@ -1359,10 +1432,11 @@ async function applyDocumentChanges(
   const applied = await vscode.workspace.applyEdit(edit);
 
   if (!applied) {
-    await sendDocChanged();
+    await sendAppliedFailed();
     return;
   }
 
+  noteOwnAppliedText();
   await sendApplied(document.version);
 }
 

--- a/webview/src/editor.ts
+++ b/webview/src/editor.ts
@@ -1892,6 +1892,8 @@ export function createEditor({
     setText(textValue) {
       gitBlameHover?.hide();
       clearDiagnosticSuggestionState();
+      // Commit widget editors (tables) before replacing the underlying doc.
+      commitActiveTableInput();
       const currentText = view.state.doc.toString();
       const syncChange = findSyncChange(currentText, textValue);
       if (!syncChange) {
@@ -1903,12 +1905,17 @@ export function createEditor({
       const mappedAnchor = Math.min(mapPositionThroughChange(anchor, syncChange), newLength);
       const mappedHead = Math.min(mapPositionThroughChange(head, syncChange), newLength);
       applyingExternal = true;
-      view.dispatch({
-        changes: syncChange,
-        selection: { anchor: mappedAnchor, head: mappedHead }
-      });
-      applyingExternal = false;
-      pendingExternalUndoSelectionPreserve = true;
+      try {
+        view.dispatch({
+          changes: syncChange,
+          selection: { anchor: mappedAnchor, head: mappedHead }
+        });
+        pendingExternalUndoSelectionPreserve = true;
+      } finally {
+        // If dispatch throws (live decorations/plugins), never leave this stuck true —
+        // otherwise user edits stop calling onApplyChanges and silently never reach the host.
+        applyingExternal = false;
+      }
       syncSelectionClass();
       emitSelectionChange();
     },

--- a/webview/src/helpers/errors.ts
+++ b/webview/src/helpers/errors.ts
@@ -48,14 +48,17 @@ export const logWebviewRenderError = (context: string, error: unknown, extra: Re
 export interface FailureNoticeState {
   message: string;
   kind: string;
+  showReload: boolean;
 }
 
 export const createFailureNoticeManager = (notice: EditorNotice) => {
-  let failureNotice: FailureNoticeState = { message: '', kind: 'error' };
+  let failureNotice: FailureNoticeState = { message: '', kind: 'error', showReload: false };
 
   const updateEditorNotice = () => {
     if (failureNotice.message) {
-      notice.setEditorNotice(failureNotice.message, failureNotice.kind);
+      notice.setEditorNotice(failureNotice.message, failureNotice.kind, {
+        showReload: failureNotice.showReload
+      });
       return;
     }
     notice.clearEditorNotice();
@@ -66,11 +69,7 @@ export const createFailureNoticeManager = (notice: EditorNotice) => {
     kind: 'error' | 'warning' = 'error',
     options?: { showReload?: boolean }
   ): void => {
-    failureNotice = { message, kind };
-    if (options?.showReload) {
-      notice.setEditorNotice(message, kind, { showReload: true });
-      return;
-    }
+    failureNotice = { message, kind, showReload: options?.showReload === true };
     updateEditorNotice();
   };
 
@@ -78,7 +77,7 @@ export const createFailureNoticeManager = (notice: EditorNotice) => {
     if (!failureNotice.message) {
       return;
     }
-    failureNotice = { message: '', kind: 'error' };
+    failureNotice = { message: '', kind: 'error', showReload: false };
     updateEditorNotice();
   };
 

--- a/webview/src/helpers/errors.ts
+++ b/webview/src/helpers/errors.ts
@@ -1,8 +1,10 @@
 const liveModeFailureNoticeMessage = 'Live mode failed to render this document. Switched to Source mode.';
 const editorUpdateFailureNoticeMessage = 'Editor failed to update this document. Try reopening the file.';
+const externalSyncConflictNoticeMessage = 'Document changed outside the editor. Showing host content. Your unsaved MEO buffer was discarded from the view (use Undo if needed).';
+const externalSyncAdoptFailureNoticeMessage = 'Could not apply an external document update. Reload from the host document or reopen the file.';
 
 export interface EditorNotice {
-  setEditorNotice: (message: string, kind?: string) => void;
+  setEditorNotice: (message: string, kind?: string, options?: { showReload?: boolean }) => void;
   clearEditorNotice: () => void;
 }
 
@@ -59,8 +61,16 @@ export const createFailureNoticeManager = (notice: EditorNotice) => {
     notice.clearEditorNotice();
   };
 
-  const setFailureNotice = (message: string, kind: 'error' | 'warning' = 'error'): void => {
+  const setFailureNotice = (
+    message: string,
+    kind: 'error' | 'warning' = 'error',
+    options?: { showReload?: boolean }
+  ): void => {
     failureNotice = { message, kind };
+    if (options?.showReload) {
+      notice.setEditorNotice(message, kind, { showReload: true });
+      return;
+    }
     updateEditorNotice();
   };
 
@@ -80,7 +90,9 @@ export const createFailureNoticeManager = (notice: EditorNotice) => {
     hasFailureNotice,
     updateEditorNotice,
     get liveModeFailureMessage() { return liveModeFailureNoticeMessage; },
-    get editorUpdateFailureMessage() { return editorUpdateFailureNoticeMessage; }
+    get editorUpdateFailureMessage() { return editorUpdateFailureNoticeMessage; },
+    get externalSyncConflictMessage() { return externalSyncConflictNoticeMessage; },
+    get externalSyncAdoptFailureMessage() { return externalSyncAdoptFailureNoticeMessage; }
   };
 };
 

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -560,6 +560,9 @@ let syncedText = '';
 let inFlight = false;
 let inFlightText: string | null = null;
 let saveAfterSync = false;
+/** Last host text/version we know about when setText adopt fails (for Reload). */
+let hostAuthoritativeText: string | null = null;
+let hostAuthoritativeVersion: number | null = null;
 let currentMode: 'live' | 'source' = 'live';
 let hasLocalModePreference = false;
 let pendingInitialText: string | null = null;
@@ -627,23 +630,44 @@ toolbarAlignmentResizeObserver.observe(editorWrapper);
 toolbarAlignmentResizeObserver.observe(editorHost);
 window.addEventListener('resize', scheduleSingleToolbarTextAlignment);
 
-const setEditorNotice = (message: string, kind = 'info') => {
+const setEditorNotice = (message: string, kind = 'info', options?: { showReload?: boolean }) => {
   const normalizedMessage = `${message ?? ''}`.trim();
   if (!normalizedMessage) {
     clearEditorNotice();
     return;
   }
-  editorNoticeBanner.textContent = normalizedMessage;
+  editorNoticeBanner.replaceChildren();
+  const messageEl = document.createElement('span');
+  messageEl.className = 'editor-notice-message';
+  messageEl.textContent = normalizedMessage;
+  editorNoticeBanner.appendChild(messageEl);
+  if (options?.showReload) {
+    const reloadBtn = document.createElement('button');
+    reloadBtn.type = 'button';
+    reloadBtn.className = 'editor-notice-action';
+    reloadBtn.textContent = 'Reload';
+    reloadBtn.title = 'Reload editor content from the VS Code document';
+    reloadBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void reloadEditorFromHost('notice-reload');
+    });
+    editorNoticeBanner.appendChild(reloadBtn);
+  }
   editorNoticeBanner.dataset.kind = kind;
   editorNoticeBanner.hidden = false;
   editorNoticeBanner.classList.add('is-visible');
+  // Allow clicking Reload; keep the banner non-blocking for the rest of the UI.
+  editorNoticeBanner.style.pointerEvents = options?.showReload ? 'auto' : 'none';
 };
 
 const clearEditorNotice = () => {
+  editorNoticeBanner.replaceChildren();
   editorNoticeBanner.textContent = '';
   delete editorNoticeBanner.dataset.kind;
   editorNoticeBanner.hidden = true;
   editorNoticeBanner.classList.remove('is-visible');
+  editorNoticeBanner.style.pointerEvents = 'none';
 };
 
 const editorNotice: EditorNotice = {
@@ -1094,14 +1118,69 @@ const setEditorTextSafely = (text: string, context: string): boolean => {
         return true;
       } catch (retryError) {
         logWebviewRenderError('setText.retryInSource', retryError, { context });
-        failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
+        failureNotice.setFailureNotice(failureNotice.externalSyncAdoptFailureMessage, 'error', { showReload: true });
         return false;
       }
     }
 
-    failureNotice.setFailureNotice(failureNotice.editorUpdateFailureMessage, 'error');
+    failureNotice.setFailureNotice(failureNotice.externalSyncAdoptFailureMessage, 'error', { showReload: true });
     return false;
   }
+};
+
+const rememberHostAuthoritative = (text: string, version: number): void => {
+  hostAuthoritativeText = text;
+  hostAuthoritativeVersion = version;
+};
+
+const clearHostAuthoritative = (): void => {
+  hostAuthoritativeText = null;
+  hostAuthoritativeVersion = null;
+};
+
+const adoptHostText = (rawText: string, version: number, context: string): boolean => {
+  commitEditorTransientEdits();
+  rememberHostAuthoritative(rawText, version);
+
+  if (pendingDebounce !== null) {
+    window.clearTimeout(pendingDebounce);
+    pendingDebounce = null;
+  }
+
+  // Do not advance syncedText / clear drafts until the editor successfully shows host text.
+  const adopted = setEditorTextSafely(rawText, context);
+  if (!adopted) {
+    failureNotice.setFailureNotice(failureNotice.externalSyncAdoptFailureMessage, 'error', { showReload: true });
+    return false;
+  }
+
+  documentVersion = version;
+  syncedText = normalizeEol(rawText);
+  pendingText = null;
+  inFlight = false;
+  inFlightText = null;
+  saveAfterSync = false;
+  clearHostAuthoritative();
+  failureNotice.clearFailureNotice();
+  syncPendingDraftState();
+  scheduleWikiLinkStatusRefresh(rawText);
+  scheduleLocalLinkStatusRefresh(rawText);
+  findPanelController.updateFindStatusSummary();
+  return true;
+};
+
+const reloadEditorFromHost = async (reason: string): Promise<void> => {
+  const snapshotText = hostAuthoritativeText;
+  const snapshotVersion = hostAuthoritativeVersion;
+
+  if (typeof snapshotText === 'string' && typeof snapshotVersion === 'number') {
+    if (adoptHostText(snapshotText, snapshotVersion, `reload.${reason}`)) {
+      return;
+    }
+  }
+
+  // Ask host for a fresh init/doc snapshot.
+  vscode.postMessage({ type: 'requestReload' });
 };
 
 const shortcutHandlerContext: ShortcutHandlerContext = {
@@ -1442,6 +1521,7 @@ window.addEventListener('message', (event) => {
       setShikiTheme(message.codeTheme);
       initialMountRecoveryAttempted = false;
       failureNotice.clearFailureNotice();
+      clearHostAuthoritative();
       gitClient?.resetForInit({ hideTooltip: false });
       const nextMode = hasLocalModePreference ? currentMode : message.mode;
       documentVersion = message.version;
@@ -1521,10 +1601,11 @@ window.addEventListener('message', (event) => {
     const inFlightNormalized = inFlightText === null ? null : normalizeEol(inFlightText);
     const localDraftText = pendingText ?? inFlightText;
     const localDraftNormalized = localDraftText === null ? null : normalizeEol(localDraftText);
+    const hostVersion = typeof message.version === 'number' ? message.version : documentVersion;
 
-    documentVersion = message.version;
-
+    // Echo of our own write (or editor already matches host).
     if (incomingText === currentText) {
+      documentVersion = hostVersion;
       syncedText = currentText;
 
       if (pendingNormalized === incomingText) {
@@ -1536,16 +1617,20 @@ window.addEventListener('message', (event) => {
         inFlightText = null;
       }
 
+      clearHostAuthoritative();
       flushChanges();
       maybeSaveAfterSync();
       syncPendingDraftState();
       return;
     }
 
+    // Host confirmed the in-flight full replace we just sent.
     if (inFlight && inFlightNormalized === incomingText) {
+      documentVersion = hostVersion;
       syncedText = incomingText;
       inFlight = false;
       inFlightText = null;
+      clearHostAuthoritative();
       flushChanges();
       maybeSaveAfterSync();
       syncPendingDraftState();
@@ -1553,51 +1638,51 @@ window.addEventListener('message', (event) => {
     }
 
     if (pendingNormalized === incomingText) {
+      documentVersion = hostVersion;
       syncedText = incomingText;
       pendingText = null;
       inFlight = false;
       inFlightText = null;
+      clearHostAuthoritative();
       flushChanges();
       maybeSaveAfterSync();
       syncPendingDraftState();
       return;
     }
 
+    // External host write while we still have a local draft that differs.
+    // Prefer host content so agents/git/outside editors win; do not silently
+    // force the local draft back over the host without painting the new text.
     if (localDraftText !== null && localDraftNormalized !== incomingText) {
-      syncedText = incomingText;
-      pendingText = localDraftText;
+      const hadLocalDraft = true;
       inFlight = false;
       inFlightText = null;
-
+      pendingText = null;
       if (pendingDebounce !== null) {
         window.clearTimeout(pendingDebounce);
         pendingDebounce = null;
       }
-
-      flushChanges();
-      maybeSaveAfterSync();
-      syncPendingDraftState();
+      const adopted = adoptHostText(message.text, hostVersion, 'docChanged.external-over-local');
+      if (adopted && hadLocalDraft) {
+        failureNotice.setFailureNotice(failureNotice.externalSyncConflictMessage, 'warning');
+      }
       return;
     }
 
-    syncedText = incomingText;
-    pendingText = null;
+    // Pure external update (no conflicting local draft).
+    adoptHostText(message.text, hostVersion, 'docChanged.external');
+    return;
+  }
+
+  if (message.type === 'appliedFailed') {
+    // Host rejected applyEdit — drop inFlight and re-sync from host payload if provided.
     inFlight = false;
     inFlightText = null;
-    saveAfterSync = false;
-
-    if (pendingDebounce !== null) {
-      window.clearTimeout(pendingDebounce);
-      pendingDebounce = null;
-    }
-
-    syncPendingDraftState();
-    if (!setEditorTextSafely(message.text, 'docChanged')) {
+    if (typeof message.text === 'string' && typeof message.version === 'number') {
+      adoptHostText(message.text, message.version, 'appliedFailed');
       return;
     }
-    scheduleWikiLinkStatusRefresh(message.text);
-    scheduleLocalLinkStatusRefresh(message.text);
-    findPanelController.updateFindStatusSummary();
+    vscode.postMessage({ type: 'requestReload' });
     return;
   }
 

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -1681,16 +1681,12 @@ window.addEventListener('message', (event) => {
     // Prefer host content so agents/git/outside editors win; do not silently
     // force the local draft back over the host without painting the new text.
     if (localDraftText !== null && localDraftNormalized !== incomingText) {
-      const hadLocalDraft = true;
-      inFlight = false;
-      inFlightText = null;
-      pendingText = null;
       if (pendingDebounce !== null) {
         window.clearTimeout(pendingDebounce);
         pendingDebounce = null;
       }
       const adopted = adoptHostText(message.text, hostVersion, 'docChanged.external-over-local');
-      if (adopted && hadLocalDraft) {
+      if (adopted) {
         failureNotice.setFailureNotice(failureNotice.externalSyncConflictMessage, 'warning');
       }
       return;

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -230,11 +230,36 @@ body {
   line-height: 1.4;
   z-index: 275;
   pointer-events: none;
+  align-items: center;
+  gap: 10px;
 }
 
 .editor-notice.is-visible {
-  display: block;
+  display: flex;
 }
+
+.editor-notice-message {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.editor-notice-action {
+  flex: 0 0 auto;
+  appearance: none;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.editor-notice-action:hover {
+  filter: brightness(1.08);
+}
+
 
 .editor-notice[data-kind='warning'] {
   border-color: var(--vscode-inputValidation-warningBorder, #b89500);

--- a/webview/src/types.d.ts
+++ b/webview/src/types.d.ts
@@ -24,6 +24,7 @@ type WebviewMessage =
   | { type: 'resolveLocalLinks'; requestId: string; targets: string[] }
   | { type: 'requestDiagnosticSuggestions'; requestId: string; from: number; to: number; message: string; source?: string; code?: string }
   | { type: 'saveDocument' }
+  | { type: 'requestReload' }
   | { type: 'exportDocument'; format: 'html' | 'pdf' }
   | { type: 'exportSnapshot'; requestId: string; text: string; environment?: Record<string, unknown> }
   | { type: 'exportSnapshotError'; requestId: string; error: string; message?: string }
@@ -40,6 +41,7 @@ type ExtensionMessage =
   | { type: 'init'; text: string; version: number; diagnostics: EditorDiagnostic[]; theme: ThemeSettings; mode: 'live' | 'source'; outlinePosition: 'left' | 'right'; outlineVisible: boolean; lineNumbers: boolean; gitChangesGutter: boolean; gitDiffLineHighlights: boolean; spellCheckEnabled: boolean; contentMaxWidthEnabled: boolean; vimMode: boolean; vimKeybindings: VimKeybinding[]; vimLeader: string; findOptions: { wholeWord: boolean; caseSensitive: boolean }; restoreTopLine?: number; restoreTopLineOffset?: number }
   | { type: 'docChanged'; text: string; version: number }
   | { type: 'applied'; version: number }
+  | { type: 'appliedFailed'; text?: string; version?: number }
   | { type: 'focusEditor' }
   | { type: 'revealSelection'; anchor: number; head: number; focus?: boolean }
   | { type: 'diagnosticsChanged'; diagnostics: EditorDiagnostic[] }


### PR DESCRIPTION
## Summary

Fixes the hard-fail class from #72: red banner **"Editor failed to update this document…"**, lost Live edits, and desync when the open markdown buffer is rewritten by **git / LLM agents / outside editors** (not only Copilot review handoff).

Related: #57, #31, #36, #60.

## Root causes addressed

1. **`applyingExternal` not exception-safe** (`webview/src/editor.ts` `setText`) — if `dispatch` threw, the flag stayed `true` forever and user keystrokes never called `onApplyChanges`.
2. **Sync bookkeeping advanced before successful adopt** (`docChanged`) — `syncedText` moved to host text even when `setEditorTextSafely` failed, so the next local flush could overwrite the host with a stale webview buffer.
3. **Local-always-wins conflict branch** — any pending draft + external write skipped painting host text and immediately forced the local draft back via full-doc `applyChanges`.
4. **Uncommitted Live widgets** (table cells) wiped under external `setText`.
5. **No recovery UX** besides reopen tab; `applyEdit === false` only sent another `docChanged` with no explicit failure opcode.

## Changes

| Area | Fix |
|---|---|
| `editor.ts` `setText` | `try/finally` on `applyingExternal`; `commitActiveTableInput()` before replace |
| `index.ts` `docChanged` | Prefer **host** on external conflict; only commit `syncedText`/draft clears after successful adopt via `adoptHostText()` |
| Notice banner | **Reload** action; keeps a host-authoritative snapshot when adopt fails |
| Host `panelSession` | `appliedFailed` when `applyEdit` fails; `requestReload` forces re-init + `docChanged`; short echo filter after own apply |
| CSS | Notice row layout for message + Reload button |

### Conflict policy (new)

- Echo of our own write / already-matching editor → update version bookkeeping only.
- In-flight text equals host → clear in-flight (normal apply ack path).
- **Local draft ≠ host** → adopt host into the editor (agents/git win); optional warning that the unsaved MEO buffer was dropped from the view.
- Pure external update → `adoptHostText` (commit widgets → setText → then advance sync state).

## Test plan

- [ ] Open `.md` in Live; externally append/replace file content (CLI / second window) → editor shows new text, no hard red dead-end
- [ ] Type locally (pending debounce) then external rewrite → host content appears; no silent overwrite loop
- [ ] Force a setText failure path (if reproducible) → banner offers **Reload** and recovers
- [ ] Table cell mid-edit + external rewrite → no stuck applyingExternal; further typing still syncs after recovery
- [ ] Normal Live typing/save without external writers still works (no regressions on `applied` path)
- [ ] Git checkout/discard of the open file updates the preview

Closes #72
